### PR TITLE
added scoverage and coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ scala:
   - 2.10.3
 jdk:
   - openjdk7
+script: "sbt coveralls"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,7 @@
 import sbt._
 import sbt.Keys._
+import scoverage.ScoverageSbtPlugin.instrumentSettings
+import CoverallsPlugin.coverallsSettings
 
 object Finch extends Build {
 
@@ -40,5 +42,5 @@ object Finch extends Build {
 
   lazy val root = Project(id = "finch",
     base = file("."),
-    settings = baseSettings ++ buildSettings ++ publishSettings)
+    settings = baseSettings ++ buildSettings ++ publishSettings ++ instrumentSettings ++ coverallsSettings)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,10 @@
-resolvers += Classpaths.typesafeReleases
+resolvers ++= Seq(
+  Classpaths.typesafeReleases,
+  Classpaths.sbtPluginReleases
+)
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
+
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "0.99.7.1")
+
+addSbtPlugin("com.sksamuel.scoverage" %% "sbt-coveralls" % "0.0.5")


### PR DESCRIPTION
I've added [scoverage](https://github.com/scoverage/scalac-scoverage-plugin) to the build which can be used locally by running `sbt clean scoverage:test`. Right now its bare bones. It will just generate a report and because of a bug will not even do highlighting in reports.

I've also added coveralls support to get actual highlighted reports. You can see an example coverage report from my branch at https://coveralls.io/builds/1100597.

Whenever a travis-ci build runs, a coverage report will automatically be generated.
This is for issue #58.
