### PR TITLE
Improve implicit convertsion from router to service/endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Hello World!
 This "Hello World!" example is built with the `0.5.0-SNAPSHOT` version of `finch-core`.
 
 ```scala
-Httpx.serve(":8080", Get / "hello" / string /> Ok("Hello " + _ + "!").toFuture)
+import io.finch._
+import io.finch.route._
+import io.finch.response._
+
+Httpx.serve(":8080",
+  Get / "hello" / string /> Ok("Hello, " + _ + "!").toFuture: Endpoint[HttRequest, HttpResponse]
+)
 ```
 
 Documentation


### PR DESCRIPTION
I need some help with it. What I want to achieve is to allow users mix routers of both futures and services into a endpoint. Like this:

```scala
val e: Endpoint[A, B] = (Get / "a" /> b.toFuture) | (Get / "b" /> bService)
```

For now, I only managed to solve it by [specifying the type explicitly](https://github.com/finagle/finch/commit/1bb7e3b82d4788131969c07bb1044f468ce1ea2e#diff-15fab5bf685af131056294bdbbcd0950R178). What we want to do is to probably chain implicit conversion, which seems to be possible according to this [SO question](http://stackoverflow.com/questions/5332801/how-can-i-chain-implicits-in-scala). I can't really figure out how to do it. It feels like we have to change the `orElse` method on router. 