### PR TITLE
Unify error handling and simplify implementation of request package - fixes #157

### DIFF
--- a/core/src/main/scala/io/finch/request/optional.scala
+++ b/core/src/main/scala/io/finch/request/optional.scala
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s):
+ * Ben Whitehead
+ * Ryan Plessner
+ * Pedro Viegas
+ * Jens Halm
+ */
+
+package io.finch.request
+
+import com.twitter.util.Future
+import io.finch._
+import items._
+import scala.reflect.ClassTag
+
+/**
+ * An empty ''RequestReader''.
+ */
+object EmptyReader extends RequestReader[Nothing] {
+  val item = MultipleItems
+  def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
+    new NoSuchElementException("Empty reader.").toFutureException
+}
+
+/**
+ * A const param.
+ */
+object ConstReader {
+
+  /**
+   * Creates a ''RequestReader'' that reads given ''const'' param from the request.
+   *
+   * @return a const param value
+   */
+  def apply[A](const: Future[A]) = new RequestReader[A] {
+    val item = MultipleItems
+    def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = const
+  }
+}
+
+/**
+ * A required integer param.
+ */
+object RequiredIntParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required integer ''param''
+   * from the request or raises an exception when the param is missing or empty
+   * or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a param value
+   */
+  def apply(param: String): RequestReader[Int] = RequiredParam(param).as[Int]
+}
+
+/**
+ * A required long param.
+ */
+object RequiredLongParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required long ''param''
+   * from the request or raises an exception when the param is missing or empty
+   * or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a param value
+   */
+  def apply(param: String): RequestReader[Long] = RequiredParam(param).as[Long]
+}
+
+/**
+ * A required boolean param.
+ */
+object RequiredBooleanParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required boolean ''param''
+   * from the request or raises an exception when the param is missing or empty
+   * or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a param value
+   */
+  def apply(param: String): RequestReader[Boolean] = RequiredParam(param).as[Boolean]
+}
+
+/**
+ * A required float param.
+ */
+object RequiredFloatParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required float ''param''
+   * from the request or raises an exception when the param is missing or empty
+   * or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a param value
+   */
+  def apply(param: String): RequestReader[Float] = RequiredParam(param).as[Float]
+}
+
+/**
+ * A required double param.
+ */
+object RequiredDoubleParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required double ''param''
+   * from the request or raises an exception when the param is missing or empty
+   * or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a param value
+   */
+  def apply(param: String): RequestReader[Double] = RequiredParam(param).as[Double]
+}
+
+/**
+ * An optional int param.
+ */
+object OptionalIntParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional integer ''param''
+   * from the request into an ''Option''.
+   *
+   * @param param the param to read
+   *
+   * @return an option that contains a param value or ''None'' if the param
+   *         is empty or it doesn't correspond to the expected type
+   */
+  def apply(param: String): RequestReader[Option[Int]] = OptionalParam(param).as[Int]
+}
+
+/**
+ * An optional long param.
+ */
+object OptionalLongParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional long ''param''
+   * from the request into an ''Option''.
+   *
+   * @param param the param to read
+   *
+   * @return an option that contains a param value or ''None'' if the param
+   *         is empty or it doesn't correspond to the expected type
+   */
+  def apply(param: String): RequestReader[Option[Long]] = OptionalParam(param).as[Long]
+}
+
+/**
+ * An optional boolean param.
+ */
+object OptionalBooleanParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional boolean ''param''
+   * from the request into an ''Option''.
+   *
+   * @param param the param to read
+   *
+   * @return an option that contains a param value or ''None'' if the param
+   *         is empty or it doesn't correspond to the expected type
+   */
+  def apply(param: String): RequestReader[Option[Boolean]] = OptionalParam(param).as[Boolean]
+}
+
+/**
+ * An optional float param.
+ */
+object OptionalFloatParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional float ''param''
+   * from the request into an ''Option''.
+   *
+   * @param param the param to read
+   *
+   * @return an option that contains a param value or ''None'' if the param
+   *         is empty or it doesn't correspond to the expected type
+   */
+  def apply(param: String): RequestReader[Option[Float]] = OptionalParam(param).as[Float]
+}
+
+/**
+ * An optional double param.
+ */
+object OptionalDoubleParam {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional double ''param''
+   * from the request into an ''Option''.
+   *
+   * @param param the param to read
+   *
+   * @return an option that contains a param value or ''None'' if the param
+   *         is empty or it doesn't correspond to the expected type
+   */
+  def apply(param: String): RequestReader[Option[Double]] = OptionalParam(param).as[Double]
+}
+
+/**
+ * A required multi-value integer param.
+ */
+object RequiredIntParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required multi-value integer
+   * ''param'' from the request into an ''List'' or raises an exception when the
+   * param is missing or empty or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param
+   */
+  def apply(param: String): RequestReader[Seq[Int]] = RequiredParams(param).as[Int]
+}
+
+/**
+ * A required multi-value long param.
+ */
+object RequiredLongParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required multi-value long
+   * ''param'' from the request into an ''List'' or raises an exception when the
+   * param is missing or empty or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param
+   */
+  def apply(param: String): RequestReader[Seq[Long]] = RequiredParams(param).as[Long]
+}
+
+/**
+ * A required multi-value boolean param.
+ */
+object RequiredBooleanParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required multi-value boolean
+   * ''param'' from the request into an ''List'' or raises an exception when the
+   * param is missing or empty or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param
+   */
+  def apply(param: String): RequestReader[Seq[Boolean]] = RequiredParams(param).as[Boolean]
+}
+
+/**
+ * A required multi-value float param.
+ */
+object RequiredFloatParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required multi-value float
+   * ''param'' from the request into an ''List'' or raises an exception when the
+   * param is missing or empty or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param
+   */
+  def apply(param: String): RequestReader[Seq[Float]] = RequiredParams(param).as[Float]
+}
+
+/**
+ * A required multi-value double param.
+ */
+object RequiredDoubleParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads a required multi-value double
+   * ''param'' from the request into an ''List'' or raises an exception when the
+   * param is missing or empty or doesn't correspond to an expected type.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param
+   */
+  def apply(param: String): RequestReader[Seq[Double]] = RequiredParams(param).as[Double]
+}
+
+/**
+ * An optional multi-value integer param.
+ */
+object OptionalIntParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional multi-value
+   * integer ''param'' from the request into an ''List''.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param or
+   *         en empty list ''Nil'' if the param is missing or empty or doesn't
+   *         correspond to a requested type.
+   */
+  def apply(param: String): RequestReader[Seq[Int]] = OptionalParams(param).as[Int]
+}
+
+/**
+ * An optional multi-value long param.
+ */
+object OptionalLongParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional multi-value
+   * integer ''param'' from the request into an ''List''.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param or
+   *         en empty list ''Nil'' if the param is missing or empty or doesn't
+   *         correspond to a requested type.
+   */
+  def apply(param: String): RequestReader[Seq[Long]] = OptionalParams(param).as[Long]
+}
+
+/**
+ * An optional multi-value boolean param.
+ */
+object OptionalBooleanParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional multi-value
+   * boolean ''param'' from the request into an ''List''.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param or
+   *         en empty list ''Nil'' if the param is missing or empty or doesn't
+   *         correspond to a requested type.
+   */
+  def apply(param: String): RequestReader[Seq[Boolean]] = OptionalParams(param).as[Boolean]
+}
+
+/**
+ * An optional multi-value float param.
+ */
+object OptionalFloatParams {
+
+  /**
+   * Creates a ''RequestReader'' that reads an optional multi-value
+   * float ''param'' from the request into an ''List''.
+   *
+   * @param param the param to read
+   *
+   * @return a ''List'' that contains all the values of multi-value param or
+   *         en empty list ''Nil'' if the param is missing or empty or doesn't
+   *         correspond to a requested type.
+   */
+  def apply(param: String): RequestReader[Seq[Float]] = OptionalParams(param).as[Float]
+}
+
+/**
+ * An optional multi-value double param.
+ */
+object OptionalDoubleParams {
+
+/**
+ * Creates a ''RequestReader'' that reads an optional multi-value
+ * double ''param'' from the request into an ''List''.
+ *
+ * @param param the param to read
+ *
+ * @return a ''List'' that contains all the values of multi-value param or
+ *         en empty list ''Nil'' if the param is missing or empty or doesn't
+ *         correspond to a requested type.
+ */
+  def apply(param: String): RequestReader[Seq[Double]] = OptionalParams(param).as[Double]
+}
+
+  /**
+ * A ''RequestReader'' that reads an optional encoded object serialized in request body
+ * and decodes it, according to an implicit decoder, into an ''Option''.
+ */
+object OptionalBody {
+  def apply[A](implicit m: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[Option[A]] = OptionalStringBody.as[A]
+
+  // TODO: Make it accept `Req` instead
+  def apply[A](req: HttpRequest)(implicit m: DecodeMagnet[A], tag: ClassTag[A]): Future[Option[A]] =
+    OptionalBody[A](m, tag)(req)
+}
+
+/**
+ * A ''RequestReader'' that reads an encoded object serialized in request body
+ * and decodes it according to an implicit decoder.
+ */
+object RequiredBody {
+  def apply[A](implicit m: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[A] = OptionalStringBody.as[A].failIfEmpty
+  
+  // TODO: Make it accept `Req` instead
+  def apply[A](req: HttpRequest)(implicit m: DecodeMagnet[A], tag: ClassTag[A]): Future[A] = RequiredBody[A](m, tag)(req)
+}

--- a/core/src/main/scala/io/finch/request/package.scala
+++ b/core/src/main/scala/io/finch/request/package.scala
@@ -59,6 +59,18 @@ package request {
 
 package object request extends LowPriorityImplicits {
 
+  
+  implicit val decodeInt: DecodeRequest[Int] = DecodeRequest { s => Try(s.toInt) }
+  
+  implicit val decodeLong: DecodeRequest[Long] = DecodeRequest { s => Try(s.toLong) }
+  
+  implicit val decodeFloat: DecodeRequest[Float] = DecodeRequest { s => Try(s.toFloat) }
+  
+  implicit val decodeDouble: DecodeRequest[Double] = DecodeRequest { s => Try(s.toDouble) }
+  
+  implicit val decodeBoolean: DecodeRequest[Boolean] = DecodeRequest { s => Try(s.toBoolean) }
+  
+  
   /**
    * A reusable validation rule that can be applied to any [[RequestReader]] with a matching type.
    */
@@ -117,12 +129,31 @@ package object request extends LowPriorityImplicits {
   }
   
   /**
+   * Representations for the various request item types
+   * that can be processed with ''RequestReaders''.
+   */
+  object items {
+    sealed abstract class RequestItem(val kind: String, val nameOption:Option[String] = None) {
+      val description = kind + nameOption.fold("")(" '"+_+"'")
+    }
+    case class ParamItem(name: String) extends RequestItem("param", Some(name))
+    case class HeaderItem(name: String) extends RequestItem("header", Some(name))
+    case class CookieItem(name: String) extends RequestItem("cookie", Some(name))
+    case object BodyItem extends RequestItem("body")
+    case object MultipleItems extends RequestItem("request")
+  }
+  
+  import items._
+  
+  /**
    * A request reader (a Reader Monad) reads a ''Future'' of ''A'' from the ''HttpRequest''.
    *
    * @tparam A the result type
    */
   trait RequestReader[A] { self =>
 
+    def item: RequestItem
+    
     /**
      * Reads the data from given request ''req''.
      *
@@ -132,14 +163,22 @@ package object request extends LowPriorityImplicits {
     def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[A]
 
     def flatMap[B](fn: A => RequestReader[B]) = new RequestReader[B] {
+      val item = MultipleItems
       def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = self(req) flatMap { fn(_)(req) }
     }
 
     def map[B](fn: A => B) = new RequestReader[B] {
+      val item = self.item
       def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = self(req) map fn
     }
     
+    def embedFlatMap[B](fn: A => Future[B]) = new RequestReader[B] {
+      val item = self.item
+      def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = self(req) flatMap fn
+    }
+    
     def ~[B](that: RequestReader[B]): RequestReader[A ~ B] = new RequestReader[A ~ B] {
+      val item = MultipleItems
       def apply[Req] (req: Req)(implicit ev: Req => HttpRequest): Future[A ~ B] = 
         Future.join(self(req)(ev).liftToTry, that(req)(ev).liftToTry) flatMap {
           case (Return(a), Return(b)) => new ~(a, b).toFuture
@@ -169,13 +208,9 @@ package object request extends LowPriorityImplicits {
      * @return a ''RequestReader'' that will return the value of this reader if it is valid.
      *         Otherwise a ''RequestReaderError'' is returned as ''FutureException''.
      */
-    def should(rule: String)(predicate: A => Boolean): RequestReader[A] = new RequestReader[A] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[A] = {
-        self(req).flatMap { a =>
-          if (predicate(a)) a.toFuture
-          else new RequestReaderError(s"${self.toString} should $rule.").toFutureException
-        }
-      }
+    def should(rule: String)(predicate: A => Boolean): RequestReader[A] = embedFlatMap { a =>
+      if (predicate(a)) a.toFuture
+      else NotValid(self.item, rule).toFutureException
     }
     
     /**
@@ -187,14 +222,7 @@ package object request extends LowPriorityImplicits {
      * @return a ''RequestReader'' that will return the value of this reader if it is valid.
      *         Otherwise a ''RequestReaderError'' is returned as ''FutureException''.
      */
-    def shouldNot(rule: String)(predicate: A => Boolean): RequestReader[A] = new RequestReader[A] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[A] = {
-        self(req).flatMap { a =>
-          if (!predicate(a)) a.toFuture
-          else new RequestReaderError(s"${self.toString} should not $rule.").toFutureException
-        }
-      }
-    }
+    def shouldNot(rule: String)(predicate: A => Boolean): RequestReader[A] = should(s"not $rule.")(x => !predicate(x))
     
     /**
      * Validates the result of this ''RequestReader'' using a predefined rule. This method allows
@@ -220,28 +248,33 @@ package object request extends LowPriorityImplicits {
   }
   
   /**
+   * Convenience methods for creating new reader instances.
+   */
+  object RequestReader {
+    
+    def apply[A](reqItem: RequestItem)(f: HttpRequest => A): RequestReader[A] = 
+      new RequestReader[A] {
+        val item = reqItem
+        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = f(req).toFuture
+      }
+    
+  }
+  
+  private[this] def notParsed[A](reader: RequestReader[_], tag: ClassTag[_]): PartialFunction[Throwable,Try[A]] = {
+    case exc => Throw(NotParsed(reader.item, tag, exc))
+  }
+  
+  /**
    * Implicit conversion that allows to call ''as[A]'' on any ''RequestReader[String]''
    * to perform a type conversion based on an implicit ''DecodeRequest[A]'' which must
    * be in scope.
    * 
    * The resulting reader will fail when type conversion fails.
    */
-  implicit class StringReaderOps(val reader: RequestReader[String]) {
+  implicit class StringReaderOps(val reader: RequestReader[String]) extends AnyVal {
 
-    /* IMPLEMENTATION NOTE: The three implicit classes for string based readers should
-     * all extend AnyVal to avoid instance creation for each invocation of the extension
-     * method. However, this let's us run into a compiler bug when we compile for Scala 2.10:
-     * https://issues.scala-lang.org/browse/SI-8018. The bug is caused by the combination of
-     * three things: 1) an implicit class, 2) extending AnyVal, 3) wrapping a class with type
-     * parameters. 2) is the only thing we can remove here, otherwise we'd need to move the
-     * body of the methods somewhere else. Once we drop support for Scala 2.10, these classes
-     * can safely extends AnyVal. 
-     */
-    
-    def as[A](implicit magnet: DecodeMagnet[A]): RequestReader[A] = reader flatMap { value =>
-      new RequestReader[A] {
-        def apply[Req] (req: Req)(implicit ev: Req => HttpRequest): Future[A] = Future.const(magnet()(value))
-      } 
+    def as[A](implicit magnet: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[A] = reader embedFlatMap { value =>
+      Future.const(magnet()(value).rescue(notParsed(reader, tag)))
     }
     
   }
@@ -254,13 +287,11 @@ package object request extends LowPriorityImplicits {
    * The resulting reader will fail when the result is non-empty and type conversion fails.
    * It will succeed if the result is empty or type conversion succeeds.
    */
-  implicit class StringOptionReaderOps(val reader: RequestReader[Option[String]]) {
+  implicit class StringOptionReaderOps(val reader: RequestReader[Option[String]]) extends AnyVal {
     
-    def as[A](implicit magnet: DecodeMagnet[A]): RequestReader[Option[A]] = reader flatMap { 
-      case Some(value) => new RequestReader[Option[A]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = Future.const(magnet()(value) map (Option(_)))
-      }
-      case None => ConstReader(Future.None)
+    def as[A](implicit magnet: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[Option[A]] = reader embedFlatMap { 
+      case Some(value) => Future.const(magnet()(value).rescue(notParsed(reader, tag)) map (Some(_)))
+      case None => Future.None
     }
     
   }
@@ -276,14 +307,32 @@ package object request extends LowPriorityImplicits {
    */
   implicit class StringSeqReaderOps(val reader: RequestReader[Seq[String]]) {
     
-    def as[A](implicit magnet: DecodeMagnet[A]): RequestReader[Seq[A]] = reader flatMap { items =>
-      new RequestReader[Seq[A]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = {
-          val converted = items map (magnet()(_))
-          if (converted.forall(_.isReturn)) converted.map(_.get).toFuture
-          else RequestReaderErrors(converted collect { case Throw(e) => e }).toFutureException
-        }
-      }
+    /* IMPLEMENTATION NOTE: This implicit class should extend AnyVal like all the other ones,
+     * to avoid instance creation for each invocation of the extension method. However, 
+     * this let's us run into a compiler bug when we compile for Scala 2.10:
+     * https://issues.scala-lang.org/browse/SI-8018. The bug is caused by the combination of
+     * four things: 1) an implicit class, 2) extending AnyVal, 3) wrapping a class with type
+     * parameters, 4) a partial function in the body. 2) is the only thing we can easily remove here, 
+     * otherwise we'd need to move the body of the method somewhere else. Once we drop support for 
+     * Scala 2.10, this class can safely extends AnyVal. 
+     */
+    
+    def as[A](implicit magnet: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[Seq[A]] = reader embedFlatMap { items =>
+      val converted = items map (magnet()(_))
+      if (converted.forall(_.isReturn)) converted.map(_.get).toFuture
+      else RequestReaderErrors(converted collect { case Throw(e) => NotParsed(reader.item, tag, e) }).toFutureException
+    }
+    
+  }
+  
+  /**
+   * Implicit conversion that adds convenience methods to readers for optional values.
+   */
+  implicit class OptionReaderOps[A](val reader: RequestReader[Option[A]]) extends AnyVal {
+    
+    def failIfEmpty: RequestReader[A] = reader embedFlatMap { 
+      case Some(value) => value.toFuture
+      case None => NotPresent(reader.item).toFutureException
     }
     
   }
@@ -309,7 +358,9 @@ package object request extends LowPriorityImplicits {
    *
    * @param message the message
    */
-  class RequestReaderError(val message: String) extends Exception(message)
+  class RequestReaderError(val message: String, cause: Throwable) extends Exception(message, cause) {
+    def this(message: String) = this(message, null)
+  }
 
   /**
    * An exception that collects multiple request reader errors.
@@ -320,105 +371,33 @@ package object request extends LowPriorityImplicits {
     extends RequestReaderError("One or more errors reading request: " + errors.map(_.getMessage).mkString("\n  ","\n  ",""))
   
   /**
-   * An exception that indicates missed parameter in the request.
+   * An exception that indicates a required request item (header, param, cookie, body)
+   * was missing in the request.
    *
-   * @param param the missed parameter name
+   * @param item the missing request item
    */
-  case class ParamNotFound(param: String) extends RequestReaderError(s"Param '$param' not found in the request.")
+  case class NotPresent(item: RequestItem) extends RequestReaderError(s"Required ${item.description} not present in the request.")
 
   /**
-   * An exception that indicates a broken validation rule on the param.
+   * An exception that indicates a broken validation rule on the request item.
    *
-   * @param param the param name
+   * @param item the invalid request item
    * @param rule the rule description
    */
-  case class ValidationFailed(param: String, rule: String)
-    extends RequestReaderError(s"Request validation failed: param '$param' $rule.")
-
+  case class NotValid(item: RequestItem, rule: String)
+    extends RequestReaderError(s"Validation failed: ${item.description} $rule.")
+  
   /**
-   * An exception that indicates missed header in the request.
+   * An exception that indicates that a request item could be parsed.
    *
-   * @param header the missed header name
+   * @param item the invalid request item
+   * @param targetType the type the item should be converted into
+   * @param cause the cause of the parsing error
    */
-  case class HeaderNotFound(header: String) extends RequestReaderError(s"Header '$header' not found in the request.")
+  case class NotParsed(item: RequestItem, targetType: ClassTag[_], cause: Throwable)
+    extends RequestReaderError(s"${item.description} cannot be converted to ${targetType.runtimeClass.getSimpleName}: ${cause.getMessage}.")
 
-  /**
-   * An exception that indicates a missing cookie in the request.
-   *
-   * @param cookie the missing cookie's name
-   */
-  case class CookieNotFound(cookie: String) extends RequestReaderError(s"Cookie '$cookie' not found in the request.")
-
-  /**
-   * An exception that indicated a missing body in the request.
-   */
-  object BodyNotFound extends RequestReaderError("Body not found in the request.")
-
-  /**
-   * An exception that indicates an error in JSON format.
-   */
-  object BodyNotParsed extends RequestReaderError("A serialized object in a request body can not be parsed.")
-
-  /**
-   * An empty ''RequestReader''.
-   */
-  object EmptyReader extends RequestReader[Nothing] {
-    def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-      new NoSuchElementException("Empty reader.").toFutureException
-  }
-
-  /**
-   * A const param.
-   */
-  object ConstReader {
-
-    /**
-     * Creates a ''RequestReader'' that reads given ''const'' param from the request.
-     *
-     * @return a const param value
-     */
-    def apply[A](const: Future[A]) = new RequestReader[A] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = const
-    }
-  }
-
-  private[this] object StringToValueOrFail {
-    def apply[A](param: String, rule: String)(number: => A) = new RequestReader[A] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-        try number.toFuture
-        catch { case _: IllegalArgumentException => ValidationFailed(param, rule).toFutureException }
-
-      override def toString: String = s"param: $param"
-    }
-  }
-
-  private[this] object SomeStringToSomeValue {
-    def apply[A](fn: String => A)(o: Option[String]) = o.flatMap { s =>
-      try Some(fn(s))
-      catch { case _: IllegalArgumentException => None }
-    }
-  }
-
-  private[this] object StringsToValues {
-    def apply[A](fn: String => A)(l: Seq[String]) = l.flatMap { s =>
-      try List(fn(s))
-      catch { case _: IllegalArgumentException => Nil }
-    }
-  }
-
-  /**
-   * A helper function that encapsulates the logic necessary to turn the ''ChannelBuffer''
-   * of ''req'' into an ''Array[Byte]''
-   * @return The ''Array[Byte]'' representing the contents of the request body
-   */
-  private[this] object RequestBody {
-    def apply(req: HttpRequest): Array[Byte] = {
-      val buf = req.content
-      val out = Array.ofDim[Byte](buf.length)
-      buf.write(out, 0)
-      out
-    }
-  }
+  
 
   /**
    * A required string param.
@@ -433,116 +412,7 @@ package object request extends LowPriorityImplicits {
      *
      * @return a param value
      */
-    def apply(param: String) = new RequestReader[String] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[String] =
-        req.params.get(param) match {
-          case Some("") => ValidationFailed(param, "should not be empty").toFutureException
-          case Some(value) => value.toFuture
-          case None => ParamNotFound(param).toFutureException
-        }
-
-      override def toString: String = s"Required parameter '$param'"
-    }
-  }
-
-  /**
-   * A required integer param.
-   */
-  object RequiredIntParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required integer ''param''
-     * from the request or raises an exception when the param is missing or empty
-     * or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a param value
-     */
-    def apply(param: String): RequestReader[Int] = for {
-      s <- RequiredParam(param)
-      n <- StringToValueOrFail(param, "should be integer")(s.toInt)
-    } yield n
-  }
-
-  /**
-   * A required long param.
-   */
-  object RequiredLongParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required long ''param''
-     * from the request or raises an exception when the param is missing or empty
-     * or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a param value
-     */
-    def apply(param: String): RequestReader[Long] = for {
-      s <- RequiredParam(param)
-      n <- StringToValueOrFail(param, "should be long")(s.toLong)
-    } yield n
-  }
-
-  /**
-   * A required boolean param.
-   */
-  object RequiredBooleanParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required boolean ''param''
-     * from the request or raises an exception when the param is missing or empty
-     * or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a param value
-     */
-    def apply(param: String): RequestReader[Boolean] = for {
-      s <- RequiredParam(param)
-      n <- StringToValueOrFail(param, "should be boolean")(s.toBoolean)
-    } yield n
-  }
-
-  /**
-   * A required float param.
-   */
-  object RequiredFloatParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required float ''param''
-     * from the request or raises an exception when the param is missing or empty
-     * or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a param value
-     */
-    def apply(param: String): RequestReader[Float] = for {
-      s <- RequiredParam(param)
-      n <- StringToValueOrFail(param, "should be float")(s.toFloat)
-    } yield n
-  }
-
-  /**
-   * A required double param.
-   */
-  object RequiredDoubleParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required double ''param''
-     * from the request or raises an exception when the param is missing or empty
-     * or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a param value
-     */
-    def apply(param: String): RequestReader[Double] = for {
-      s <- RequiredParam(param)
-      n <- StringToValueOrFail(param, "should be double")(s.toDouble)
-    } yield n
+    def apply(param: String): RequestReader[String] = OptionalParam(param).failIfEmpty.shouldNot("be empty")(_.trim.isEmpty)
   }
 
   /**
@@ -559,110 +429,19 @@ package object request extends LowPriorityImplicits {
      * @return an option that contains a param value or ''None'' if the param
      *         is empty or it doesn't correspond to the expected type
      */
-    def apply(param: String): RequestReader[Option[String]] =
-      new RequestReader[Option[String]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-          req.params.get(param).toFuture
-
-        override def toString: String = s"Optional parameter '$param'"
-      }
+    def apply(param: String): RequestReader[Option[String]] = RequestReader(ParamItem(param))(_.params.get(param))
   }
 
   /**
-   * An optional int param.
+   * A helper function that encapsulates the logic necessary to read
+   * a multi-value parameter.
    */
-  object OptionalIntParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional integer ''param''
-     * from the request into an ''Option''.
-     *
-     * @param param the param to read
-     *
-     * @return an option that contains a param value or ''None'' if the param
-     *         is empty or it doesn't correspond to the expected type
-     */
-    def apply(param: String): RequestReader[Option[Int]] = for {
-      o <- OptionalParam(param)
-    } yield SomeStringToSomeValue(_.toInt)(o)
+  private[this] object RequestParams {
+    def apply(req: HttpRequest, param: String): Seq[String] = {
+      req.params.getAll(param).toList.flatMap(_.split(","))
+    }
   }
-
-  /**
-   * An optional long param.
-   */
-  object OptionalLongParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional long ''param''
-     * from the request into an ''Option''.
-     *
-     * @param param the param to read
-     *
-     * @return an option that contains a param value or ''None'' if the param
-     *         is empty or it doesn't correspond to the expected type
-     */
-    def apply(param: String): RequestReader[Option[Long]] = for {
-      o <- OptionalParam(param)
-    } yield SomeStringToSomeValue(_.toLong)(o)
-  }
-
-  /**
-   * An optional boolean param.
-   */
-  object OptionalBooleanParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional boolean ''param''
-     * from the request into an ''Option''.
-     *
-     * @param param the param to read
-     *
-     * @return an option that contains a param value or ''None'' if the param
-     *         is empty or it doesn't correspond to the expected type
-     */
-    def apply(param: String): RequestReader[Option[Boolean]] = for {
-      o <- OptionalParam(param)
-    } yield SomeStringToSomeValue(_.toBoolean)(o)
-  }
-
-  /**
-   * An optional float param.
-   */
-  object OptionalFloatParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional float ''param''
-     * from the request into an ''Option''.
-     *
-     * @param param the param to read
-     *
-     * @return an option that contains a param value or ''None'' if the param
-     *         is empty or it doesn't correspond to the expected type
-     */
-    def apply(param: String): RequestReader[Option[Float]] = for {
-      o <- OptionalParam(param)
-    } yield SomeStringToSomeValue(_.toFloat)(o)
-  }
-
-  /**
-   * An optional double param.
-   */
-  object OptionalDoubleParam {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional double ''param''
-     * from the request into an ''Option''.
-     *
-     * @param param the param to read
-     *
-     * @return an option that contains a param value or ''None'' if the param
-     *         is empty or it doesn't correspond to the expected type
-     */
-    def apply(param: String): RequestReader[Option[Double]] = for {
-      o <- OptionalParam(param)
-    } yield SomeStringToSomeValue(_.toDouble)(o)
-  }
-
+  
   /**
    * A required multi-value string param.
    */
@@ -677,119 +456,11 @@ package object request extends LowPriorityImplicits {
      *
      * @return a ''List'' that contains all the values of multi-value param
      */
-    def apply(param: String): RequestReader[Seq[String]] =
-      new RequestReader[Seq[String]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-          req.params.getAll(param).toList.flatMap(_.split(",")) match {
-            case Nil => ParamNotFound(param).toFutureException
-            case unfiltered => unfiltered.filter(_ != "") match {
-              case Nil => ValidationFailed(param, "should not be empty").toFutureException
-              case filtered => filtered.toFuture
-            }
-          }
-
-        override def toString: String = s"Required parameters '$param'"
-      }
-  }
-
-  /**
-   * A required multi-value integer param.
-   */
-  object RequiredIntParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required multi-value integer
-     * ''param'' from the request into an ''List'' or raises an exception when the
-     * param is missing or empty or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param
-     */
-    def apply(param: String): RequestReader[Seq[Int]] = for {
-      ss <- RequiredParams(param)
-      ns <- StringToValueOrFail(param, "should be integer")(ss.map { _.toInt })
-    } yield ns
-  }
-
-  /**
-   * A required multi-value long param.
-   */
-  object RequiredLongParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required multi-value long
-     * ''param'' from the request into an ''List'' or raises an exception when the
-     * param is missing or empty or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param
-     */
-    def apply(param: String): RequestReader[Seq[Long]] = for {
-      ss <- RequiredParams(param)
-      ns <- StringToValueOrFail(param, "should be long")(ss.map { _.toLong })
-    } yield ns
-  }
-
-  /**
-   * A required multi-value boolean param.
-   */
-  object RequiredBooleanParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required multi-value boolean
-     * ''param'' from the request into an ''List'' or raises an exception when the
-     * param is missing or empty or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param
-     */
-    def apply(param: String): RequestReader[Seq[Boolean]] = for {
-      ss <- RequiredParams(param)
-      ns <- StringToValueOrFail(param, "should be boolean")(ss.map { _.toBoolean })
-    } yield ns
-  }
-
-  /**
-   * A required multi-value float param.
-   */
-  object RequiredFloatParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required multi-value float
-     * ''param'' from the request into an ''List'' or raises an exception when the
-     * param is missing or empty or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param
-     */
-    def apply(param: String): RequestReader[Seq[Float]] = for {
-      ss <- RequiredParams(param)
-      ns <- StringToValueOrFail(param, "should be float")(ss.map { _.toFloat })
-    } yield ns
-  }
-
-  /**
-   * A required multi-value double param.
-   */
-  object RequiredDoubleParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads a required multi-value double
-     * ''param'' from the request into an ''List'' or raises an exception when the
-     * param is missing or empty or doesn't correspond to an expected type.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param
-     */
-    def apply(param: String): RequestReader[Seq[Double]] = for {
-      ss <- RequiredParams(param)
-      ns <- StringToValueOrFail(param, "should be double")(ss.map { _.toDouble })
-    } yield ns
+    def apply(param: String): RequestReader[Seq[String]] = 
+      (RequestReader(ParamItem(param))(RequestParams(_, param)) embedFlatMap {
+        case Nil => NotPresent(ParamItem(param)).toFutureException
+        case unfiltered => unfiltered.filter(_ != "").toFuture 
+      }).shouldNot("be empty")(_.isEmpty)
   }
 
   /**
@@ -806,113 +477,8 @@ package object request extends LowPriorityImplicits {
      * @return a ''List'' that contains all the values of multi-value param or
      *         en empty list ''Nil'' if the param is missing or empty.
      */
-    def apply(param: String): RequestReader[Seq[String]] =
-      new RequestReader[Seq[String]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-          req.params.getAll(param).toList.flatMap(_.split(",")).filter(_ != "").toFuture
-
-        override def toString: String = s"Optional parameters '$param'"
-      }
-  }
-
-  /**
-   * An optional multi-value integer param.
-   */
-  object OptionalIntParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional multi-value
-     * integer ''param'' from the request into an ''List''.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param or
-     *         en empty list ''Nil'' if the param is missing or empty or doesn't
-     *         correspond to a requested type.
-     */
-    def apply(param: String): RequestReader[Seq[Int]] = for {
-      l <- OptionalParams(param)
-    } yield StringsToValues(_.toInt)(l)
-  }
-
-  /**
-   * An optional multi-value long param.
-   */
-  object OptionalLongParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional multi-value
-     * integer ''param'' from the request into an ''List''.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param or
-     *         en empty list ''Nil'' if the param is missing or empty or doesn't
-     *         correspond to a requested type.
-     */
-    def apply(param: String): RequestReader[Seq[Long]] = for {
-      l <- OptionalParams(param)
-    } yield StringsToValues(_.toLong)(l)
-  }
-
-  /**
-   * An optional multi-value boolean param.
-   */
-  object OptionalBooleanParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional multi-value
-     * boolean ''param'' from the request into an ''List''.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param or
-     *         en empty list ''Nil'' if the param is missing or empty or doesn't
-     *         correspond to a requested type.
-     */
-    def apply(param: String): RequestReader[Seq[Boolean]] = for {
-      l <- OptionalParams(param)
-    } yield StringsToValues(_.toBoolean)(l)
-  }
-
-  /**
-   * An optional multi-value float param.
-   */
-  object OptionalFloatParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional multi-value
-     * float ''param'' from the request into an ''List''.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param or
-     *         en empty list ''Nil'' if the param is missing or empty or doesn't
-     *         correspond to a requested type.
-     */
-    def apply(param: String): RequestReader[Seq[Float]] = for {
-      l <- OptionalParams(param)
-    } yield StringsToValues(_.toFloat)(l)
-  }
-
-  /**
-   * An optional multi-value double param.
-   */
-  object OptionalDoubleParams {
-
-    /**
-     * Creates a ''RequestReader'' that reads an optional multi-value
-     * double ''param'' from the request into an ''List''.
-     *
-     * @param param the param to read
-     *
-     * @return a ''List'' that contains all the values of multi-value param or
-     *         en empty list ''Nil'' if the param is missing or empty or doesn't
-     *         correspond to a requested type.
-     */
-    def apply(param: String): RequestReader[Seq[Double]] = for {
-      l <- OptionalParams(param)
-    } yield StringsToValues(_.toDouble)(l)
+    def apply(param: String): RequestReader[Seq[String]] = 
+      RequestReader(ParamItem(param))(RequestParams(_, param).filter(_ != ""))
   }
 
   /**
@@ -922,21 +488,13 @@ package object request extends LowPriorityImplicits {
 
     /**
      * Creates a ''RequestReader'' that reads a required string ''header''
-     * from the request or raises an exception when the param is missing or empty.
+     * from the request or raises an exception when the header is missing.
      *
      * @param header the header to read
      *
      * @return a header
      */
-    def apply(header: String): RequestReader[String] = new RequestReader[String] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-        req.headerMap.get(header) match {
-          case Some(value) => value.toFuture
-          case None => HeaderNotFound(header).toFutureException
-        }
-
-      override def toString: String = s"Required header '$header'"
-    }
+    def apply(header: String): RequestReader[String] = OptionalHeader(header).failIfEmpty
   }
 
   /**
@@ -953,51 +511,52 @@ package object request extends LowPriorityImplicits {
      * @return an option that contains a header value or ''None'' if the header
      *         is not exist in the request
      */
-    def apply(header: String): RequestReader[Option[String]] =
-      new RequestReader[Option[String]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
-          req.headerMap.get(header).toFuture
-
-        override def toString: String = s"Optional header '$header'"
-      }
+    def apply(header: String): RequestReader[Option[String]] = RequestReader(HeaderItem(header))(_.headerMap.get(header))
   }
 
   /**
+   * A helper function that encapsulates the logic necessary to turn the ''ChannelBuffer''
+   * of ''req'' into an ''Array[Byte]''
+   * @return The ''Array[Byte]'' representing the contents of the request body
+   */
+  private[this] object RequestBody {
+    def apply(req: HttpRequest): Array[Byte] = {
+      val buf = req.content
+      val out = Array.ofDim[Byte](buf.length)
+      buf.write(out, 0)
+      out
+    }
+  }
+  
+  /**
    * A ''RequestReader'' that reads the request body, interpreted as a ''Array[Byte]'',
-   * or throws a ''BodyNotFound'' exception.
+   * or throws a ''NotPresent'' exception.
    */
   object RequiredArrayBody extends RequestReader[Array[Byte]] {
-    def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Array[Byte]] =
-      OptionalArrayBody(req).flatMap {
-        case Some(body) => body.toFuture
-        case None => BodyNotFound.toFutureException
-      }
-
-    override def toString: String = "Required body"
+    val item = BodyItem
+    def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Array[Byte]] = OptionalArrayBody.failIfEmpty(req)
   }
 
   /**
    * A ''RequestReader'' that reads the request body, interpreted as a ''Array[Byte]'',
    * into an ''Option''.
    */
-  object OptionalArrayBody extends RequestReader[Option[Array[Byte]]]{
+  object OptionalArrayBody extends RequestReader[Option[Array[Byte]]] {
+    val item = BodyItem
     def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Option[Array[Byte]]] =
       req.contentLength match {
         case Some(length) if length > 0 => Some(RequestBody(req)).toFuture
         case _ => Future.None
       }
-
-    override def toString: String = "Optional body"
   }
 
   /**
    * A ''RequestReader'' that reads the request body, interpreted as a ''String'',
-   * or throws a ''BodyNotFound'' exception.
+   * or throws a ''NotPresent'' exception.
    */
   object RequiredStringBody extends RequestReader[String] {
-    def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[String] = for {
-      b <- RequiredArrayBody(req)
-    } yield new String(b, "UTF-8")
+    val item = BodyItem
+    def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[String] = OptionalStringBody.failIfEmpty(req)
   }
 
   /**
@@ -1005,46 +564,10 @@ package object request extends LowPriorityImplicits {
    * into an ''Option''.
    */
   object OptionalStringBody extends RequestReader[Option[String]] {
+    val item = BodyItem
     def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Option[String]] = for {
       b <- OptionalArrayBody(req)
-    } yield b match {
-      case Some(body) => Some(new String(body, "UTF-8"))
-      case None => None
-    }
-  }
-
-  /**
-   * A ''RequestReader'' that reads an optional encoded object serialized in request body
-   * and decodes it, according to an implicit decoder, into an ''Option''.
-   */
-  object OptionalBody {
-    def apply[A](implicit m: DecodeMagnet[A]): RequestReader[Option[A]] = OptionalStringBody.flatMap {
-      case Some(body) => new RequestReader[Option[A]] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = Future.const(m()(body) map (Some(_)))
-        override def toString: String = "Optional body"
-      }
-      case None => ConstReader(Future.None)
-    }
-
-    // TODO: Make it accept `Req` instead
-    def apply[A](req: HttpRequest)(implicit m: DecodeMagnet[A]): Future[Option[A]] =
-      OptionalBody[A](m)(req)
-  }
-
-  /**
-   * A ''RequestReader'' that reads an encoded object serialized in request body
-   * and decodes it according to an implicit decoder.
-   */
-  object RequiredBody {
-    def apply[A](implicit m: DecodeMagnet[A]): RequestReader[A] = OptionalBody[A].flatMap {
-      case Some(body) => new RequestReader[A] {
-        def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = body.toFuture
-        override def toString: String = "Required body"
-      }
-      case None => ConstReader(BodyNotFound.toFutureException)
-    }
-    // TODO: Make it accept `Req` instead
-    def apply[A](req: HttpRequest)(implicit m: DecodeMagnet[A]): Future[A] = RequiredBody[A](m)(req)
+    } yield b map (new String(_, "UTF-8"))
   }
 
   /**
@@ -1058,12 +581,7 @@ package object request extends LowPriorityImplicits {
      *
      * @return An option that contains a cookie or None if the cookie does not exist on the request.
      */
-    def apply(cookieName: String) = new RequestReader[Option[Cookie]] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Option[Cookie]] =
-        req.cookies.get(cookieName).toFuture
-
-      override def toString: String = s"Optional cookie '$cookieName'"
-    }
+    def apply(cookie: String): RequestReader[Option[Cookie]] = RequestReader(CookieItem(cookie))(_.cookies.get(cookie))
   }
 
   /**
@@ -1078,15 +596,7 @@ package object request extends LowPriorityImplicits {
      *
      * @return the cookie
      */
-    def apply(cookieName: String): RequestReader[Cookie] = new RequestReader[Cookie] {
-      def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Cookie] =
-        OptionalCookie(cookieName)(req) flatMap {
-          case None => CookieNotFound(cookieName).toFutureException
-          case Some(cookie: Cookie) => cookie.toFuture
-        }
-
-      override def toString: String = s"Required cookie '$cookieName'"
-    }
+    def apply(cookieName: String): RequestReader[Cookie] = OptionalCookie(cookieName).failIfEmpty
   }
 
   /**
@@ -1094,6 +604,15 @@ package object request extends LowPriorityImplicits {
    */
   trait DecodeRequest[+A] {
     def apply(req: String): Try[A]
+  }
+  
+  /**
+   * Convenience method for creating new DecodeRequest instances.
+   */
+  object DecodeRequest {
+    def apply[A](f: String => Try[A]): DecodeRequest[A] = new DecodeRequest[A] {
+      def apply(value: String): Try[A] = f(value)
+    }
   }
 
   /**

--- a/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
@@ -25,7 +25,8 @@ package io.finch.request
 import org.scalatest.{FlatSpec,Matchers}
 
 import com.twitter.finagle.httpx.Request
-import com.twitter.util.{Await,Throw}
+import com.twitter.util.{Await,Throw,Try,Return}
+import items._
 
 class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
 
@@ -36,35 +37,45 @@ class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
        case a ~ b ~ c => (a, b, c)
      }
   
+  def extractNotParsedTargets (result: Try[(Int, Double, Int)]): AnyRef = {
+    (result handle {
+      case RequestReaderErrors(errors) => errors map {
+        case NotParsed(item, _, _) => item
+      }
+      case NotParsed(item, _, _) => Seq(item)
+      case _ => Seq()
+    }).get
+  }
+  
 
   "The applicative reader" should "produce three errors if all three numbers cannot be parsed" in {
     val request = Request.apply("a"->"foo", "b"->"foo", "c"->"foo")
-    Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
-      ValidationFailed("a", "should be integer"),
-      ValidationFailed("b", "should be double"),
-      ValidationFailed("c", "should be integer")
-    ))))
+    extractNotParsedTargets(Await.result(reader(request).liftToTry)) should be (Seq(
+      ParamItem("a"),
+      ParamItem("b"),
+      ParamItem("c")
+    ))
   }
   
   it should "produce two validation errors if two numbers cannot be parsed" in {
     val request = Request.apply("a"->"foo", "b"->"7.7", "c"->"foo")
-    Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
-      ValidationFailed("a", "should be integer"),
-      ValidationFailed("c", "should be integer")
-    ))))
+    extractNotParsedTargets(Await.result(reader(request).liftToTry)) should be (Seq(
+      ParamItem("a"),
+      ParamItem("c")
+    ))
   }
   
   it should "produce two ParamNotFound errors if two parameters are missing" in {
     val request = Request.apply("b"->"7.7")
     Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
-      ParamNotFound("a"),
-      ParamNotFound("c")
+      NotPresent(ParamItem("a")),
+      NotPresent(ParamItem("c"))
     ))))
   }
   
   it should "produce one error if the last parameter cannot be parsed to an integer" in {
     val request = Request.apply("a"->"9", "b"->"7.7", "c"->"foo")
-    Await.result(reader(request).liftToTry) should be (Throw(ValidationFailed("c","should be integer")))
+    extractNotParsedTargets(Await.result(reader(request).liftToTry)) should be (Seq(ParamItem("c")))
   }
   
   it should "parse all integers and doubles" in {

--- a/core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/core/src/test/scala/io/finch/request/BodySpec.scala
@@ -29,6 +29,7 @@ import com.twitter.util.{Await, Future, Try}
 import io.finch.HttpRequest
 import org.jboss.netty.handler.codec.http.HttpHeaders
 import org.scalatest.{FlatSpec, Matchers}
+import items._
 
 class BodySpec extends FlatSpec with Matchers {
   val foo = "foo"
@@ -43,11 +44,11 @@ class BodySpec extends FlatSpec with Matchers {
   it should "produce an error if the body is empty" in {
     val request: HttpRequest = requestWithBody(Array[Byte]())
     val futureResult: Future[Array[Byte]] = RequiredArrayBody(request)
-    a [BodyNotFound.type] should be thrownBy Await.result(futureResult)
+    a [NotPresent] should be thrownBy Await.result(futureResult)
   }
 
-  it should "have a toString that produces a string representation of itself" in {
-    RequiredArrayBody.toString should equal(s"Required body")
+  it should "have a corresponding RequestItem" in {
+    RequiredArrayBody.item should equal(BodyItem)
   }
 
   "An OptionalArrayBody" should "be properly read if it exists" in {
@@ -62,8 +63,8 @@ class BodySpec extends FlatSpec with Matchers {
     Await.result(futureResult) should equal(None)
   }
 
-  it should "have a toString that produces a string representation of itself" in {
-    OptionalArrayBody.toString should equal(s"Optional body")
+  it should "have a corresponding RequestItem" in {
+    OptionalArrayBody.item should equal(BodyItem)
   }
 
   "A RequiredStringBody" should "be properly read if it exists" in {
@@ -75,7 +76,7 @@ class BodySpec extends FlatSpec with Matchers {
   it should "produce an error if the body is empty" in {
     val request: HttpRequest = requestWithBody("")
     val futureResult: Future[String] = RequiredStringBody(request)
-    a [BodyNotFound.type] should be thrownBy Await.result(futureResult)
+    a [NotPresent] should be thrownBy Await.result(futureResult)
   }
 
   "An OptionalStringBody" should "be properly read if it exists" in {
@@ -144,10 +145,10 @@ class BodySpec extends FlatSpec with Matchers {
     val oi: RequestReader[Option[Int]] = OptionalBody[Int]
     val o: Future[Option[Int]] = OptionalBody[Int](req)
 
-    a [NumberFormatException] should be thrownBy Await.result(ri(req))
-    a [NumberFormatException] should be thrownBy Await.result(i)
-    a [NumberFormatException] should be thrownBy Await.result(oi(req))
-    a [NumberFormatException] should be thrownBy Await.result(o)
+    a [NotParsed] should be thrownBy Await.result(ri(req))
+    a [NotParsed] should be thrownBy Await.result(i)
+    a [NotParsed] should be thrownBy Await.result(oi(req))
+    a [NotParsed] should be thrownBy Await.result(o)
   }
 
   private[this] def requestWithBody(body: String): HttpRequest = {

--- a/core/src/test/scala/io/finch/request/CookieSpec.scala
+++ b/core/src/test/scala/io/finch/request/CookieSpec.scala
@@ -46,7 +46,7 @@ class CookieSpec extends FlatSpec with Matchers {
     request.addCookie(cookie)
     val futureResult: Future[Cookie] = RequiredCookie("another-cookie")(request)
 
-    a [CookieNotFound] should be thrownBy Await.result(futureResult)
+    a [NotPresent] should be thrownBy Await.result(futureResult)
   }
 
   it should "read an optional cookie if it exists" in {
@@ -64,8 +64,8 @@ class CookieSpec extends FlatSpec with Matchers {
     Await.result(futureResult) should equal(None)
   }
 
-  it should "have a toString that produces a string representation of itself" in {
-    RequiredCookie(cookieName).toString should equal(s"Required cookie '$cookieName'")
-    OptionalCookie(cookieName).toString should equal(s"Optional cookie '$cookieName'")
+  it should "have a matching RequestItem" in {
+    RequiredCookie(cookieName).item should equal(items.CookieItem(cookieName))
+    OptionalCookie(cookieName).item should equal(items.CookieItem(cookieName))
   }
 }

--- a/core/src/test/scala/io/finch/request/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/request/DecodeSpec.scala
@@ -34,9 +34,7 @@ class DecodeSpec extends FlatSpec with Matchers {
 
   private def decode[A](json: String)(implicit d: DecodeRequest[A]): Try[A] = d(json)
   
-  implicit val decodeInt = new DecodeRequest[Int] {
-     def apply(req: String): Try[Int] = Try(req.toInt)
-  }
+  implicit val decodeInt = DecodeRequest { s => Try(s.toInt) }
   
   "A DecodeJson" should "be accepted as implicit instance of superclass" in {
     implicit object BigDecimalJson extends DecodeRequest[BigDecimal] {

--- a/core/src/test/scala/io/finch/request/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/HeaderSpec.scala
@@ -39,7 +39,7 @@ class HeaderSpec extends FlatSpec with Matchers {
   it should "error if it does not exist" in {
     val request = Request()
     val futureResult = RequiredHeader("Location")(request)
-    a [HeaderNotFound] should be thrownBy Await.result(futureResult)
+    a [NotPresent] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -56,9 +56,9 @@ class HeaderSpec extends FlatSpec with Matchers {
     Await.result(futureResult) should be (None)
   }
 
-  "A Header Reader" should "have a toString that produces a string representation of itself" in {
+  "A Header Reader" should "have a matching RequestItem" in {
     val header = "Location"
-    RequiredHeader(header).toString should equal(s"Required header '$header'")
-    OptionalHeader(header).toString should equal(s"Optional header '$header'")
+    RequiredHeader(header).item should equal(items.HeaderItem(header))
+    OptionalHeader(header).item should equal(items.HeaderItem(header))
   }
 }

--- a/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
@@ -42,9 +42,9 @@ class OptionalParamSpec extends FlatSpec with Matchers {
     Await.result(futureResult) should equal(None)
   }
 
-  it should "have a toString that produces a string representation of itself" in {
+  it should "have a matching RequestItem" in {
     val param = "foo"
-    OptionalParam(param).toString should equal(s"Optional parameter '$param'")
+    OptionalParam(param).item should equal(items.ParamItem(param))
   }
 
 
@@ -57,7 +57,7 @@ class OptionalParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a number" in {
     val request: HttpRequest = Request.apply(("foo", "non-boolean"))
     val futureResult: Future[Option[Boolean]] = OptionalBooleanParam("foo")(request)
-    Await.result(futureResult) should equal(None)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -70,7 +70,7 @@ class OptionalParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a number" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Option[Int]] = OptionalIntParam("foo")(request)
-    Await.result(futureResult) should equal(None)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -83,7 +83,7 @@ class OptionalParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a number" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Option[Long]] = OptionalLongParam("foo")(request)
-    Await.result(futureResult) should equal(None)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
   "An OptionalFloatParam" should "be parsed as a double" in {
@@ -95,7 +95,7 @@ class OptionalParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a number" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Option[Float]] = OptionalFloatParam("foo")(request)
-    Await.result(futureResult) should equal(None)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -108,6 +108,6 @@ class OptionalParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a number" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Option[Double]] = OptionalDoubleParam("foo")(request)
-    Await.result(futureResult) should equal(None)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 }

--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -58,9 +58,9 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     Await.result(futureResult) should be (Nil)
   }
 
-  it should "have a toString that produces a string representation of itself" in {
+  it should "have a matching RequestItem" in {
     val param = "foo"
-    OptionalParams(param).toString should equal(s"Optional parameters '$param'")
+    OptionalParams(param).item should equal(items.ParamItem(param))
   }
 
 
@@ -73,12 +73,10 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     result should contain(false)
   }
 
-  it should "only include valid booleans" in {
+  it should "produce an error if one of the params is not a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "5"))
     val futureResult: Future[Seq[Boolean]] = OptionalBooleanParams("foo")(request)
-    val result: Seq[Boolean] = Await.result(futureResult)
-    result should have length 1
-    result should contain(true)
+    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -91,12 +89,10 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     result should contain(255)
   }
 
-  it should "only include valid integers" in {
+  it should "produce an error if one of the params is not an integer" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = OptionalIntParams("foo")(request)
-    val result: Seq[Int] = Await.result(futureResult)
-    result should have length 1
-    result should contain(255)
+    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -109,12 +105,10 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     result should contain(7500000000000000L)
   }
 
-  it should "only include valid longs" in {
+  it should "produce an error if one of the params is not a long" in {
     val request: HttpRequest = Request.apply(("foo", "false"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = OptionalLongParams("foo")(request)
-    val result: Seq[Long] = Await.result(futureResult)
-    result should have length 1
-    result should contain(7500000000000000L)
+    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
   }
 
   "A OptionalFloatParams" should "be parsed as a list of floats" in {
@@ -126,12 +120,10 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     result should contain(536.22345f)
   }
 
-  it should "only include valid floats" in {
+  it should "produce an error if one of the params is not a float" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "true"), ("foo", "5.123"))
     val futureResult: Future[Seq[Float]] = OptionalFloatParams("foo")(request)
-    val result: Seq[Float] = Await.result(futureResult)
-    result should have length 1
-    result should contain(5.123f)
+    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -144,11 +136,9 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
     result should contain(66566.45243)
   }
 
-  it should "only include valid doubles" in {
+  it should "produce an error if one of the params is not a double" in {
     val request: HttpRequest = Request.apply(("foo", "45543245.435"), ("foo", "non-number"))
     val futureResult: Future[Seq[Double]] = OptionalDoubleParams("foo")(request)
-    val result: Seq[Double] = Await.result(futureResult)
-    result should have length 1
-    result should contain(45543245.435)
+    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
   }
 }

--- a/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
@@ -38,18 +38,18 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is empty" in {
     val request: HttpRequest = Request.apply(("foo", ""))
     val futureResult: Future[String] = RequiredParam("foo")(request)
-    a [ValidationFailed] should be thrownBy Await.result(futureResult)
+    a [NotValid] should be thrownBy Await.result(futureResult)
   }
 
   it should "produce an error if the param does not exist" in {
     val request: HttpRequest = Request.apply(("bar", "foo"))
     val futureResult: Future[String] = RequiredParam("foo")(request)
-    a [ParamNotFound] should be thrownBy Await.result(futureResult)
+    a [NotPresent] should be thrownBy Await.result(futureResult)
   }
 
-  it should "have a toString that produces a string representation of itself" in {
+  it should "have a matching RequestItem" in {
     val param = "foo"
-    RequiredParam(param).toString should equal(s"Required parameter '$param'")
+    RequiredParam(param).item should equal(items.ParamItem(param))
   }
 
   "A RequiredBooleanParam" should "be parsed as a boolean" in {
@@ -61,7 +61,7 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "5"))
     val futureResult: Future[Boolean] = RequiredBooleanParam("foo")(request)
-    a [ValidationFailed] should be thrownBy Await.result(futureResult)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -74,7 +74,7 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not an integer" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Int] = RequiredIntParam("foo")(request)
-    a [ValidationFailed] should be thrownBy Await.result(futureResult)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -87,7 +87,7 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a long" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Long] = RequiredLongParam("foo")(request)
-    a [ValidationFailed] should be thrownBy Await.result(futureResult)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
   "A RequiredFloatParam" should "be parsed as a float" in {
@@ -99,7 +99,7 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a float" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Float] = RequiredFloatParam("foo")(request)
-    a [ValidationFailed] should be thrownBy Await.result(futureResult)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -112,6 +112,6 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   it should "produce an error if the param is not a double" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"))
     val futureResult: Future[Double] = RequiredDoubleParam("foo")(request)
-    a [ValidationFailed] should be thrownBy Await.result(futureResult)
+    a [NotParsed] should be thrownBy Await.result(futureResult)
   }
 }

--- a/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -50,7 +50,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "throw a ParamNotFound Exception if the parameter does not exist at all" in {
     val request: HttpRequest = Request.apply(("foo", "5"), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = RequiredParams("baz")(request)
-    intercept[ParamNotFound] {
+    intercept[NotPresent] {
       Await.result(futureResult)
     }
   }
@@ -58,14 +58,14 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "throw a Validation Exception if all of the parameter values are empty" in {
     val request: HttpRequest = Request.apply(("foo", ""), ("bar", "6"), ("foo", ""))
     val futureResult: Future[Seq[String]] = RequiredParams("foo")(request)
-    intercept[ValidationFailed] {
+    intercept[NotValid] {
       Await.result(futureResult)
     }
   }
 
-  it should "have a toString that produces a string representation of itself" in {
+  it should "have a matching RequestItem" in {
     val param = "foo"
-    RequiredParams(param).toString should equal(s"Required parameters '$param'")
+    RequiredParams(param).item should equal(items.ParamItem(param))
   }
 
 
@@ -81,7 +81,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "5"))
     val futureResult: Future[Seq[Boolean]] = RequiredBooleanParams("foo")(request)
-    intercept[ValidationFailed] {
+    intercept[RequestReaderErrors] {
       Await.result(futureResult)
     }
   }
@@ -98,8 +98,8 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
   it should "produce an error if one of the params is not an integer" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "255"))
-    val futureResult: Future[Int] = RequiredIntParam("foo")(request)
-    intercept[ValidationFailed] {
+    val futureResult: Future[Seq[Int]] = RequiredIntParams("foo")(request)
+    intercept[RequestReaderErrors] {
       Await.result(futureResult)
     }
   }
@@ -117,7 +117,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a long" in {
     val request: HttpRequest = Request.apply(("foo", "false"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = RequiredLongParams("foo")(request)
-    intercept[ValidationFailed] {
+    intercept[RequestReaderErrors] {
       Await.result(futureResult)
     }
   }
@@ -135,7 +135,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a float" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "true"))
     val futureResult: Future[Seq[Float]] = RequiredFloatParams("foo")(request)
-    intercept[ValidationFailed] {
+    intercept[RequestReaderErrors] {
       Await.result(futureResult)
     }
   }
@@ -153,7 +153,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a double" in {
     val request: HttpRequest = Request.apply(("foo", "45543245.435"), ("foo", "non-number"))
     val futureResult: Future[Seq[Double]] = RequiredDoubleParams("foo")(request)
-    intercept[ValidationFailed] {
+    intercept[RequestReaderErrors] {
       Await.result(futureResult)
     }
   }

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -191,10 +191,9 @@ object HandleExceptions extends SimpleFilter[HttpRequest, HttpResponse] {
   def apply(req: HttpRequest, service: Service[HttpRequest, HttpResponse]) =
     service(req) handle {
       case UserNotFound(id) => BadRequest(Json.obj("error" -> "user_not_found", "id" -> id))
-      case ParamNotFound(param) => BadRequest(Json.obj("error" -> "param_not_found", "param" -> param))
-      case ValidationFailed(param, rule) => BadRequest(Json.obj("error" -> "bad_param", "param" -> param, "rule" -> rule))
-      case BodyNotFound => BadRequest(Json.obj("error" -> "body_not_found"))
-      case BodyNotParsed => BadRequest(Json.obj("error" -> "body_not_parsed"))
+      case NotPresent(item) => BadRequest(Json.obj("error" -> "item_not_found", "item" -> item))
+      case np: NotParsed => BadRequest(Json.obj("error" -> "item_not_parsed", "item" -> np.item, "message" -> np.getMessage))
+      case NotValid(item, rule) => BadRequest(Json.obj("error" -> "item_not_valid", "rule" -> rule))
       case _ => InternalServerError()
     }
 }

--- a/docs.md
+++ b/docs.md
@@ -251,12 +251,24 @@ val child: RequestReader[User] =
 The exceptions from a request-reader might be handled just like other future exceptions in Finagle:
 ```scala
 val user: Future[Json] = service(...) handle {
-  case ParamNotFound(param) => Json.obj("error" -> "param_not_found", "param" -> param)
-  case ValidationFailed(param, rule) => Json.obj("error" -> "validation_failed", "param" -> param, "rule" -> rule)
+  case NotFound(ParamItem(param)) => Json.obj("error" -> "param_not_found", "param" -> param)
+  case NotValid(ParamItem(param), rule) => Json.obj("error" -> "validation_failed", "param" -> param, "rule" -> rule)
 }
 ```
 
-Note, that all the exception throw by `RequestReader` are case classes. So, the pattern matching may be used to handle them.
+All the exceptions throw by `RequestReader` are case classes. Therefore pattern matching may be used to handle them.
+
+These are all error types produced by Finch (which all extend `RequestReaderError`):
+
+```scala
+case class RequestReaderErrors(errors: Seq[Throwable]) // when multiple request item were invalid or missing
+
+case class NotFound(item: RequestItem) // when a required request item (header, param, cookie, body) was missing
+
+case class NotParsed(item: RequestItem, targetType: ClassTag[_], cause: Throwable) // when type conversion failed
+
+case class NotValid(item: RequestItem, rule: String) // when a validation rule did not pass for a request item
+```
 
 
 ### Multiple-Value Params

--- a/json/src/main/scala/io/finch/json/package.scala
+++ b/json/src/main/scala/io/finch/json/package.scala
@@ -26,7 +26,6 @@ package io.finch
 import io.finch.request.DecodeRequest
 import io.finch.response.EncodeResponse
 import com.twitter.util.{Try, Throw, Return}
-import io.finch.request.BodyNotParsed
 
 package object json {
   implicit val encodeFinchJson = new EncodeResponse[Json] {
@@ -37,6 +36,6 @@ package object json {
 
   implicit val decodeFinchJson = new DecodeRequest[Json] {
     def apply(json: String): Try[Json] = Json.decode(json)
-      .fold[Try[Json]](Throw(BodyNotParsed))(Return(_)) // TODO - error detail is swallowed
+      .fold[Try[Json]](Throw(new IllegalArgumentException("unknown error parsing JSON")))(Return(_)) // TODO - error detail is swallowed
   }
 }


### PR DESCRIPTION
This is the 4th of 5 PRs extracted from #162.

It is exactly as reviewed in the discussion PR except for:

* Changed the name of the `mapFuture` method to `embedFlatMap` as discussed in the other PR
* Adjusted syntax of new test methods to be aligned with the new contribution guide
* Added more detail for the description for 2) below to make the motivation for this big refactoring clearer
* Added back `extends AnyVal` in two of the three implicit classes for `as[A]` as the simplification of the implementation did no longer trigger the compiler bug there

## PR 4: Unify error handling and simplify the implementation of the `request` package

This is really two PRs in one, but since both require a bigger refactoring it would have been too cumbersome to split this work

#### 1) Unify Error Handling

The error handling has already been discussed here: https://github.com/finagle/finch/issues/26#issuecomment-72385723

It unifies all error types of Finch to just these 4:

```scala
case class RequestReaderErrors(errors: Seq[Throwable]) // when multiple request item were invalid or missing

case class NotFound(item: RequestItem) // when a required request item (header, param, cookie, body) was missing

case class NotParsed(item: RequestItem, targetType: ClassTag[_], cause: Throwable) // when type conversion failed

case class NotValid(item: RequestItem, rule: String) // when a validation rule did not pass for a request item
```

where RequestItem is this ADT:

```scala
sealed abstract class RequestItem(val kind: String, val nameOption:Option[String] = None) {
  val description = kind + nameOption.fold("")(" '"+_+"'")
}
case class ParamItem(name: String) extends RequestItem("param", Some(name))
case class HeaderItem(name: String) extends RequestItem("header", Some(name))
case class CookieItem(name: String) extends RequestItem("cookie", Some(name))
case object BodyItem extends RequestItem("body")
case object MultipleItems extends RequestItem("request")
```

This makes the life for both Finch users and Finch maintainers easier, as it is very consistent and intuitive.

#### 2) Simplify the Implementation of the `request` Package

Apart from the change in error types, this refactoring does not change any public APIs, but it greatly simplifies the implementation of the request package, which should become immediately obvious when skimming over the diff. The simplification was made possible through:

* Introducing a `RequestReader` companion object with a convenient factory method to create new readers with less plumbing
* Introducing an `embedFlatMap` in `RequestReader` which made internal use of `flatMap` obsolete, which usually led to a much more verbose implementation and would not allow us to keep track of the `RequestItem`
* Introducing an implicit `failIfEmpty` on any `RequestReader[Option[A]]` that allows for easy reuse of the same base reader for the required and optional variants
* Using the `should` and `shouldNot` method for internal validation, too

Some of the existing reader implementations have been moved to a new `optional.scala` file as they are candidates for deprecation, but this will be discussed in PR 5.

Breaking API changes: Everything around `Exception` types