### PR TITLE
Scalac flags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,20 @@ val baseSettings = Defaults.defaultSettings ++ Seq(
     "com.twitter" %% "finagle-httpx" % "6.24.0",
     "org.scalatest" %% "scalatest" % "2.2.3" % "test"
   ),
-  scalacOptions ++= Seq( "-unchecked", "-deprecation", "-feature"),
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-language:existentials",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-unchecked",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Xfuture",
+    "-Ywarn-unused-import"
+  ),
   coverageExcludedPackages := ".*demo.*"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,25 +8,29 @@ lazy val buildSettings = Seq(
   crossScalaVersions := Seq("2.10.4", "2.11.5")
 )
 
+lazy val compilerOptions = scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-feature",
+  "-language:existentials",
+  "-language:higherKinds",
+  "-language:implicitConversions",
+  "-unchecked",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-numeric-widen",
+  "-Xfuture"
+) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((2, 11)) => Seq("-Ywarn-unused-import")
+  case _ => Seq.empty
+})
+
 val baseSettings = Defaults.defaultSettings ++ Seq(
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-httpx" % "6.24.0",
     "org.scalatest" %% "scalatest" % "2.2.3" % "test"
   ),
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-encoding", "UTF-8",
-    "-feature",
-    "-language:existentials",
-    "-language:higherKinds",
-    "-language:implicitConversions",
-    "-unchecked",
-    "-Yno-adapted-args",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Xfuture",
-    "-Ywarn-unused-import"
-  ),
+  compilerOptions,
   coverageExcludedPackages := ".*demo.*"
 )
 

--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -26,7 +26,6 @@ import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
 import io.finch._
 import org.scalatest.{Matchers, FlatSpec}
-import org.scalatest.Matchers._
 
 class OptionalParamsSpec extends FlatSpec with Matchers {
 


### PR DESCRIPTION
For #129. Doesn't include `Xlint` and "Xfatal-warnings" for reasons discussed in the issue.