### PR TITLE
Implicit converter from Json to HttpResponse

### DIFF
--- a/finch-core/src/main/scala/io/finch/json/package.scala
+++ b/finch-core/src/main/scala/io/finch/json/package.scala
@@ -25,6 +25,7 @@ package io.finch
 
 import io.finch.response._
 import com.twitter.finagle.Service
+import com.twitter.util.Future
 import scala.language.implicitConversions
 
 package object json {
@@ -71,5 +72,23 @@ package object json {
      * for the compiler decide to use JsonToHttp directly.
      */
     def asJson: Service[Req, HttpResponse] = this
+  }
+
+/**
+   * Allow for the creation of Http Service from a simple future
+   *
+   * @param future The future to implicitly convert.
+   * @param enc the EncodeJson used to convert type ''Resp'' to ''HttpResponse''
+   */
+  implicit class FutureToHttp[Resp](future: Future[Resp])
+                                   (implicit enc: EncodeJson[Resp]) extends Service[HttpRequest, HttpResponse] {
+
+    def apply(req: HttpRequest) = future flatMap TurnJsonIntoHttp[Resp]
+
+    /**
+     * This function should be used when there isn't enough type information
+     * for the compiler decide to use JsonToHttp directly.
+     */
+    def asJson: Service[HttpRequest, HttpResponse] = this
   }
 }


### PR DESCRIPTION
This add support for automatic conversion from `Service[Req, T]` to `Service[Req, HttpResponse]` when an `EncodeJson[T]` is provided, such as:

``` scala
trait Json

implicit val encode = new EncodeJson[Json] { def apply(j: Json) = "42" }

val service: Service[HttpRequest, Json] =  ???

val e = Endpoint[HttpRequest, HttpResponse] {
  case Method.Get -> Root / "a" => service // should be implicitly converted into http
}
```

When type information is not provided to compiler, you can still force the conversion using the `.asJson` method:

``` scala
val e = Endpoint {
  case Method.Get -> Root / "a" => service.asJson
}
```

Futures are also supported:

``` scala

val e = Endpoint[HttpRequest, HttpResponse] {
  case Method.Get -> Root / "a" => (new Json).toFuture
}
```

Likewise, we can also force conversion with the `.asJson`

Addresses #104 
