### PR TITLE
Fix compiler warning in JsonSpec

### DIFF
--- a/finch-core/src/test/scala/io/finch/json/JsonSpec.scala
+++ b/finch-core/src/test/scala/io/finch/json/JsonSpec.scala
@@ -23,7 +23,6 @@
 
 package io.finch.json
 
-import io.finch.json.{EncodeJson, DecodeJson}
 import org.scalatest.{Matchers, FlatSpec}
 import scala.math._
 


### PR DESCRIPTION
The removed imports was not required. Addresses #101 
