### PR TITLE
improve DecodeRequest API to return Try instead of Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target/
 .idea/
 .idea_modules/
 .DS_STORE
+.cache
+.settings
+.project
+.classpath

--- a/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
@@ -4,7 +4,7 @@ import argonaut.Argonaut._
 import argonaut._
 import com.twitter.finagle.Service
 import com.twitter.finagle.httpx.Request
-import com.twitter.util.Await
+import com.twitter.util.{Await,Return}
 import io.finch._
 import io.finch.request.RequiredBody
 import io.finch.response.TurnIntoHttp
@@ -36,15 +36,15 @@ class ArgonautSpec extends FlatSpec with Matchers {
   val exampleUser = TestUser(42, "bob")
 
   "An ArgonautDecode" should "decode json string into a data structure" in {
-    toArgonautDecode(testUserCodec)(str) shouldEqual Option(exampleUser)
+    toArgonautDecode(testUserCodec)(str) shouldEqual Return(exampleUser)
   }
 
-  it should "return None if the string is not valid json" in {
-    toArgonautDecode(testUserCodec)(badJson) shouldEqual None
+  it should "fail if the string is not valid json" in {
+    toArgonautDecode(testUserCodec)(badJson).isThrow shouldEqual true
   }
 
-  it should "return None if the decoder could not decode the string into data" in {
-    toArgonautDecode(testUserCodec)(invalidStructure) shouldEqual None
+  it should "fail if the decoder could not decode the string into data" in {
+    toArgonautDecode(testUserCodec)(invalidStructure).isThrow shouldEqual true
   }
 
   it should "be compatible with finch-core's requests" in {

--- a/core/src/test/scala/io/finch/request/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/request/DecodeSpec.scala
@@ -23,16 +23,18 @@
 package io.finch.request
 
 import org.scalatest.{Matchers, FlatSpec}
+import com.twitter.util.{Try,Return}
 import scala.math._
 
 class DecodeSpec extends FlatSpec with Matchers {
 
-  private def decode[A](json: String)(implicit d: DecodeRequest[A]): Option[A] = d(json)
+  private def decode[A](json: String)(implicit d: DecodeRequest[A]): Try[A] = d(json)
+  
   "A DecodeJson" should "be accepted as implicit instance of superclass" in {
     implicit object BigDecimalJson extends DecodeRequest[BigDecimal] {
-      def apply(s: String): Option[BigDecimal] = Some(BigDecimal(s))
+      def apply(s: String): Try[BigDecimal] = Try(BigDecimal(s))
     }
 
-    decode[ScalaNumber]("12345.25") shouldBe Some(BigDecimal(12345.25))
+    decode[ScalaNumber]("12345.25") shouldBe Return(BigDecimal(12345.25))
   }
 }

--- a/docs.md
+++ b/docs.md
@@ -297,13 +297,14 @@ An HTTP body may be fetched from the HTTP request using the following readers:
 Finch supports pluggable request decoders. In fact, any type `A` my be read from the request body using either:
 `io.finch.request.RequiredBody[A]` or `io.finch.request.OptionalBody[A]` if there is an implicit value of type 
 `DecodeRequest[A]` available in the scope. The `DecodeRequest[A]` abstraction may be described as function 
-`String => Option[A]`. Thus, any decoders may be easily defined to use the functionality of body readers. Note, that 
+`String => Try[A]`. Thus, any decoders may be easily defined to use the functionality of body readers. Note, that 
 the body type (i.e., `Double`) should be always explicitly defined for both `RequiredBody` and `OptionalBody`.
 
 ```
 implicit val decodeDouble = new DecodeRequest[Double] {
-  def apply(s: String): Option[Double] =
-    try { Some(s.toDouble) } catch { case _: NumberFormatException => None }
+  
+  def apply(s: String): Try[Double] = Try { s.toDouble }
+  
 }
 val req: HttpRequest = ???
 val readDouble: RequestReader[Double] = RequiredBody[Double]

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -25,16 +25,17 @@ package io.finch
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.finch.request.DecodeAnyRequest
 import io.finch.response.EncodeAnyResponse
+import com.twitter.util.Try
 
 import scala.reflect.ClassTag
 
 package object jackson {
 
   implicit def decodeJackson(implicit mapper: ObjectMapper) = new DecodeAnyRequest {
-    def apply[A: ClassTag](s: String): Option[A] = try {
+    def apply[A: ClassTag](s: String): Try[A] = Try {
       val clazz = implicitly[ClassTag[A]].runtimeClass.asInstanceOf[Class[A]]
-      Some(mapper.readValue[A](s, clazz))
-    } catch { case _: Exception => None }
+      mapper.readValue[A](s, clazz)
+    }
   }
 
   implicit def encodeJackson(implicit mapper: ObjectMapper) = new EncodeAnyResponse {

--- a/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
+++ b/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.httpx.Request
 import com.twitter.io.Buf.Utf8
-import com.twitter.util.{Await, Future}
+import com.twitter.util.{Await, Future, Return}
 import io.finch.request.{OptionalBody, RequiredBody, RequestReader}
 import io.finch.response.Ok
 import org.jboss.netty.handler.codec.http.HttpHeaders
@@ -42,7 +42,13 @@ class JacksonSpec extends FlatSpec with Matchers {
   it should "decode a case class from JSON" in {
     val json = "{\"bar\":\"bar\",\"baz\":20}"
     val decode = decodeJackson(objectMapper)
-    decode[Foo](json) shouldBe Some(Foo("bar", 20))
+    decode[Foo](json) shouldBe Return(Foo("bar", 20))
+  }
+  
+  it should "fail given invalid JSON" in {
+    val json = "{\"bar\":\"bar\",\"baz\":20}"
+    val decode = decodeJackson(objectMapper)
+    decode[Foo]("{{{{").isThrow shouldBe true
   }
 
   it should "work w/o exceptions with ResponseBuilder" in {
@@ -56,7 +62,7 @@ class JacksonSpec extends FlatSpec with Matchers {
     val decode = decodeJackson(objectMapper)
 
     encode(list) shouldBe "[1,2,3]"
-    decode[List[Int]]("[1,2,3]") shouldBe Some(List(1, 2, 3))
+    decode[List[Int]]("[1,2,3]") shouldBe Return(List(1, 2, 3))
   }
 
   it should "work w/o exceptions with RequestReader" in {

--- a/jawn/src/main/scala/io/finch/jawn/pacakge.scala
+++ b/jawn/src/main/scala/io/finch/jawn/pacakge.scala
@@ -27,6 +27,8 @@ import _root_.jawn.ast.{CanonicalRenderer, JValue}
 import _root_.jawn.{Facade, Parser}
 import io.finch.request.DecodeRequest
 import io.finch.response.EncodeResponse
+import com.twitter.util.{Try, Return, Throw}
+import scala.util.{Success, Failure}
 
 /**
  * This package provides support for use of the Jawn json parsing library in Finch.io.
@@ -40,7 +42,10 @@ package object jawn {
    *
    */
   implicit def toJawnDecode[J](implicit facade: Facade[J]): DecodeRequest[J] = new DecodeRequest[J] {
-    def apply(json: String): Option[J] = Parser.parseFromString(json).toOption
+    def apply(json: String): Try[J] = Parser.parseFromString(json) match {
+      case Success(value) => Return(value)
+      case Failure(error) => Throw(error)
+    }
   }
 
   /**

--- a/jawn/src/test/scala/io/finch/jawn/JawnSpec.scala
+++ b/jawn/src/test/scala/io/finch/jawn/JawnSpec.scala
@@ -36,6 +36,10 @@ class JawnSpec extends FlatSpec with Matchers {
   "A DecodeJawn" should "parse valid json into its ast" in {
     toJawnDecode(facade)(str).foreach(v => v.shouldBe(jsVal))
   }
+  
+  it should "fail given invalid JSON" in {
+    toJawnDecode(facade)("{{{{").isThrow shouldBe true
+  }
 
   "An EncodeJawn" should "render a valid JValue as a string" in {
     EncodeJawn(jsVal) == str

--- a/json/src/main/scala/io/finch/json/package.scala
+++ b/json/src/main/scala/io/finch/json/package.scala
@@ -25,6 +25,8 @@ package io.finch
 
 import io.finch.request.DecodeRequest
 import io.finch.response.EncodeResponse
+import com.twitter.util.{Try, Throw, Return}
+import io.finch.request.BodyNotParsed
 
 package object json {
   implicit val encodeFinchJson = new EncodeResponse[Json] {
@@ -34,6 +36,7 @@ package object json {
   }
 
   implicit val decodeFinchJson = new DecodeRequest[Json] {
-    def apply(json: String): Option[Json] = Json.decode(json)
+    def apply(json: String): Try[Json] = Json.decode(json)
+      .fold[Try[Json]](Throw(BodyNotParsed))(Return(_)) // TODO - error detail is swallowed
   }
 }


### PR DESCRIPTION
This is the 2nd of 5 PRs extracted from https://github.com/finagle/finch/pull/162.

It is exactly as reviewed in the discussion PR except for:

* made all the changes requested in comments in https://github.com/finagle/finch/pull/162

This is the description for this PR, copied from the discussion PR:

## PR 2: Improve `DecodeRequest` API to return `Try[T]` instead of `Option[T]` for improved error handling

This is also very unlikely controversial. The existing API was insufficient for proper error handling.
Returning an `Option` is usually not a good idea in APIs where details about the failure may be helpful.

The new API is simply:
```scala
trait DecodeAnyRequest {
  def apply[A: ClassTag](req: String): Try[A]
}
```

This PR also makes all necessary adaptions for the various JSON integrations (Argonaut, Jawn, Jackson, Finch JSON).

Note that Finch JSON still does not report any error detail, as the underlying public API (Scala SDK JSON parser) is very limited. It should be possible to extract more detail through using a more low-level API here, but this is not yet covered by this PR.  

Breaking API changes: Only for those who manually implemented a `DecodeRequest`. Anyone using the various JSON integration modules should not be affected.