### PR TITLE
Intoroduce io.finch.route package

### DIFF
--- a/core/src/main/scala/io/finch/route/package.scala
+++ b/core/src/main/scala/io/finch/route/package.scala
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2015, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s): -
+ */
+
+package io.finch
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.Method
+import com.twitter.util.Future
+
+/**
+ * This package contains various of functions and types that enable _router
+ * combinators_ in Finch. A Finch [[route.Router]] is an abstraction that
+ * is responsible for routing the HTTP requests using their method and path
+ * information. There are two types of routers in Finch: [[route.Router0]]
+ * and [[route.RouterN]]. `Router0` matches the route and returns an `Option`
+ * of the rest of the route. `RouterN[A]` (or just `Router[A]`) in addition
+ * to the `Router0` behaviour extracts a value of type `A` from the route.
+ *
+ * A [[route.Router]] that extracts [[Service]] is called an endpoint. An
+ * endpoint `Req => Rep` might be implicitly converted into `Service[Req, Rep]`.
+ * Thus, the following example is a valid Finch code:
+ *
+ * {{{
+ *   def hello(s: String) = new Service[HttRequest, HttpResponse] {
+ *     def apply(req: HttpRequest) = Ok(s"Hello $name!").toFuture
+ *   }
+ *
+ *   Httpx.serve(
+ *     new InetSocketAddress(8081),
+ *     Get / string /> hello // will be implicitly converted into service
+ *   )
+ * }}}
+ */
+package object route {
+
+  //
+  // ADT that describes a route abstraction.
+  //
+  private[route] sealed trait RouteToken
+  private[route] case class MethodToken(m: Method) extends RouteToken
+  private[route] case class PathToken(p: String) extends RouteToken
+
+  private[route] type Route = List[RouteToken]
+
+  /**
+   * A case class that enables the following syntax:
+   *
+   * {{{
+   *   val r: Router[Int / String] = Get / int / string
+   *   val s: String = p /> { case i / s => s + i }
+   * }}}
+   */
+  case class /[+A, +B](_1: A, _2: B)
+
+  /**
+   * A user friendly alias for [[RouterN]].
+   */
+  type Router[+A] = RouterN[A]
+
+  /**
+   * An exception, which is thrown by router in case of missing route `r`.
+   */
+  case class RouteNotFound(r: String) extends Exception(s"Route not found: $r")
+
+  private[route] def requestToRoute[Req](req: Req)(implicit ev: Req => HttpRequest): Route =
+    MethodToken(req.method) :: (req.path.split("/").toList.tail map PathToken)
+
+  /**
+   * Implicitly converts the given `Router[Service[_, _]]` into a service.
+   */
+  implicit def routerOfServiceToService[Req, Rep](
+    r: RouterN[Service[Req, Rep]]
+  )(implicit ev: Req => HttpRequest): Service[Req, Rep] = new Service[Req, Rep] {
+    def apply(req: Req): Future[Rep] = {
+      val path = requestToRoute(req)
+      r(path) match {
+        case Some((_, service)) => service(req)
+        case _ => RouteNotFound(req.path).toFutureException
+      }
+    }
+  }
+
+  /**
+   * Implicitly converts the given `Router[Future[_]]` into a service.
+   */
+  implicit def routerOfFutureToService[Req, Rep](
+    r: RouterN[Future[Rep]]
+  )(implicit ev: Req => HttpRequest): Service[Req, Rep] = routerOfServiceToService(r.map { f =>
+    new Service[Req, Rep] {
+      def apply(req: Req) = f
+    }
+  })
+
+  implicit def intToMatcher(i: Int): Router0 = new Matcher(i.toString)
+  implicit def stringToMatcher(s: String): Router0 = new Matcher(s)
+  implicit def booleanToMather(b: Boolean): Router0 = new Matcher(b.toString)
+
+  /**
+   * A router that extracts some value of the type `A` from the given route.
+   */
+  trait RouterN[+A] { self =>
+
+    /**
+     * Extracts some value of type `A` from the given `route`. In case of
+     * success it returns `Some` tuple of the _rest_ of the route and the fetched
+     * _value_. In case of failure it returns `None`.
+     */
+    def apply(route: Route): Option[(Route, A)]
+
+    /**
+     * Maps this router to the given function `fn`.
+     */
+    def map[B](fn: A => B): RouterN[B] = new RouterN[B] {
+      def apply(route: Route): Option[(Route, B)] = for {
+        (r, a) <- self(route)
+      } yield (r, fn(a))
+      override def toString = self.toString
+    }
+
+    /**
+     * Maps the router to the given function `fn`. If the given function `None`
+     * the resulting router will also return `None`.
+     */
+    def maybeMap[B](fn: A => Option[B]): RouterN[B] = new RouterN[B] {
+      def apply(route: Route): Option[(Route, B)] = for {
+        (r, a) <- self(route)
+        b <- fn(a)
+      } yield (r, b)
+      override def toString = self.toString
+    }
+
+    /**
+     * Flat-maps this router to the given function `fn`.
+     */
+    def flatMap[B](fn: A => RouterN[B]): RouterN[B] = new RouterN[B] {
+      def apply(route: Route): Option[(Route, B)] = for {
+        (r, a) <- self(route)
+        (rr, b) <- fn(a)(r)
+      } yield (rr, b)
+      override def toString = self.toString
+    }
+
+    /**
+     * Flat-maps this router to the given [[Router0]].
+     */
+    def flatMap(rm: => Router0): RouterN[A] = new RouterN[A] {
+      def apply(route: Route): Option[(Route, A)] = for {
+        (r, a) <- self(route)
+        rr <- rm(r)
+      } yield (rr, a)
+
+      override def toString = s"${self.toString}/${rm.toString}"
+    }
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed if either this or `that` routers are succeed.
+     */
+    def orElse[B >: A](that: RouterN[B]): RouterN[B] = new RouterN[B] {
+      def apply(route: Route): Option[(Route, B)] =
+        self(route) orElse that(route)
+      override def toString = s"(${self.toString}|${that.toString})"
+    }
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed only if both this and `that` routers are succeed.
+     */
+    def /[B](that: RouterN[B]): RouterN[A / B] = new RouterN[A / B] {
+      val ab = for { a <- self; b <- that } yield new /(a, b)
+      def apply(route: Route): Option[(Route, /[A, B])] = ab(route)
+      override def toString = s"${self.toString}/${that.toString}"
+    }
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed only if both this and `that` routers are succeed.
+     */
+    def /(that: Router0): RouterN[A] =
+      this flatMap that
+
+    /**
+     * Maps this router to the given function `fn`.
+     */
+    def />[B](fn: A => B): RouterN[B] =
+      this map fn
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed if either this or `that` routers are succeed.
+     */
+    def |[B >: A](that: RouterN[B]): RouterN[B] =
+      this orElse that
+
+    // A workaround for https://issues.scala-lang.org/browse/SI-1336
+    def withFilter(p: A => Boolean) = self
+  }
+
+  /**
+   * A router that match the given route to some predicate.
+   */
+  trait Router0 { self =>
+
+    /**
+     * Matches the given `route` to some predicate and returns `Some` of the
+     * _rest_ of the route in case of success or `None` otherwise.
+     */
+    def apply(route: Route): Option[Route]
+
+    /**
+     * Maps this router to the given value `a`.
+     */
+    def map[A](a: => A): RouterN[A] = new RouterN[A] {
+      def apply(route: Route): Option[(Route, A)] = for {
+        r <- self(route)
+      } yield (r, a)
+      override def toString = self.toString
+    }
+
+    /**
+     * Flat-maps this router to the given [[RouterN]].
+     */
+    def flatMap[A](re: => RouterN[A]): RouterN[A] = new RouterN[A] {
+      def apply(route: Route): Option[(Route, A)] =
+        self(route) flatMap { r => re(r) }
+      override def toString = s"${self.toString}/${re.toString}"
+    }
+
+    /**
+     * Flat-maps this router to the given `rm` router.
+     */
+    def flatMap(rm: => Router0): Router0 = new Router0 {
+      def apply(route: Route): Option[Route] =
+        self(route) flatMap { r => rm(r) }
+      override def toString = s"${self.toString}/${rm.toString}"
+    }
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed if either this or `that` routers are succeed.
+     */
+    def orElse(that: Router0): Router0 = new Router0 {
+      def apply(route: Route): Option[Route] =
+        self(route) orElse that(route)
+      override def toString = s"(${self.toString}|${that.toString})"
+    }
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed only if both this and `that` routers are succeed.
+     */
+    def /(that: Router0): Router0 =
+      this flatMap that
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed only if both this and `that` routers are succeed.
+     */
+    def /[A](that: RouterN[A]): RouterN[A] =
+      this flatMap that
+
+    /**
+     * Maps this router to some value.
+     */
+    def />[A](a: => A): RouterN[A] =
+      this map a
+
+    /**
+     * Sequentially composes this router with the given `that` router. The resulting
+     * router will succeed if either this or `that` routers are succeed.
+     */
+    def |(that: Router0): Router0 =
+      this orElse that
+  }
+
+  /**
+   * An universal matcher.
+   */
+  case class Matcher(s: String) extends Router0 {
+    def apply(route: Route): Option[Route] = for {
+      PathToken(ss) <- route.headOption if ss == s
+    } yield route.tail
+    override def toString = s
+  }
+
+  private[route] def stringToSomeValue[A](fn: String => A)(s: String): Option[A] =
+    try Some(fn(s)) catch { case _: IllegalArgumentException => None }
+
+  /**
+   * A [[RouterN]] that extracts a path token.
+   */
+  object PathTokenExtractor extends RouterN[String] {
+    override def apply(route: Route): Option[(Route, String)] = for {
+      PathToken(ss) <- route.headOption
+    } yield (route.tail, ss)
+  }
+
+  /**
+   * An universal extractor that extracts some value of type `A` if
+   * it's possible to fetch the value from the string.
+   */
+  case class Extractor[A](name: String, f: String => Option[A]) extends RouterN[A] {
+    def apply(route: Route): Option[(Route, A)] = PathTokenExtractor.maybeMap(f)(route)
+    def apply(n: String): Extractor[A] = copy(name = n)
+    override def toString = s":$name"
+  }
+
+  /**
+   * A router that matches the given HTTP method `m` in the route.
+   */
+  case class MethodMatcher(m: Method) extends Router0 {
+    def apply(route: Route): Option[Route] = for {
+      MethodToken(mm) <- route.headOption if m == mm
+    } yield route.tail
+    override def toString = s"${m.toString.toUpperCase}"
+  }
+
+  //
+  // A group of routers that matches HTTP methods.
+  //
+  object Get extends MethodMatcher(Method.Get)
+  object Post extends MethodMatcher(Method.Post)
+  object Patch extends MethodMatcher(Method.Patch)
+  object Delete extends MethodMatcher(Method.Delete)
+  object Head extends MethodMatcher(Method.Head)
+  object Options extends MethodMatcher(Method.Options)
+  object Put extends MethodMatcher(Method.Put)
+  object Connect extends MethodMatcher(Method.Connect)
+  object Trace extends MethodMatcher(Method.Trace)
+
+  /**
+   * A [[Router0]] that skips one route token.
+   */
+  object * extends Router0 {
+    def apply(route: Route): Option[Route] = Some(route.tail)
+    override def toString = "*"
+  }
+
+  /**
+   * A [[Router0]] that matches the end of the route.
+   */
+  object $ extends Router0 {
+    def apply(route: Route): Option[Route] =
+      if (route.isEmpty) Some(Nil) else None
+    override def toString = ""
+  }
+
+  /**
+   * A router that extract an integer from the route.
+   */
+  object int extends Extractor("int", stringToSomeValue(_.toInt))
+
+  /**
+   * A router that extract a long value from the route.
+   */
+  object long extends Extractor("long", stringToSomeValue(_.toLong))
+
+  /**
+   * A router that extract a string value from the route.
+   */
+  object string extends Extractor("string", Some(_))
+
+  /**
+   * A router that extract a boolean value from the route.
+   */
+  object boolean extends Extractor("boolean", stringToSomeValue(_.toBoolean))
+}

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2015, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s):
+ */
+
+package io.finch.route
+
+import com.twitter.util.Await
+
+import io.finch._
+import io.finch.response._
+
+import com.twitter.finagle.httpx
+import com.twitter.finagle.httpx.Method
+import com.twitter.finagle.Service
+import org.scalatest.{Matchers, FlatSpec}
+
+class RouterSpec extends FlatSpec with Matchers {
+
+  val route = List(
+    MethodToken(Method.Get), PathToken("a"), PathToken("1"), PathToken("b"), PathToken("2")
+  )
+
+  "A Router" should "extract single string" in {
+    val r = Get / string
+    r(route) shouldBe Some((route.drop(2), "a"))
+  }
+
+  it should "extract multiple strings" in {
+    val r = Get / string / "1" / string
+    r(route) shouldBe Some((route.drop(4), /("a", "b")))
+  }
+
+  it should "match method" in {
+    Get(route) shouldBe Some(route.tail)
+  }
+
+  it should "match method only once" in {
+    val r = Get / Get
+    r(route) shouldBe None
+  }
+
+  it should "match string" in {
+    val r = Get / "a"
+    r(route) shouldBe Some(route.drop(2))
+  }
+
+  it should "match 2 or more strings" in {
+    val r = Get / "a" / 1 / "b"
+    r(route) shouldBe Some(route.drop(4))
+  }
+
+  it should "not match if one of the routers failed" in {
+    val r = Get / "a" / 2
+    r(route) shouldBe None
+  }
+
+  it should "not match if the method is missing" in {
+    val r = "a" / "b"
+    r(route) shouldBe None
+  }
+
+  it should "be able to skip route tokens" in {
+    val r = * / "a"
+    r(route) shouldBe Some(route.drop(2))
+  }
+
+  it should "match either one or other matcher" in {
+    val r = (Get | Post) / ("a" | "b")
+    r(route) shouldBe Some(route.drop(2))
+  }
+
+  it should "match int" in {
+    val r = Get / "a" / 1
+    r(route) shouldBe Some(route.drop(3))
+  }
+
+  it should "be able to not match int if it's a different value" in {
+    val r = Get / "a" / 2
+    r(route) shouldBe None
+  }
+
+  it should "be able to skip one route tokens" in {
+    val r = Get / *
+    r (route) shouldBe Some(route.drop(2))
+  }
+
+  it should "be able to match the whole route" in {
+    val r1 = Get / * / $
+    val r2 = Get / * / * / * / * / $
+    r1(route) shouldBe None
+    r2(route) shouldBe Some(Nil)
+  }
+
+  it should "support DSL for string and int extractors" in {
+    val r1 = Get / "a" / int / string
+    val r2 = Get / "a" / int("1") / "b" / int("2") / $
+
+    r1(route) shouldBe Some((route.drop(4), /(1, "b")))
+    r2(route) shouldBe Some((Nil, /(1, 2)))
+  }
+
+  it should "support DSL for boolean marchers and extractors" in {
+    val route = List(PathToken("flag"), PathToken("true"))
+    val r1 = "flag" / boolean
+    val r2 = "flag" / true
+
+    r1(route) shouldBe Some((Nil, true))
+    r2(route) shouldBe Some(Nil)
+  }
+
+  it should "be implicitly converted into a service" in {
+    def echo(s: String) = new Service[HttpRequest, String] {
+      def apply(request: HttpRequest) = s.toFuture
+    }
+
+    val service: Service[HttpRequest, String] = Get / string /> echo
+    Await.result(service(httpx.Request("/foo"))) shouldBe "foo"
+  }
+
+  it should "be composable as an endpoint" in {
+    val r1 = Get / "a" / int /> { _ + 10 }
+    val r2 = Get / "b" / int / int /> { case a / b => a + b }
+    val r3 = r1 | r2
+
+    r3(route) shouldBe Some((route.drop(3), 11))
+  }
+
+  it should "maps to value" in {
+    val r = Get /> 10
+    r(route) shouldBe Some((route.tail, 10))
+  }
+
+  it should "converts into a string" in {
+    val r1 = Get / $
+    val r2 = Get / "a" / true / 1
+    val r3 = Get / ("a" | "b") / int / long / string
+    val r4 = Get / string("name") / int("id") / boolean("flag") / "foo"
+    val r5 = Post / * / $
+
+    r1.toString shouldBe "GET/"
+    r2.toString shouldBe "GET/a/true/1"
+    r3.toString shouldBe "GET/(a|b)/:int/:long/:string"
+    r4.toString shouldBe "GET/:name/:id/:flag/foo"
+    r5.toString shouldBe "POST/*/"
+  }
+
+  it should "support the for-comprehension syntax" in {
+    val r1 = for { a / b <- Get / string / int } yield a + b
+    val r2 = for { a / b / c <- Get / "a" / int / string / int } yield b + c + a
+    val r3 = r1 | r2
+
+    r1(route) shouldBe Some((route.drop(3), "a1"))
+    r2(route) shouldBe Some((Nil, "b21"))
+    r3(route) shouldBe r1(route)
+  }
+
+  it should "be implicitly convertible into service from future" in {
+    val s: Service[HttpRequest, HttpResponse] =
+      (Get / "foo" /> Ok("bar").toFuture) |
+      (Get / "bar" /> Ok("foo").toFuture)
+
+    Await.result(s(httpx.Request("/foo"))).contentString shouldBe "bar"
+    Await.result(s(httpx.Request("/bar"))).contentString shouldBe "foo"
+    a [RouteNotFound] should be thrownBy Await.result(s(httpx.Request("/baz")))
+  }
+}


### PR DESCRIPTION
This is an initial implementation of route combinators as discussed in #146. There is no DSL layer yet - just raw classes. So, for now we have to explicitly create new instances like `StringMatcher` and `StringExtractor`. The next step would be to write a bunch of implicit conversion in order to enable full-featured DSL.

But now I wanted to collect a feedback and ask for an advice. I don't really think we need both `RouteMatcher` and `RouteExtractor`. My primary goal now is to replace them both with just `Router`. I would love to hear your advices @pasviegas, @benjumanji, @rodrigopr and @rpless on how can we achieve it.

The main problem here is that there are routers that don't extract anything but match something: `Get`, `StringMatcher`. So, the problem is in `RouteExtractor.flatMap` method. Let's say we have just `Router` and define `Get` as `Router[Unit]`. And when we flatMap it to `Router[Int]` we will get `Router[Unit / Int]`, which is wrong.

Anyway. The main idea i was trying to show is that router is just a function `Route => A`. And if `A` is `Service[Req, Rep]` we can call such router an `Endpoint`, since it takes a route and returns a service. This is exactly what endpoint is.