### PR TITLE
Fix subproject links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Modules
 
 Finch uses multi-project structure and contains of the following _modules_:
 
-* [`finch-core`](finch-core) - the core classes/functions
-* [`finch-json`](finch-json) - the lightweight and  immutable JSON API
-* [`finch-demo`](finch-demo) - the demo project
-* [`finch-jawn`](finch-jawn) - the JSON API support for the [Jawn](https://github.com/non/jawn) library
-* [`finch-argonaut`](finch-argonaut) - the JSON API support for the [Argonaut](http://argonaut.io/) library
+* [`finch-core`](core) - the core classes/functions
+* [`finch-json`](json) - the lightweight and  immutable JSON API
+* [`finch-demo`](demo) - the demo project
+* [`finch-jawn`](jawn) - the JSON API support for the [Jawn](https://github.com/non/jawn) library
+* [`finch-argonaut`](argonaut) - the JSON API support for the [Argonaut](http://argonaut.io/) library
 
 Installation 
 ------------


### PR DESCRIPTION
Sorry I missed these the first time around. I've left the names the same, since the artifacts will have the prefix.