### PR TITLE
Update to use httpx

### DIFF
--- a/finch-core/src/main/scala/io/finch/Endpoint.scala
+++ b/finch-core/src/main/scala/io/finch/Endpoint.scala
@@ -22,10 +22,10 @@
 
 package io.finch
 
-import org.jboss.netty.handler.codec.http.HttpMethod
-import com.twitter.finagle.http.path.Path
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.service.NotFoundService
+import com.twitter.finagle.httpx.Method
+import com.twitter.finagle.httpx.path.Path
+import com.twitter.finagle.httpx.service.NotFoundService
 
 /**
  * A REST API endpoint that primary defines a ''route'' and might be converted
@@ -40,7 +40,7 @@ trait Endpoint[Req <: HttpRequest, Rep] { self =>
    *
    * @return a route of this endpoint
    */
-  def route: PartialFunction[(HttpMethod, Path), Service[Req, Rep]]
+  def route: PartialFunction[(Method, Path), Service[Req, Rep]]
 
   /**
    * Sends a request ''req'' to this Endpoint.
@@ -69,7 +69,7 @@ trait Endpoint[Req <: HttpRequest, Rep] { self =>
    *
    * @return a new endpoint
    */
-  def orElse(that: PartialFunction[(HttpMethod, Path), Service[Req, Rep]]): Endpoint[Req, Rep] =
+  def orElse(that: PartialFunction[(Method, Path), Service[Req, Rep]]): Endpoint[Req, Rep] =
     new Endpoint[Req, Rep] {
       def route = self.route orElse that
     }

--- a/finch-core/src/main/scala/io/finch/package.scala
+++ b/finch-core/src/main/scala/io/finch/package.scala
@@ -22,7 +22,7 @@
 
 package io
 
-import com.twitter.finagle.http._
+import com.twitter.finagle.httpx._
 import com.twitter.util.Future
 import com.twitter.finagle.{Filter, Service}
 

--- a/finch-core/src/main/scala/io/finch/request/package.scala
+++ b/finch-core/src/main/scala/io/finch/request/package.scala
@@ -145,20 +145,10 @@ package object request {
    */
   private[this] object RequestBody {
     def apply(req: HttpRequest): Array[Byte] = {
-      val channelBuffer = req.content
-      //Check if channelBuffer  can be handled with array method
-      if (channelBuffer.hasArray) {
-        val array = channelBuffer.array
-
-        //the index of the first byte in the backing byte array of this ChannelBuffer.
-        //if there isn't a backing byte array, then this throws
-        val arrayOffset = channelBuffer.arrayOffset
-        //the index of the first readable byte in this ChannelBuffer
-        val readerIndex = channelBuffer.readerIndex()
-
-        //return a copy of the backing array, starting at the effective beginning of the HTTP response body
-        array.slice(arrayOffset + readerIndex, array.length)
-      } else channelBuffer.toByteBuffer.array
+      val buf = req.content
+      val out = Array.ofDim[Byte](buf.length)
+      buf.write(out, 0)
+      out
     }
   }
 

--- a/finch-core/src/main/scala/io/finch/response/package.scala
+++ b/finch-core/src/main/scala/io/finch/response/package.scala
@@ -25,8 +25,8 @@ package io.finch
 
 import io.finch.json.EncodeJson
 import org.jboss.netty.handler.codec.http.HttpResponseStatus
-import com.twitter.finagle.http.{Status, Response}
-import com.twitter.finagle.http.path.Path
+import com.twitter.finagle.httpx.{Status, Response}
+import com.twitter.finagle.httpx.path.Path
 import com.twitter.finagle.Service
 
 package object response {
@@ -37,7 +37,7 @@ package object response {
    * @param status the http response status
    * @param headers the HTTP headers map
    */
-  case class ResponseBuilder(status: HttpResponseStatus, headers: Map[String, String] = Map.empty) {
+  case class ResponseBuilder(status: Status, headers: Map[String, String] = Map.empty) {
 
     /**
      * Creates a new respond with given ''headers''.
@@ -58,7 +58,7 @@ package object response {
     def apply(plain: String) = {
       val rep = Response(status)
       rep.setContentString(plain)
-      headers.foreach { case (k, v) => rep.headers().add(k, v) }
+      headers.foreach { case (k, v) => rep.headerMap.add(k, v) }
 
       rep
     }
@@ -74,7 +74,7 @@ package object response {
       val rep = Response(status)
       rep.setContentTypeJson()
       rep.setContentString(encode(json))
-      headers.foreach { case (k, v) => rep.headers().add(k, v) }
+      headers.foreach { case (k, v) => rep.headerMap.add(k, v) }
 
       rep
     }
@@ -86,7 +86,7 @@ package object response {
      */
     def apply() = {
       val rep = Response(status)
-      headers.foreach { case (k, v) => rep.headers().add(k, v) }
+      headers.foreach { case (k, v) => rep.headerMap.add(k, v) }
 
       rep
     }
@@ -133,7 +133,7 @@ package object response {
   object PreconditionFailed extends ResponseBuilder(Status.PreconditionFailed)   // 412
   object RequestEntityTooLarge
     extends ResponseBuilder(Status.RequestEntityTooLarge)                        // 413
-  object RequestUriTooLong extends ResponseBuilder(Status.RequestUriTooLong)     // 414
+  object RequestUriTooLong extends ResponseBuilder(Status.RequestURITooLong)     // 414
   object UnsupportedMediaType
     extends ResponseBuilder(Status.UnsupportedMediaType)                         // 415
   object RequestedRangeNotSatisfiable
@@ -144,9 +144,8 @@ package object response {
   object FailedDependency extends ResponseBuilder(Status.FailedDependency)       // 424
   object UnorderedCollection extends ResponseBuilder(Status.UnorderedCollection) // 425
   object UpgradeRequired extends ResponseBuilder(Status.UpgradeRequired)         // 426
-  object PreconditionRequired
-    extends ResponseBuilder(HttpResponseStatus.PRECONDITION_REQUIRED)            // 428
-  object TooManyRequests extends ResponseBuilder(Status.TooManyRequests)         // 429
+  object PreconditionRequired extends ResponseBuilder(Status(428))               // 428
+  object TooManyRequests extends ResponseBuilder(Status(429))                    // 429
 
   // 5xx
   object InternalServerError extends ResponseBuilder(Status.InternalServerError) // 500
@@ -165,7 +164,7 @@ package object response {
    * An old version of `ResponseBuilder`.
    */
   @deprecated("Use predefined response builders like `Ok` or `SeeOther` instead.", "0.1.8")
-  class Respond(status: HttpResponseStatus, headers: Map[String, String] = Map.empty)
+  class Respond(status: Status, headers: Map[String, String] = Map.empty)
     extends ResponseBuilder(status, headers)
 
   /**
@@ -173,7 +172,7 @@ package object response {
    */
   @deprecated("Use predefined response builders like `Ok` or `SeeOther` instead.", "0.1.8")
   object Respond {
-    def apply(status: HttpResponseStatus, headers: Map[String, String] = Map.empty) =
+    def apply(status: Status, headers: Map[String, String] = Map.empty) =
       new Respond(status, headers)
   }
 

--- a/finch-core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/finch-core/src/test/scala/io/finch/EndpointSpec.scala
@@ -23,8 +23,8 @@
 package io.finch
 
 import com.twitter.finagle.{Filter, Service}
-import com.twitter.finagle.http.{Request, Method, Status}
-import com.twitter.finagle.http.path._
+import com.twitter.finagle.httpx.{Request, Method, Status}
+import com.twitter.finagle.httpx.path._
 import com.twitter.util.Await
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/finch-core/src/test/scala/io/finch/auth/BasicallyAuthorizeSpec.scala
+++ b/finch-core/src/test/scala/io/finch/auth/BasicallyAuthorizeSpec.scala
@@ -23,7 +23,7 @@
 package io.finch.auth
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.{Request, Status}
+import com.twitter.finagle.httpx.{Request, Status}
 import com.twitter.util.{Await, Base64StringEncoder, Future}
 import io.finch.response.Ok
 import io.finch.{HttpRequest, HttpResponse, _}
@@ -34,7 +34,7 @@ class BasicallyAuthorizeSpec extends FlatSpec with Matchers {
   "A BasicallyAuthorize" should "produce an Unauthorized response if given the wrong credentials" in {
     val auth = BasicallyAuthorize("admin", "password")
     val request = Request()
-    request.headers().set("Authorization", encode("wrong", "login"))
+    request.headerMap.update("Authorization", encode("wrong", "login"))
     val futureResult = auth(request, okService())
     val result = Await.result(futureResult)
 
@@ -44,7 +44,7 @@ class BasicallyAuthorizeSpec extends FlatSpec with Matchers {
   it should "pass the user through to the given service if the correct credentials" in {
     val auth = BasicallyAuthorize("admin", "password")
     val request = Request()
-    request.headers().set("Authorization", encode("admin", "password"))
+    request.headerMap.update("Authorization", encode("admin", "password"))
     val futureResult = auth(request, okService())
     val result = Await.result(futureResult)
 

--- a/finch-core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/BodySpec.scala
@@ -23,7 +23,9 @@
 
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
+import com.twitter.io.Buf
+import com.twitter.io.Buf.ByteArray
 import com.twitter.util.{Await, Future}
 import io.finch.HttpRequest
 import org.jboss.netty.buffer.ChannelBuffers
@@ -97,8 +99,8 @@ class BodySpec extends FlatSpec with Matchers {
 
   private[this] def requestWithBody(body: Array[Byte]): HttpRequest = {
     val r = Request()
-    r.setContent(ChannelBuffers.wrappedBuffer(body))
-    r.headers().set(HttpHeaders.Names.CONTENT_LENGTH, body.length)
+    r.content = ByteArray.Owned(body)
+    r.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, body.length.toString)
     r
   }
 }

--- a/finch-core/src/test/scala/io/finch/request/HeaderSpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/HeaderSpec.scala
@@ -22,7 +22,7 @@
 
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.Await
 import org.scalatest.{Matchers, FlatSpec}
 
@@ -30,7 +30,7 @@ class HeaderSpec extends FlatSpec with Matchers {
 
   "A RequiredHeader" should "properly read the header field" in {
     val request = Request()
-    request.headers().set("Location", "some header")
+    request.headerMap.update("Location", "some header")
     val futureResult = RequiredHeader("Location")(request)
     Await.result(futureResult) should equal("some header")
   }
@@ -44,7 +44,7 @@ class HeaderSpec extends FlatSpec with Matchers {
 
   "An OptionalHeader" should "properly read an existing header field" in {
     val request = Request()
-    request.headers().set("Location", "some header")
+    request.headerMap.update("Location", "some header")
     val futureResult = OptionalHeader("Location")(request)
     Await.result(futureResult) should equal(Some("some header"))
   }

--- a/finch-core/src/test/scala/io/finch/request/OptionalParamSpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/OptionalParamSpec.scala
@@ -23,7 +23,7 @@
 
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
 import io.finch._
 import org.scalatest.{Matchers, FlatSpec}

--- a/finch-core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -22,7 +22,7 @@
 
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
 import io.finch._
 import org.scalatest.{Matchers, FlatSpec}

--- a/finch-core/src/test/scala/io/finch/request/RequiredParamSpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/RequiredParamSpec.scala
@@ -22,7 +22,7 @@
  */
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
 import io.finch.HttpRequest
 import org.scalatest.{Matchers, FlatSpec}

--- a/finch-core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -22,7 +22,7 @@
 
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
 import io.finch._
 import org.scalatest.{Matchers, FlatSpec}

--- a/finch-core/src/test/scala/io/finch/request/ValidationRuleSpec.scala
+++ b/finch-core/src/test/scala/io/finch/request/ValidationRuleSpec.scala
@@ -22,7 +22,7 @@
 
 package io.finch.request
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.Await
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/finch-core/src/test/scala/io/finch/response/RedirectSpec.scala
+++ b/finch-core/src/test/scala/io/finch/response/RedirectSpec.scala
@@ -22,8 +22,8 @@
 
 package io.finch.response
 
-import com.twitter.finagle.http.path.Root
-import com.twitter.finagle.http.{Request, Status}
+import com.twitter.finagle.httpx.{Request, Status}
+import com.twitter.finagle.httpx.path.Root
 import com.twitter.util.Await
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/finch-core/src/test/scala/io/finch/response/ResponseBuilderSpec.scala
+++ b/finch-core/src/test/scala/io/finch/response/ResponseBuilderSpec.scala
@@ -22,7 +22,7 @@
 
 package io.finch.response
 
-import com.twitter.finagle.http.Status
+import com.twitter.finagle.httpx.Status
 import org.scalatest.{Matchers, FlatSpec}
 
 class ResponseBuilderSpec extends FlatSpec with Matchers {
@@ -47,6 +47,6 @@ class ResponseBuilderSpec extends FlatSpec with Matchers {
   it should "build empty responses with status" in {
     val rep = SeeOther()
     rep.getContentString() shouldBe ""
-    rep.getStatus() shouldBe Status.SeeOther
+    rep.status shouldBe Status.SeeOther
   }
 }

--- a/finch-demo/src/main/scala/io/finch/demo/Main.scala
+++ b/finch-demo/src/main/scala/io/finch/demo/Main.scala
@@ -22,10 +22,11 @@
 
 package io.finch.demo
 
-import com.twitter.finagle.builder.ServerBuilder
 import com.twitter.finagle.{SimpleFilter, Service}
-import com.twitter.finagle.http.{RichHttp, Http, Method}
-import com.twitter.finagle.http.path._
+import com.twitter.finagle.Httpx
+import com.twitter.finagle.httpx.Method
+import com.twitter.finagle.httpx.path._
+import com.twitter.util.Await
 
 import scala.util.Random
 import scala.collection.mutable
@@ -174,9 +175,7 @@ object Main extends App {
     BasicallyAuthorize("user", "password") ! HandleExceptions ! httpBackend
 
   // A default Finagle service builder that runs the backend.
-  ServerBuilder()
-    .codec(RichHttp[HttpRequest](new Http()))
-    .bindTo(new InetSocketAddress(8080))
-    .name("finch-demo")
-    .build(backend.toService)
+  val socket = new InetSocketAddress(8080)
+  val server = Httpx.serve(socket, backend.toService)
+  Await.ready(server)
 }

--- a/finch-json/src/test/scala/io/finch/json/JsonSpec.scala
+++ b/finch-json/src/test/scala/io/finch/json/JsonSpec.scala
@@ -22,10 +22,10 @@
 
 package io.finch.json
 
+import com.twitter.io.Buf.Utf8
 import com.twitter.finagle.Service
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
-import org.jboss.netty.buffer.ChannelBuffers
 import org.jboss.netty.handler.codec.http.HttpHeaders
 
 import org.scalatest.{Matchers, FlatSpec}
@@ -168,10 +168,10 @@ class JsonSpec extends FlatSpec with Matchers {
     import io.finch.request._
 
     val json = Json.obj("a" -> 1)
-    val jsonBody = json.toString.getBytes("UTF-8")
+    val jsonBody = Utf8(json.toString)
     val req = Request()
-    req.setContent(ChannelBuffers.wrappedBuffer(jsonBody))
-    req.headers().set(HttpHeaders.Names.CONTENT_LENGTH, jsonBody.length)
+    req.content = jsonBody
+    req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, jsonBody.length.toString)
 
     val ok: HttpResponse = Ok(json)
     val j: RequestReader[Json] = RequiredJsonBody[Json]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object Finch extends Build {
 
   val baseSettings = Defaults.defaultSettings ++ Seq(
     libraryDependencies ++= Seq(
-      "com.twitter" %% "finagle-http" % "6.22.0",
+      "com.twitter" %% "finagle-httpx" % "6.22.1-MONOCACHE",
       "org.scalatest" % "scalatest_2.10" % "2.2.1" % "test"
     ),
     scalacOptions ++= Seq( "-unchecked", "-deprecation", "-feature")
@@ -16,7 +16,7 @@ object Finch extends Build {
 
   lazy val buildSettings = Seq(
     organization := "com.github.finagle",
-    version := "0.2.0",
+    version := "0.3.0-SNAPSHOT",
     scalaVersion := "2.10.4"
   )
 


### PR DESCRIPTION
Update finch to take advantage of the newer apis afforded by httpx
- bump finch to 0.3.0-SNAPSHOT
- replace finagle-http with finagle-httpx
- bump finagle to 6.22.1-MONOCACHE

All the changes should just be api churn, moving to httpx types rather
than the raw netty types.

fixes #93 
