### PR TITLE
Fix 2.11 compiler warnings

### DIFF
--- a/finch-json/src/main/scala/io/finch/json/Json.scala
+++ b/finch-json/src/main/scala/io/finch/json/Json.scala
@@ -18,6 +18,7 @@
  * limitations under the License.
  *
  * Contributor(s):
+ * Ryan Plessner
  */
 
 package io.finch.json
@@ -61,6 +62,7 @@ sealed trait Json {
    */
   def apply[A](path: String): Option[A] = {
     def loop(path: List[String], outer: Map[String, Any]): Option[A] = path match {
+      case Nil => outer.get("") map { _.asInstanceOf[A] }
       case tag :: Nil => outer.get(tag) map { _.asInstanceOf[A] }
       case tag :: tail => outer.get(tag) match {
         case Some(JsonObject(inner)) => loop(tail, inner)
@@ -130,6 +132,7 @@ object Json {
    */
   def obj(args: (String, Any)*): Json = {
     def loop(path: List[String], value: Any): Map[String, Any] = path match {
+      case Nil => Map("" -> value)
       case tag :: Nil => Map(tag -> value)
       case tag :: tail => Map(tag -> JsonObject(loop(tail, value)))
     }

--- a/finch-json/src/test/scala/io/finch/json/JsonSpec.scala
+++ b/finch-json/src/test/scala/io/finch/json/JsonSpec.scala
@@ -18,6 +18,7 @@
  * limitations under the License.
  *
  * Contributor(s):
+ * Ryan Plessner
  */
 
 package io.finch.json
@@ -46,10 +47,10 @@ class JsonSpec extends FlatSpec with Matchers {
   }
 
   "A JSON API" should "support JSON AST construction" in {
-    val map = unwrapObject(Json.obj("a.b.c" -> 1, "a.b.d" -> 2))
+    val map = unwrapObject(Json.obj("a.b.c" -> 1, "a.b.d" -> 2, "" -> 3))
     val list = unwrapArray(Json.arr("a", "b", "c"))
 
-    map shouldBe Map("a" -> Map("b" -> Map("c" -> 1, "d" -> 2)))
+    map shouldBe Map("a" -> Map("b" -> Map("c" -> 1, "d" -> 2)), "" -> 3)
     list shouldBe List("a", "b", "c")
   }
 
@@ -159,6 +160,21 @@ class JsonSpec extends FlatSpec with Matchers {
     a[Json]("a.b").map(unwrapObject) shouldBe Some(Map("c" -> 10))
     a[Int]("a.b.c") shouldBe Some(10)
     a[Json]("a.d").map(unwrapArray) shouldBe Some(List(1, 2, 3))
+  }
+
+  it should "not return a result for a tag that does not exist" in {
+    val a = Json.obj("a.b.c" -> 10, "a.d" -> Json.arr(1, 2, 3))
+    a("d") shouldBe None
+  }
+
+  it should "not query an empty string, if the empty string is not a tag" in {
+    val a = Json.obj("a.b.c" -> 10, "a.d" -> Json.arr(1, 2, 3))
+    a("") shouldBe None
+  }
+
+  it should "query an empty string, if the empty string is a tag" in {
+    val a = Json.obj("a.b.c" -> 10, "a.d" -> Json.arr(1, 2, 3), "" -> 1)
+    a[Int]("") shouldBe Some(1)
   }
 
   it should "be compatible with finch-core" in {


### PR DESCRIPTION
Partial fix for #109.
I fixed the first two compiler warnings. The tests I added seemed to indicate that they are cases that are being caught, its just the compiler can't quite figure it out. 
I don't think we can fix the last warning without #86, because its a deprecation warning for the JSON library.
