### PR TITLE
Make initial example copy-and-paste-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ object Main extends App {
 
 Request Reader Monad
 --------------------
-**Finch.io** has two builtin request readers, which implement Reader Monad functional design pattern: 
+**Finch.io** has two built-in request readers, which implement the Reader Monad functional design pattern: 
 * `FutureRequestReader` reading `Future[A]` and
 * `RequestReader` reading just `A`.
 
-A `FutureRequestReader` has return type `Future[A]` so it might be simply used as an additional monad-transformation in a top-level for-comprehension statement. This is dramatically useful when service should fetch some params from a request before doing a real job (and not doing it at all if some of the params are not found/not valid).
+A `FutureRequestReader` has return type `Future[A]` so it might be simply used as an additional monad-transformation in a top-level for-comprehension statement. This is dramatically useful when a service should fetch some params from a request before doing a real job (and not doing it at all if some of the params are not found/not valid).
 
 There are three common implementations of a `FutureRequestReader`:
 * `RequiredParam` - fetches required params within specified type
@@ -166,7 +166,7 @@ val user = service(...) handle {
 }
 ```
 
-The most cool thing about monads is that they may be composed/reused as hell. Here is the example of _extending_ an existent reader within new fields/validation rules.
+The most cool thing about monads is that they may be composed/reused as hell. Here is an example of _extending_ an existing reader with new fields/validation rules.
 
 ```scala
 val restrictedUser = {
@@ -247,7 +247,7 @@ val (a, b): (List[Int], List[Int]) = reader(request)
 Building HTTP responses
 -----------------------
 
-An entry point into construction of HTTP responses in **Finch.io** is `Reply` class. It supports building of three types of responses: 
+An entry point into the construction of HTTP responses in **Finch.io** is the `Reply` class. It supports building of three types of responses: 
 * `application/json` within JSON object in the response body
 * `plain/text` within string in the response body
 * empty response of given HTTP status


### PR DESCRIPTION
This is awesome, Vladimir. I've made a few small additions to the README so that people don't have to hunt down imports to try out the first example—feel free to close if you're not interested.
