### PR TITLE
Use docs directory for API docs on GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ val endpoint = Endpoint[HttpRequest, HttpResponse] {
 Documentation
 -------------
  * A comprehensive documentation may be found in the [`docs.md`](docs.md) file in the root directory
- * The latest Scaladoc is [here](http://finagle.github.io/finch/latest/api/#io.finch.package)
+ * The latest Scaladoc is [here](http://finagle.github.io/finch/docs/#io.finch.package)
 
 Contacts
 --------

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val publishSettings = Seq(
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
 lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
-  site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "latest/api"),
+  site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "doc"),
   git.remoteRepo := s"git@github.com:finagle/finch.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(demo)
 )

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val publishSettings = Seq(
 lazy val allSettings = baseSettings ++ buildSettings ++ publishSettings
 
 lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Seq(
-  site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "doc"),
+  site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "docs"),
   git.remoteRepo := s"git@github.com:finagle/finch.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(demo)
 )


### PR DESCRIPTION
Hey @rpless, @vkostyukov,

This is just a suggestion, but Finagle (and some associated Twitter projects) use `/docs/` for the API documentation, and I've made the change here for consistency. Thanks for setting up sbt-unidoc, @rpless!