### PR TITLE
Scaladocs

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,6 +3,11 @@ import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 import sbt._
 import sbt.Keys._
 import com.typesafe.sbt.pgp.PgpKeys._
+import com.typesafe.sbt.SbtGit._
+import sbtunidoc.Plugin.ScalaUnidoc
+import sbtunidoc.Plugin.unidocSettings
+import com.typesafe.sbt.SbtSite.site
+import com.typesafe.sbt.SbtGhPages.ghpages
 
 object Finch extends Build {
 
@@ -53,6 +58,11 @@ object Finch extends Build {
 
   lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
+  lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
+    site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "latest/api"),
+    git.remoteRepo := s"git@github.com:finagle/finch.git"
+  )
+
   def defaultFinchProject(id: String, path: String, settings: Seq[sbt.Def.Setting[_]] = allSettings): Project =
     Project(
       id = id,
@@ -63,7 +73,7 @@ object Finch extends Build {
   lazy val root = Project(
     id = "finch",
     base = file("."),
-    settings = allSettings
+    settings = allSettings ++ docSettings
   ) aggregate(core, json, demo, jawn, argonaut)
 
   lazy val core = defaultFinchProject(id = "finch-core", path = "finch-core")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,6 +5,7 @@ import sbt.Keys._
 import com.typesafe.sbt.pgp.PgpKeys._
 import com.typesafe.sbt.SbtGit._
 import sbtunidoc.Plugin.ScalaUnidoc
+import sbtunidoc.Plugin.UnidocKeys._
 import sbtunidoc.Plugin.unidocSettings
 import com.typesafe.sbt.SbtSite.site
 import com.typesafe.sbt.SbtGhPages.ghpages
@@ -60,7 +61,8 @@ object Finch extends Build {
 
   lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
     site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "latest/api"),
-    git.remoteRepo := s"git@github.com:finagle/finch.git"
+    git.remoteRepo := s"git@github.com:finagle/finch.git",
+    unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(demo)
   )
 
   def defaultFinchProject(id: String, path: String, settings: Seq[sbt.Def.Setting[_]] = allSettings): Project =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 resolvers ++= Seq(
   Classpaths.typesafeReleases,
-  Classpaths.sbtPluginReleases
+  Classpaths.sbtPluginReleases,
+  "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
@@ -10,3 +11,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")


### PR DESCRIPTION
This PR adds the [unidoc](https://github.com/sbt/sbt-unidoc) plugin. It merges all of the documentation across subprojects into one (although oddly scaladoc doesn't seem to building correctly for jawn and argonaut).

Docs can be built using `sbt unidoc`. If you want to preview the docs you can run `sbt preview-site`, this will spin up a local server to serve the docs. Lastly, to deploy to ghpages run `sbt ghpages-push-site`. Before you run `ghpages-push-site` for the first time, you will need to setup ghpages like [this](https://github.com/sbt/sbt-ghpages#creating-ghpages-branch).
Fixes #123 