### PR TITLE
Add Jackson support #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Finch uses multi-project structure and contains of the following _modules_:
 * [`finch-demo`](demo) - the demo project
 * [`finch-jawn`](jawn) - the JSON API support for the [Jawn](https://github.com/non/jawn) library
 * [`finch-argonaut`](argonaut) - the JSON API support for the [Argonaut](http://argonaut.io/) library
+* [`finch-jackson`](jackson) - the JSON API support for the [Jackson](http://jackson.codehaus.org/) library
 
 Installation 
 ------------
@@ -24,7 +25,7 @@ Every Finch module is published at Maven Central. Use the following _sbt_ snippe
  
 ```scala
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-module" % "0.3.0"
+  "com.github.finagle" %% "[finch-module]" % "0.3.0"
 )
 ```
 

--- a/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
@@ -53,7 +53,7 @@ class ArgonautSpec extends FlatSpec with Matchers {
     req.setContentTypeJson()
     req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, str.length.toString)
 
-    val user: TestUser = Await.result(RequiredBody(req))
+    val user: TestUser = Await.result(RequiredBody[TestUser](req))
     user shouldEqual exampleUser
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val root = project.in(file("."))
   .settings(moduleName := "finch")
   .settings(allSettings: _*)
   .settings(docSettings: _*)
-  .aggregate(core, json, demo, jawn, argonaut)
+  .aggregate(core, json, demo, jawn, argonaut, jackson)
 
 lazy val core = project
   .settings(moduleName := "finch-core")
@@ -110,5 +110,12 @@ lazy val argonaut = project
   .settings(moduleName := "finch-argonaut")
   .settings(allSettings: _*)
   .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.0.4")
+  .dependsOn(core)
+  .disablePlugins(CoverallsPlugin)
+
+lazy val jackson = project
+  .settings(moduleName := "finch-jackson")
+  .settings(allSettings: _*)
+  .settings(libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.4")
   .dependsOn(core)
   .disablePlugins(CoverallsPlugin)

--- a/core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/core/src/test/scala/io/finch/request/BodySpec.scala
@@ -98,9 +98,9 @@ class BodySpec extends FlatSpec with Matchers {
     }
     val req = requestWithBody("123")
     val ri: RequestReader[Int] = RequiredBody[Int]
-    val i: Future[Int] = RequiredBody(req)
+    val i: Future[Int] = RequiredBody[Int](req)
     val oi: RequestReader[Option[Int]] = OptionalBody[Int]
-    val o = OptionalBody(req)
+    val o = OptionalBody[Int](req)
 
     Await.result(ri(req)) shouldBe 123
     Await.result(i) shouldBe 123

--- a/jackson/README.md
+++ b/jackson/README.md
@@ -1,0 +1,15 @@
+The `finch-jackson` module provides support for [Jackson](http://jackson.codehaus.org/) library.
+
+Installation
+------------
+Use the following _sbt_ snippet:
+
+```scala
+libraryDependencies ++= Seq(
+  "com.github.finagle" %% "finch-jackson" % "0.4.0"
+)
+```
+
+Documentation
+-------------
+See section [Finch JSON](/docs.md#jackson) in the [docs.md](/docs.md) file.

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s): -
+ */
+
+package io.finch
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.finch.request.DecodeAnyRequest
+import io.finch.response.EncodeAnyResponse
+
+import scala.reflect.ClassTag
+
+package object jackson {
+
+  implicit def decodeJackson(implicit mapper: ObjectMapper) = new DecodeAnyRequest {
+    def apply[A: ClassTag](s: String): Option[A] = try {
+      val clazz = implicitly[ClassTag[A]].runtimeClass.asInstanceOf[Class[A]]
+      Some(mapper.readValue[A](s, clazz))
+    } catch { case _: Exception => None }
+  }
+
+  implicit def encodeJackson(implicit mapper: ObjectMapper) = new EncodeAnyResponse {
+    def apply[A](rep: A): String = mapper.writeValueAsString(rep)
+    def contentType = "application/json"
+  }
+}

--- a/jackson/src/test/scala/io/finch/jackson/Foo.scala
+++ b/jackson/src/test/scala/io/finch/jackson/Foo.scala
@@ -1,0 +1,3 @@
+package io.finch.jackson
+
+case class Foo(bar: String, baz: Int)

--- a/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
+++ b/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s): -
+ */
+package io.finch.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.twitter.finagle.httpx.Request
+import com.twitter.io.Buf.Utf8
+import com.twitter.util.{Await, Future}
+import io.finch.request.{OptionalBody, RequiredBody, RequestReader}
+import io.finch.response.Ok
+import org.jboss.netty.handler.codec.http.HttpHeaders
+import org.scalatest.{Matchers, FlatSpec}
+
+class JacksonSpec extends FlatSpec with Matchers {
+  implicit val objectMapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  "JacksonEncode" should "encode a case class into JSON" in {
+    val encode = encodeJackson(objectMapper)
+    encode(Foo("bar", 10)) shouldBe "{\"bar\":\"bar\",\"baz\":10}"
+  }
+
+  it should "decode a case class from JSON" in {
+    val json = "{\"bar\":\"bar\",\"baz\":20}"
+    val decode = decodeJackson(objectMapper)
+    decode[Foo](json) shouldBe Some(Foo("bar", 20))
+  }
+
+  it should "work w/o exceptions with ResponseBuilder" in {
+    val foo = Foo("bar", 42)
+    Ok(foo).getContentString() shouldBe "{\"bar\":\"bar\",\"baz\":42}"
+  }
+
+  it should "work with higher kinded types" in {
+    val list = List(1, 2, 3)
+    val encode = encodeJackson(objectMapper)
+    val decode = decodeJackson(objectMapper)
+
+    encode(list) shouldBe "[1,2,3]"
+    decode[List[Int]]("[1,2,3]") shouldBe Some(List(1, 2, 3))
+  }
+
+  it should "work w/o exceptions with RequestReader" in {
+    val body = Utf8("{\"bar\":\"bar\",\"baz\":42}")
+    val req = Request()
+    req.content = body
+    req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, body.length.toString)
+
+    val rFoo: RequestReader[Foo] = RequiredBody[Foo]
+    val foo: Future[Foo] = RequiredBody[Foo](req)
+    val roFoo: RequestReader[Option[Foo]] = OptionalBody[Foo]
+    val oFoo: Future[Option[Foo]] = OptionalBody[Foo](req)
+
+    val expectedFoo = Foo("bar", 42)
+    Await.result(rFoo(req)) shouldBe expectedFoo
+    Await.result(foo) shouldBe expectedFoo
+    Await.result(roFoo(req)) shouldBe Some(expectedFoo)
+    Await.result(oFoo) shouldBe Some(expectedFoo)
+  }
+}


### PR DESCRIPTION
I implemented the basic Jackson support. Everything works almost fine except using Jackson via `RequestReader` (but I've found suitable [workaround](https://github.com/finagle/finch/pull/143/files#diff-5c501b7d1666db0ef25e62bb7109fc75R51)): `implicit val codec = decodeJackson[Foo]`. We don't need to do the opposite thing for encoding sine it works just fine. 

Any thoughts no how to avoid declaring the `decodeJackson` explicitly?