### PR TITLE
add applicative behaviour to RequestReader. Fixes #145

### DIFF
--- a/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s):
+ * Jens Halm
+ */
+package io.finch.request
+
+import org.scalatest.{FlatSpec,Matchers}
+
+import com.twitter.finagle.httpx.Request
+import com.twitter.util.{Await,Throw}
+
+class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
+
+  
+  val reader: RequestReader[(Int, Double, Int)] = 
+    (RequiredIntParam("a") ~
+     RequiredDoubleParam("b") ~
+     RequiredIntParam("c")) map { 
+       case a ~ b ~ c => (a, b, c)
+     }
+  
+  
+  "The applicative reader" should "produce three errors if all three numbers cannot be parsed" in {
+    val request = Request.apply("a"->"foo", "b"->"foo", "c"->"foo")
+    Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
+      ValidationFailed("a", "should be integer"),
+      ValidationFailed("b", "should be double"),
+      ValidationFailed("c", "should be integer")
+    ))))
+  }
+  
+  it should "produce two validation errors if two numbers cannot be parsed" in {
+    val request = Request.apply("a"->"foo", "b"->"7.7", "c"->"foo")
+    Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
+      ValidationFailed("a", "should be integer"),
+      ValidationFailed("c", "should be integer")
+    ))))
+  }
+  
+  it should "produce two ParamNotFound errors if two parameters are missing" in {
+    val request = Request.apply("b"->"7.7")
+    Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
+      ParamNotFound("a"),
+      ParamNotFound("c")
+    ))))
+  }
+  
+  it should "produce one error if the last parameter cannot be parsed to an integer" in {
+    val request = Request.apply("a"->"9", "b"->"7.7", "c"->"foo")
+    Await.result(reader(request).liftToTry) should be (Throw(ValidationFailed("c","should be integer")))
+  }
+  
+  it should "parse all integers and doubles" in {
+    val request = Request.apply("a"->"9", "b"->"7.7", "c"->"5")
+    Await.result(reader(request)) should be ((9,7.7,5))
+  }
+    
+  
+}


### PR DESCRIPTION
This adds applicative behaviour to the RequestReader. It is essential for comprehensive error handling as it collects all errors instead of the existing monadic behaviour which is fail-fast.

A monadic reader written with the current API:

``` scala
  val intTuple: RequestReader[(Int, Int)] = for {
    a <- RequiredIntParam("a")
    b <- RequiredIntParam("b")
  } yield (a, b)
```

can be rewritten in applicative style like this:

``` scala
  val intTupleApplicative: RequestReader[(Int, Int)] = 
    (RequiredIntParam("a") ~
     RequiredIntParam("b")) { 
       case a ~ b => (a, b)
     }
```

None of the existing APIs are affected by this addition.

The functionality has been added without introducing new dependencies like scalaz. The generic applicative builder has been kept separate from the (very little) code which is specific to RequestReader.

Some things remain open for debate and could quickly be adjusted depending on feedback:

1) I picked `~` as the combinator for chaining readers, as this is a very common symbol for this kind of combinators. However, we could also be forward-compatible and use the `|@|` symbol from scalaz, should we expect that scalaz might be introduced as a new dependency at some point anyway, which would make the applicative builder utility added with this PR obsolete.

2) Using the applicative behaviour would require an additional import `io.finch.applicative._`. If this new functionality should be available for everyone without additional imports, it could alternatively be integrated into the `io.finch.request._` import. 
