### PR TITLE
Validation DSL

### DIFF
--- a/core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/core/src/test/scala/io/finch/request/BodySpec.scala
@@ -46,6 +46,10 @@ class BodySpec extends FlatSpec with Matchers {
     a [BodyNotFound.type] should be thrownBy Await.result(futureResult)
   }
 
+  it should "have a toString that produces a string representation of itself" in {
+    RequiredArrayBody.toString should equal(s"Required body")
+  }
+
   "An OptionalArrayBody" should "be properly read if it exists" in {
     val request: HttpRequest = requestWithBody(fooBytes)
     val futureResult: Future[Option[Array[Byte]]] = OptionalArrayBody(request)
@@ -56,6 +60,10 @@ class BodySpec extends FlatSpec with Matchers {
     val request: HttpRequest = requestWithBody(Array[Byte]())
     val futureResult: Future[Option[Array[Byte]]] = OptionalArrayBody(request)
     Await.result(futureResult) should equal(None)
+  }
+
+  it should "have a toString that produces a string representation of itself" in {
+    OptionalArrayBody.toString should equal(s"Optional body")
   }
 
   "A RequiredStringBody" should "be properly read if it exists" in {

--- a/core/src/test/scala/io/finch/request/CookieSpec.scala
+++ b/core/src/test/scala/io/finch/request/CookieSpec.scala
@@ -63,4 +63,9 @@ class CookieSpec extends FlatSpec with Matchers {
 
     Await.result(futureResult) should equal(None)
   }
+
+  it should "have a toString that produces a string representation of itself" in {
+    RequiredCookie(cookieName).toString should equal(s"Required cookie '$cookieName'")
+    OptionalCookie(cookieName).toString should equal(s"Optional cookie '$cookieName'")
+  }
 }

--- a/core/src/test/scala/io/finch/request/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/HeaderSpec.scala
@@ -18,6 +18,7 @@
  * limitations under the License.
  *
  * Contributor(s):
+ * Ryan Plessner
  */
 
 package io.finch.request
@@ -53,5 +54,11 @@ class HeaderSpec extends FlatSpec with Matchers {
     val request = Request()
     val futureResult = OptionalHeader("Location")(request)
     Await.result(futureResult) should be (None)
+  }
+
+  "A Header Reader" should "have a toString that produces a string representation of itself" in {
+    val header = "Location"
+    RequiredHeader(header).toString should equal(s"Required header '$header'")
+    OptionalHeader(header).toString should equal(s"Optional header '$header'")
   }
 }

--- a/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
@@ -42,6 +42,11 @@ class OptionalParamSpec extends FlatSpec with Matchers {
     Await.result(futureResult) should equal(None)
   }
 
+  it should "have a toString that produces a string representation of itself" in {
+    val param = "foo"
+    OptionalParam(param).toString should equal(s"Optional parameter '$param'")
+  }
+
 
   "An OptionalBooleanParam" should "be parsed as an integer" in {
     val request: HttpRequest = Request.apply(("foo", "true"))

--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -58,6 +58,11 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     Await.result(futureResult) should be (Nil)
   }
 
+  it should "have a toString that produces a string representation of itself" in {
+    val param = "foo"
+    OptionalParams(param).toString should equal(s"Optional parameters '$param'")
+  }
+
 
   "A OptionalBooleanParams" should "be parsed as a list of booleans" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "false"))

--- a/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s):
+ * Ryan Plessner
+ */
+
+package io.finch.request
+
+import com.twitter.finagle.httpx.Request
+import com.twitter.util.Await
+import org.scalatest.{Matchers, FlatSpec}
+
+class RequestReaderValidationSpec extends FlatSpec with Matchers {
+
+  val request = Request(("foo", "6"))
+  val reader = RequiredIntParam("foo")
+
+  "A RequestReader" should "allow valid values" in {
+    val evenReader = reader.should("be even") { _ % 2 == 0 }
+    Await.result(evenReader(request)) shouldBe 6
+  }
+
+  it should "raise a RequestReader error for invalid values" in {
+    val oddReader = reader.should("be odd") { _ % 2 != 0 }
+    a [RequestReaderError] should be thrownBy Await.result(oddReader(request))
+  }
+
+  it should "allow valid values in a for-comprehension" in {
+    val readFoo: RequestReader[Int] = for {
+      foo <- reader if foo % 2 == 0
+    } yield foo
+    Await.result(readFoo(request)) shouldBe 6
+  }
+
+  it should "raise a RequestReader error for invalid values in a for-comprehension" in {
+    val readFoo: RequestReader[Int] = for {
+      foo <- reader if foo % 2 != 0
+    } yield foo
+    a [RequestReaderError] should be thrownBy Await.result(readFoo(request))
+  }
+}

--- a/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
@@ -47,6 +47,11 @@ class RequiredParamSpec extends FlatSpec with Matchers {
     a [ParamNotFound] should be thrownBy Await.result(futureResult)
   }
 
+  it should "have a toString that produces a string representation of itself" in {
+    val param = "foo"
+    RequiredParam(param).toString should equal(s"Required parameter '$param'")
+  }
+
   "A RequiredBooleanParam" should "be parsed as a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "true"))
     val futureResult: Future[Boolean] = RequiredBooleanParam("foo")(request)

--- a/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -18,6 +18,7 @@
  * limitations under the License.
  *
  * Contributor(s):
+ * Ryan Plessner
  */
 
 package io.finch.request
@@ -60,6 +61,11 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
     intercept[ValidationFailed] {
       Await.result(futureResult)
     }
+  }
+
+  it should "have a toString that produces a string representation of itself" in {
+    val param = "foo"
+    RequiredParams(param).toString should equal(s"Required parameters '$param'")
   }
 
 


### PR DESCRIPTION
This PR has a basic validation dsl for request readers as in #26. It takes the form of a `when` method on `RequestReader`s.
Basic usage looks like:
```scala
  val user: RequestReader[User] = for {
    name <- RequiredParam("name").when("should be greater then 5 symbols") { name.length > 5 }
  } yield User(userId, name, Seq.empty[Ticket])
```
Would love to get some feedback on this.