### PR TITLE
Add an implicit as[A] method to all string-based RequestReaders

### DIFF
--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -31,8 +31,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   "A OptionalParams" should "parse all of the url params with the same key" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("bar", "6"), ("foo", "25"))
-    val futureResult: Future[List[String]] = OptionalParams("foo")(request)
-    val result: List[String] = Await.result(futureResult)
+    val futureResult: Future[Seq[String]] = OptionalParams("foo")(request)
+    val result: Seq[String] = Await.result(futureResult)
     result should have length 2
     result should contain("5")
     result should contain("25")
@@ -40,21 +40,21 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   it should "return only params that are not the empty string" in {
     val request: HttpRequest = Request.apply(("foo", ""), ("bar", "6"), ("foo", "25"))
-    val futureResult: Future[List[String]] = OptionalParams("foo")(request)
-    val result: List[String] = Await.result(futureResult)
+    val futureResult: Future[Seq[String]] = OptionalParams("foo")(request)
+    val result: Seq[String] = Await.result(futureResult)
     result should have length 1
     result should contain("25")
   }
 
   it should "return Nil if the parameter does not exist at all" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("bar", "6"), ("foo", "25"))
-    val futureResult: Future[List[String]] = OptionalParams("baz")(request)
+    val futureResult: Future[Seq[String]] = OptionalParams("baz")(request)
     Await.result(futureResult) should be (Nil)
   }
 
   it should "return Nil if all of the values for that parameter ar the emptry string" in {
     val request: HttpRequest = Request.apply(("foo", ""), ("bar", "6"), ("foo", ""))
-    val futureResult: Future[List[String]] = OptionalParams("")(request)
+    val futureResult: Future[Seq[String]] = OptionalParams("")(request)
     Await.result(futureResult) should be (Nil)
   }
 
@@ -66,8 +66,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   "A OptionalBooleanParams" should "be parsed as a list of booleans" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "false"))
-    val futureResult: Future[List[Boolean]] = OptionalBooleanParams("foo")(request)
-    val result: List[Boolean] = Await.result(futureResult)
+    val futureResult: Future[Seq[Boolean]] = OptionalBooleanParams("foo")(request)
+    val result: Seq[Boolean] = Await.result(futureResult)
     result should have length 2
     result should contain(true)
     result should contain(false)
@@ -75,8 +75,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   it should "only include valid booleans" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "5"))
-    val futureResult: Future[List[Boolean]] = OptionalBooleanParams("foo")(request)
-    val result: List[Boolean] = Await.result(futureResult)
+    val futureResult: Future[Seq[Boolean]] = OptionalBooleanParams("foo")(request)
+    val result: Seq[Boolean] = Await.result(futureResult)
     result should have length 1
     result should contain(true)
   }
@@ -84,8 +84,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   "A OptionalIntParams" should "be parsed as a list of integers" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("foo", "255"))
-    val futureResult: Future[List[Int]] = OptionalIntParams("foo")(request)
-    val result: List[Int] = Await.result(futureResult)
+    val futureResult: Future[Seq[Int]] = OptionalIntParams("foo")(request)
+    val result: Seq[Int] = Await.result(futureResult)
     result should have length 2
     result should contain(5)
     result should contain(255)
@@ -93,8 +93,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   it should "only include valid integers" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "255"))
-    val futureResult: Future[List[Int]] = OptionalIntParams("foo")(request)
-    val result: List[Int] = Await.result(futureResult)
+    val futureResult: Future[Seq[Int]] = OptionalIntParams("foo")(request)
+    val result: Seq[Int] = Await.result(futureResult)
     result should have length 1
     result should contain(255)
   }
@@ -102,8 +102,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   "A OptionalLongParams" should "be parsed as a list of longs" in {
     val request: HttpRequest = Request.apply(("foo", "9000000000000000"), ("foo", "7500000000000000"))
-    val futureResult: Future[List[Long]] = OptionalLongParams("foo")(request)
-    val result: List[Long] = Await.result(futureResult)
+    val futureResult: Future[Seq[Long]] = OptionalLongParams("foo")(request)
+    val result: Seq[Long] = Await.result(futureResult)
     result should have length 2
     result should contain(9000000000000000L)
     result should contain(7500000000000000L)
@@ -111,16 +111,16 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   it should "only include valid longs" in {
     val request: HttpRequest = Request.apply(("foo", "false"), ("foo", "7500000000000000"))
-    val futureResult: Future[List[Long]] = OptionalLongParams("foo")(request)
-    val result: List[Long] = Await.result(futureResult)
+    val futureResult: Future[Seq[Long]] = OptionalLongParams("foo")(request)
+    val result: Seq[Long] = Await.result(futureResult)
     result should have length 1
     result should contain(7500000000000000L)
   }
 
   "A OptionalFloatParams" should "be parsed as a list of floats" in {
     val request: HttpRequest = Request.apply(("foo", "5.123"), ("foo", "536.22345"))
-    val futureResult: Future[List[Float]] = OptionalFloatParams("foo")(request)
-    val result: List[Float] = Await.result(futureResult)
+    val futureResult: Future[Seq[Float]] = OptionalFloatParams("foo")(request)
+    val result: Seq[Float] = Await.result(futureResult)
     result should have length 2
     result should contain(5.123f)
     result should contain(536.22345f)
@@ -128,8 +128,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   it should "only include valid floats" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "true"), ("foo", "5.123"))
-    val futureResult: Future[List[Float]] = OptionalFloatParams("foo")(request)
-    val result: List[Float] = Await.result(futureResult)
+    val futureResult: Future[Seq[Float]] = OptionalFloatParams("foo")(request)
+    val result: Seq[Float] = Await.result(futureResult)
     result should have length 1
     result should contain(5.123f)
   }
@@ -137,8 +137,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   "A OptionalDoubleParams" should "be parsed as a list of doubles" in {
     val request: HttpRequest = Request.apply(("foo", "100.0"), ("foo", "66566.45243"))
-    val futureResult: Future[List[Double]] = OptionalDoubleParams("foo")(request)
-    val result: List[Double] = Await.result(futureResult)
+    val futureResult: Future[Seq[Double]] = OptionalDoubleParams("foo")(request)
+    val result: Seq[Double] = Await.result(futureResult)
     result should have length 2
     result should contain(100.0)
     result should contain(66566.45243)
@@ -146,8 +146,8 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
   it should "only include valid doubles" in {
     val request: HttpRequest = Request.apply(("foo", "45543245.435"), ("foo", "non-number"))
-    val futureResult: Future[List[Double]] = OptionalDoubleParams("foo")(request)
-    val result: List[Double] = Await.result(futureResult)
+    val futureResult: Future[Seq[Double]] = OptionalDoubleParams("foo")(request)
+    val result: Seq[Double] = Await.result(futureResult)
     result should have length 1
     result should contain(45543245.435)
   }

--- a/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -32,8 +32,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredParams" should "parse all of the url params with the same key" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("bar", "6"), ("foo", "25"))
-    val futureResult: Future[List[String]] = RequiredParams("foo")(request)
-    val result: List[String] = Await.result(futureResult)
+    val futureResult: Future[Seq[String]] = RequiredParams("foo")(request)
+    val result: Seq[String] = Await.result(futureResult)
     result should have length 2
     result should contain("5")
     result should contain("25")
@@ -41,15 +41,15 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "return only params that are not the empty string" in {
     val request: HttpRequest = Request.apply(("foo", ""), ("bar", "6"), ("foo", "25"))
-    val futureResult: Future[List[String]] = RequiredParams("foo")(request)
-    val result: List[String] = Await.result(futureResult)
+    val futureResult: Future[Seq[String]] = RequiredParams("foo")(request)
+    val result: Seq[String] = Await.result(futureResult)
     result should have length 1
     result should contain("25")
   }
 
   it should "throw a ParamNotFound Exception if the parameter does not exist at all" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("bar", "6"), ("foo", "25"))
-    val futureResult: Future[List[String]] = RequiredParams("baz")(request)
+    val futureResult: Future[Seq[String]] = RequiredParams("baz")(request)
     intercept[ParamNotFound] {
       Await.result(futureResult)
     }
@@ -57,7 +57,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "throw a Validation Exception if all of the parameter values are empty" in {
     val request: HttpRequest = Request.apply(("foo", ""), ("bar", "6"), ("foo", ""))
-    val futureResult: Future[List[String]] = RequiredParams("foo")(request)
+    val futureResult: Future[Seq[String]] = RequiredParams("foo")(request)
     intercept[ValidationFailed] {
       Await.result(futureResult)
     }
@@ -71,8 +71,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredBooleanParams" should "be parsed as a list of booleans" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "false"))
-    val futureResult: Future[List[Boolean]] = RequiredBooleanParams("foo")(request)
-    val result: List[Boolean] = Await.result(futureResult)
+    val futureResult: Future[Seq[Boolean]] = RequiredBooleanParams("foo")(request)
+    val result: Seq[Boolean] = Await.result(futureResult)
     result should have length 2
     result should contain(true)
     result should contain(false)
@@ -80,7 +80,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "produce an error if one of the params is not a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "5"))
-    val futureResult: Future[List[Boolean]] = RequiredBooleanParams("foo")(request)
+    val futureResult: Future[Seq[Boolean]] = RequiredBooleanParams("foo")(request)
     intercept[ValidationFailed] {
       Await.result(futureResult)
     }
@@ -89,8 +89,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredIntParams" should "be parsed as a list of integers" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("foo", "255"))
-    val futureResult: Future[List[Int]] = RequiredIntParams("foo")(request)
-    val result: List[Int] = Await.result(futureResult)
+    val futureResult: Future[Seq[Int]] = RequiredIntParams("foo")(request)
+    val result: Seq[Int] = Await.result(futureResult)
     result should have length 2
     result should contain(5)
     result should contain(255)
@@ -107,8 +107,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredLongParams" should "be parsed as a list of longs" in {
     val request: HttpRequest = Request.apply(("foo", "9000000000000000"), ("foo", "7500000000000000"))
-    val futureResult: Future[List[Long]] = RequiredLongParams("foo")(request)
-    val result: List[Long] = Await.result(futureResult)
+    val futureResult: Future[Seq[Long]] = RequiredLongParams("foo")(request)
+    val result: Seq[Long] = Await.result(futureResult)
     result should have length 2
     result should contain(9000000000000000L)
     result should contain(7500000000000000L)
@@ -116,7 +116,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "produce an error if one of the params is not a long" in {
     val request: HttpRequest = Request.apply(("foo", "false"), ("foo", "7500000000000000"))
-    val futureResult: Future[List[Long]] = RequiredLongParams("foo")(request)
+    val futureResult: Future[Seq[Long]] = RequiredLongParams("foo")(request)
     intercept[ValidationFailed] {
       Await.result(futureResult)
     }
@@ -125,8 +125,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredFloatParams" should "be parsed as a list of floats" in {
     val request: HttpRequest = Request.apply(("foo", "5.123"), ("foo", "536.22345"))
-    val futureResult: Future[List[Float]] = RequiredFloatParams("foo")(request)
-    val result: List[Float] = Await.result(futureResult)
+    val futureResult: Future[Seq[Float]] = RequiredFloatParams("foo")(request)
+    val result: Seq[Float] = Await.result(futureResult)
     result should have length 2
     result should contain(5.123f)
     result should contain(536.22345f)
@@ -134,7 +134,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "produce an error if one of the params is not a float" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "true"))
-    val futureResult: Future[List[Float]] = RequiredFloatParams("foo")(request)
+    val futureResult: Future[Seq[Float]] = RequiredFloatParams("foo")(request)
     intercept[ValidationFailed] {
       Await.result(futureResult)
     }
@@ -143,8 +143,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredDoubleParams" should "be parsed as a list of doubles" in {
     val request: HttpRequest = Request.apply(("foo", "100.0"), ("foo", "66566.45243"))
-    val futureResult: Future[List[Double]] = RequiredDoubleParams("foo")(request)
-    val result: List[Double] = Await.result(futureResult)
+    val futureResult: Future[Seq[Double]] = RequiredDoubleParams("foo")(request)
+    val result: Seq[Double] = Await.result(futureResult)
     result should have length 2
     result should contain(100.0)
     result should contain(66566.45243)
@@ -152,7 +152,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "produce an error if one of the params is not a double" in {
     val request: HttpRequest = Request.apply(("foo", "45543245.435"), ("foo", "non-number"))
-    val futureResult: Future[List[Double]] = RequiredDoubleParams("foo")(request)
+    val futureResult: Future[Seq[Double]] = RequiredDoubleParams("foo")(request)
     intercept[ValidationFailed] {
       Await.result(futureResult)
     }

--- a/docs.md
+++ b/docs.md
@@ -310,6 +310,30 @@ val req: HttpRequest = ???
 val readDouble: RequestReader[Double] = RequiredBody[Double]
 ```
 
+
+### Type Conversion
+
+A `DecodeRequest[A]` can also be applied in a generic way to any `RequestReader[String]`, 
+`RequestReader[Option[String]]` or `RequestReader[Seq[String]]`
+as long as a matching implicit is in scope, through calling `as[A]` on the reader.
+
+This is an example for applying an integer conversion to a reader:
+
+```scala
+implicit val decodeInt = new DecodeRequest[Int] {
+   def apply(req: String): Try[Int] = Try(req.toInt)
+}
+
+val reader: RequestReader[Int] = RequiredParam("foo").as[Int]
+```
+
+The above is equivalent to the built-in `RequiredIntParam("foo")`, but the 
+generic `as[A]` method allows to use `DecodeRequest` instances for any target
+type, such as a Joda `DateTime` for example, making the `DecodeRequest` API
+more broadly useful than just offering this functionality for the request body
+as in previous Finch versions.
+
+
 ## Responses
 
 ### Response Builder


### PR DESCRIPTION
This is the 3rd of 5 PRs extracted from https://github.com/finagle/finch/pull/162.

It is exactly as reviewed in the discussion PR except for:

* fixed the compilation issue for Scala 2.10 which was actually caused by a compiler bug, through removing `extends AnyVal` from the implicit classes (as long as we support 2.10)
* fixed issues around `DecodeAnyRequest` and implicit resolution through making the magnet based on `DecodeAnyRequest` lower priority and added a test in `DecodeSpec` to prove this actually works

Note that two files show up as completely changed as someone checked them in with Windows line breaks. I'm not sure what the project's policy is regarding `autocrlf` settings.

This is the description for this PR, copied from the discussion PR:

## PR 3: Make `DecodeRequest` more broadly useful through adding an implicit `as[A]` method to all string based readers.

This has not yet been discussed anywhere, but is hopefully very obviously attractive. The use of the `DecodeRequest` API has previously been limited to body parsers. However, this limitation feels arbitrary. It is sometimes just as useful to have for parameters or for headers. As an example, in our current project almost each route contains two parameters which need to be converted to a Joda `DateTime`. Composing this outside of a reader would be cumbersome and feel like the wrong abstraction.

The new `as[A]` method makes it easy to do this together with other parameter validations and conversions:

```scala
val user: RequestReader[TimeSeries] = for {
  groupBy <- RequiredParam("groupBy")
  startDate <- RequiredParam("startDate").as[DateTime]
  endDate <- RequiredParam("startDate").as[DateTime]
} yield TimeSeries(groupBy, startDate, endDate)
```

The above will work as long as an implicit `DecodeRequest[DateTime]` is in scope. 

For headers this feature may come in handy, too. In particular for those where you write custom parsers based on RFCs, like the `Accept` header for example.

The beauty of this feature comes from the fact that the `as[A]` method is not hardcoded anywhere, but implicitly available for any string based reader. The `RequiredCookie` reader for example cannot be directly used with `as[A]` as it is of type `RequestReader[Cookie]`, but the following will work without problems:

```scala
RequiredCookie("visits").map(_.value).as[Int]
```

The `as[A]` method is available for the following reader types:
```scala
RequestReader[String]         --> RequestReader[A]
RequestReader[Option[String]] --> RequestReader[Option[A]]
RequestReader[Seq[String]]    --> RequestReader[Seq[A]]
```

Breaking API changes: Just one (hopefully minor): RequiredParams is now a `RequestReader[Seq[String]]` instead of `List` to make it more generic and matching to the implicit `as` for readers producing a `Seq[String]`.

Otherwise this PR is non-destructive, it only adds to the feature set. In my eyes the old `RequiredBody[A]` should at some point be deprecated in favor of `RequiredBody.as[A]` to make it all feel more unified, but this is not covered by this PR yet.
