### PR TITLE
adding type alias for Route #114

### DIFF
--- a/finch-core/src/main/scala/io/finch/Endpoint.scala
+++ b/finch-core/src/main/scala/io/finch/Endpoint.scala
@@ -40,7 +40,7 @@ trait Endpoint[Req <: HttpRequest, Rep] { self =>
    *
    * @return a route of this endpoint
    */
-  def route: PartialFunction[(Method, Path), Service[Req, Rep]]
+  def route: Route[Req, Rep]
 
   /**
    * Sends a request ''req'' to this Endpoint.

--- a/finch-core/src/main/scala/io/finch/package.scala
+++ b/finch-core/src/main/scala/io/finch/package.scala
@@ -25,6 +25,7 @@ package io
 import scala.language.implicitConversions
 
 import com.twitter.finagle.httpx._
+import com.twitter.finagle.httpx.path.Path
 import com.twitter.util.Future
 import com.twitter.finagle.{Filter, Service}
 
@@ -68,6 +69,7 @@ package object finch {
 
   type HttpRequest = Request
   type HttpResponse = Response
+  type Route[Req <: HttpRequest, Rep] = PartialFunction[(Method, Path), Service[Req, Rep]]
 
   /**
    * Alters any object within a ''toFuture'' method.


### PR DESCRIPTION
Decided not to change the other methods, so it is easier to grasp what is the parameter while auto completing, 

The other methods are:

``` scala

def orElse(that: PartialFunction[(Method, Path), Service[Req, Rep]])

def apply[Req <: HttpRequest, Rep](r: PartialFunction[(Method, Path), Service[Req, Rep]])

```

Should I change both too?
