### PR TITLE
Deprecate APIs which are now supported in a more generic way or have been renamed

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/package.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/package.scala
@@ -26,7 +26,7 @@ package io.finch
 
 import _root_.argonaut.{EncodeJson, Json, Parse, DecodeJson}
 import io.finch.request.DecodeRequest
-import io.finch.request.RequestReaderError
+import io.finch.request.RequestError
 import io.finch.response.EncodeResponse
 import com.twitter.util.{Try, Throw, Return}
 
@@ -39,7 +39,7 @@ package object argonaut {
    */
   implicit def toArgonautDecode[A](implicit decode: DecodeJson[A]): DecodeRequest[A] = new DecodeRequest[A] {
     override def apply(json: String): Try[A] = Parse.decodeEither(json).fold(
-      error => Throw(new RequestReaderError(error)),
+      error => Throw(new RequestError(error)),
       Return(_)
     )
   }

--- a/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
@@ -53,7 +53,7 @@ class ArgonautSpec extends FlatSpec with Matchers {
     req.setContentTypeJson()
     req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, str.length.toString)
 
-    val user: TestUser = Await.result(RequiredBody[TestUser](req))
+    val user: TestUser = Await.result(RequiredBody.as[TestUser].apply(req))
     user shouldEqual exampleUser
   }
 

--- a/core/src/main/scala/io/finch/request/optional.scala
+++ b/core/src/main/scala/io/finch/request/optional.scala
@@ -34,6 +34,7 @@ import scala.reflect.ClassTag
 /**
  * An empty ''RequestReader''.
  */
+@deprecated("use RequestReader.exception()", "0.5.0")
 object EmptyReader extends RequestReader[Nothing] {
   val item = MultipleItems
   def apply[Req](req: Req)(implicit ev: Req => HttpRequest) =
@@ -43,6 +44,7 @@ object EmptyReader extends RequestReader[Nothing] {
 /**
  * A const param.
  */
+@deprecated("use RequestReader.const() or RequestReader.value()", "0.5.0")
 object ConstReader {
 
   /**
@@ -59,6 +61,7 @@ object ConstReader {
 /**
  * A required integer param.
  */
+@deprecated("use RequiredParam(name).as[Int]", "0.5.0")
 object RequiredIntParam {
 
   /**
@@ -76,6 +79,7 @@ object RequiredIntParam {
 /**
  * A required long param.
  */
+@deprecated("use RequiredParam(name).as[Long]", "0.5.0")
 object RequiredLongParam {
 
   /**
@@ -93,6 +97,7 @@ object RequiredLongParam {
 /**
  * A required boolean param.
  */
+@deprecated("use RequiredParam(name).as[Boolean]", "0.5.0")
 object RequiredBooleanParam {
 
   /**
@@ -110,6 +115,7 @@ object RequiredBooleanParam {
 /**
  * A required float param.
  */
+@deprecated("use RequiredParam(name).as[Float]", "0.5.0")
 object RequiredFloatParam {
 
   /**
@@ -127,6 +133,7 @@ object RequiredFloatParam {
 /**
  * A required double param.
  */
+@deprecated("use RequiredParam(name).as[Double]", "0.5.0")
 object RequiredDoubleParam {
 
   /**
@@ -144,6 +151,7 @@ object RequiredDoubleParam {
 /**
  * An optional int param.
  */
+@deprecated("use OptionalParam(name).as[Int]", "0.5.0")
 object OptionalIntParam {
 
   /**
@@ -161,6 +169,7 @@ object OptionalIntParam {
 /**
  * An optional long param.
  */
+@deprecated("use OptionalParam(name).as[Long]", "0.5.0")
 object OptionalLongParam {
 
   /**
@@ -178,6 +187,7 @@ object OptionalLongParam {
 /**
  * An optional boolean param.
  */
+@deprecated("use OptionalParam(name).as[Boolean]", "0.5.0")
 object OptionalBooleanParam {
 
   /**
@@ -195,6 +205,7 @@ object OptionalBooleanParam {
 /**
  * An optional float param.
  */
+@deprecated("use OptionalParam(name).as[Float]", "0.5.0")
 object OptionalFloatParam {
 
   /**
@@ -212,6 +223,7 @@ object OptionalFloatParam {
 /**
  * An optional double param.
  */
+@deprecated("use OptionalParam(name).as[Double]", "0.5.0")
 object OptionalDoubleParam {
 
   /**
@@ -229,6 +241,7 @@ object OptionalDoubleParam {
 /**
  * A required multi-value integer param.
  */
+@deprecated("use RequiredParams(name).as[Int]", "0.5.0")
 object RequiredIntParams {
 
   /**
@@ -246,6 +259,7 @@ object RequiredIntParams {
 /**
  * A required multi-value long param.
  */
+@deprecated("use RequiredParams(name).as[Long]", "0.5.0")
 object RequiredLongParams {
 
   /**
@@ -263,6 +277,7 @@ object RequiredLongParams {
 /**
  * A required multi-value boolean param.
  */
+@deprecated("use RequiredParams(name).as[Boolean]", "0.5.0")
 object RequiredBooleanParams {
 
   /**
@@ -280,6 +295,7 @@ object RequiredBooleanParams {
 /**
  * A required multi-value float param.
  */
+@deprecated("use RequiredParams(name).as[Float]", "0.5.0")
 object RequiredFloatParams {
 
   /**
@@ -297,6 +313,7 @@ object RequiredFloatParams {
 /**
  * A required multi-value double param.
  */
+@deprecated("use RequiredParams(name).as[Double]", "0.5.0")
 object RequiredDoubleParams {
 
   /**
@@ -314,6 +331,7 @@ object RequiredDoubleParams {
 /**
  * An optional multi-value integer param.
  */
+@deprecated("use OptionalParams(name).as[Int]", "0.5.0")
 object OptionalIntParams {
 
   /**
@@ -332,6 +350,7 @@ object OptionalIntParams {
 /**
  * An optional multi-value long param.
  */
+@deprecated("use OptionalParams(name).as[Long]", "0.5.0")
 object OptionalLongParams {
 
   /**
@@ -350,6 +369,7 @@ object OptionalLongParams {
 /**
  * An optional multi-value boolean param.
  */
+@deprecated("use OptionalParams(name).as[Boolean]", "0.5.0")
 object OptionalBooleanParams {
 
   /**
@@ -368,6 +388,7 @@ object OptionalBooleanParams {
 /**
  * An optional multi-value float param.
  */
+@deprecated("use OptionalParams(name).as[Float]", "0.5.0")
 object OptionalFloatParams {
 
   /**
@@ -386,6 +407,7 @@ object OptionalFloatParams {
 /**
  * An optional multi-value double param.
  */
+@deprecated("use OptionalParams(name).as[Double]", "0.5.0")
 object OptionalDoubleParams {
 
 /**
@@ -401,25 +423,42 @@ object OptionalDoubleParams {
   def apply(param: String): RequestReader[Seq[Double]] = OptionalParams(param).as[Double]
 }
 
-  /**
- * A ''RequestReader'' that reads an optional encoded object serialized in request body
- * and decodes it, according to an implicit decoder, into an ''Option''.
+/**
+ * A ''RequestReader'' that reads the request body, interpreted as a ''Array[Byte]'',
+ * or throws a ''NotPresent'' exception.
  */
-object OptionalBody {
-  def apply[A](implicit m: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[Option[A]] = OptionalStringBody.as[A]
-
-  // TODO: Make it accept `Req` instead
-  def apply[A](req: HttpRequest)(implicit m: DecodeMagnet[A], tag: ClassTag[A]): Future[Option[A]] =
-    OptionalBody[A](m, tag)(req)
+@deprecated("use RequiredBinaryBody", "0.5.0")
+object RequiredArrayBody extends RequestReader[Array[Byte]] {
+  val item = BodyItem
+  def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Array[Byte]] = RequiredBinaryBody(req)
 }
 
 /**
- * A ''RequestReader'' that reads an encoded object serialized in request body
- * and decodes it according to an implicit decoder.
+ * A ''RequestReader'' that reads the request body, interpreted as a ''Array[Byte]'',
+ * into an ''Option''.
  */
-object RequiredBody {
-  def apply[A](implicit m: DecodeMagnet[A], tag: ClassTag[A]): RequestReader[A] = OptionalStringBody.as[A].failIfEmpty
-  
-  // TODO: Make it accept `Req` instead
-  def apply[A](req: HttpRequest)(implicit m: DecodeMagnet[A], tag: ClassTag[A]): Future[A] = RequiredBody[A](m, tag)(req)
+@deprecated("use OptionalBinaryBody", "0.5.0")
+object OptionalArrayBody extends RequestReader[Option[Array[Byte]]] {
+  val item = BodyItem
+  def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Option[Array[Byte]]] = OptionalBinaryBody(req)
+}
+
+/**
+ * A ''RequestReader'' that reads the request body, interpreted as a ''String'',
+ * or throws a ''NotPresent'' exception.
+ */
+@deprecated("use RequiredBody", "0.5.0")
+object RequiredStringBody extends RequestReader[String] {
+  val item = BodyItem
+  def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[String] = RequiredBody(req)
+}
+
+/**
+ * A ''RequestReader'' that reads the request body, interpreted as a ''String'',
+ * into an ''Option''.
+ */
+@deprecated("use OptionalBody", "0.5.0")
+object OptionalStringBody extends RequestReader[Option[String]] {
+  val item = BodyItem
+  def apply[Req](req: Req)(implicit ev: Req => HttpRequest): Future[Option[String]] = OptionalBody(req)
 }

--- a/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
@@ -39,7 +39,7 @@ class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
   
   def extractNotParsedTargets (result: Try[(Int, Double, Int)]): AnyRef = {
     (result handle {
-      case RequestReaderErrors(errors) => errors map {
+      case RequestErrors(errors) => errors map {
         case NotParsed(item, _, _) => item
       }
       case NotParsed(item, _, _) => Seq(item)
@@ -67,7 +67,7 @@ class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
   
   it should "produce two ParamNotFound errors if two parameters are missing" in {
     val request = Request.apply("b"->"7.7")
-    Await.result(reader(request).liftToTry) should be (Throw(RequestReaderErrors(Seq(
+    Await.result(reader(request).liftToTry) should be (Throw(RequestErrors(Seq(
       NotPresent(ParamItem("a")),
       NotPresent(ParamItem("c"))
     ))))

--- a/core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/core/src/test/scala/io/finch/request/BodySpec.scala
@@ -105,10 +105,10 @@ class BodySpec extends FlatSpec with Matchers {
        def apply(req: String): Try[Int] = Try(req.toInt)
     }
     val req = requestWithBody("123")
-    val ri: RequestReader[Int] = RequiredBody[Int]
-    val i: Future[Int] = RequiredBody[Int](req)
-    val oi: RequestReader[Option[Int]] = OptionalBody[Int]
-    val o = OptionalBody[Int](req)
+    val ri: RequestReader[Int] = RequiredBody.as[Int]
+    val i: Future[Int] = RequiredBody.as[Int].apply(req)
+    val oi: RequestReader[Option[Int]] = OptionalBody.as[Int]
+    val o = OptionalBody.as[Int].apply(req)
 
     Await.result(ri(req)) shouldBe 123
     Await.result(i) shouldBe 123
@@ -124,10 +124,10 @@ class BodySpec extends FlatSpec with Matchers {
     implicit val cReqEv = (req: CReq) => req.http // implicit view
 
     val req = CReq(requestWithBody("42.0"))
-    val rd: RequestReader[Double] = RequiredBody[Double]
-    val d = RequiredBody[Double](req)
-    val od: RequestReader[Option[Double]] = OptionalBody[Double]
-    val o: Future[Option[Double]] = OptionalBody[Double](req)
+    val rd: RequestReader[Double] = RequiredBody.as[Double]
+    val d = RequiredBody.as[Double].apply(req)
+    val od: RequestReader[Option[Double]] = OptionalBody.as[Double]
+    val o: Future[Option[Double]] = OptionalBody.as[Double].apply(req)
 
     Await.result(rd(req)) shouldBe 42.0
     Await.result(d) shouldBe 42.0
@@ -140,10 +140,10 @@ class BodySpec extends FlatSpec with Matchers {
        def apply(req: String): Try[Int] = Try(req.toInt)
     }
     val req = requestWithBody("foo")
-    val ri: RequestReader[Int] = RequiredBody[Int]
-    val i: Future[Int] = RequiredBody[Int](req)
-    val oi: RequestReader[Option[Int]] = OptionalBody[Int]
-    val o: Future[Option[Int]] = OptionalBody[Int](req)
+    val ri: RequestReader[Int] = RequiredBody.as[Int]
+    val i: Future[Int] = RequiredBody.as[Int].apply(req)
+    val oi: RequestReader[Option[Int]] = OptionalBody.as[Int]
+    val o: Future[Option[Int]] = OptionalBody.as[Int].apply(req)
 
     a [NotParsed] should be thrownBy Await.result(ri(req))
     a [NotParsed] should be thrownBy Await.result(i)

--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -76,7 +76,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "5"))
     val futureResult: Future[Seq[Boolean]] = OptionalBooleanParams("foo")(request)
-    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
+    a [RequestErrors] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -92,7 +92,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not an integer" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = OptionalIntParams("foo")(request)
-    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
+    a [RequestErrors] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -108,7 +108,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a long" in {
     val request: HttpRequest = Request.apply(("foo", "false"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = OptionalLongParams("foo")(request)
-    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
+    a [RequestErrors] should be thrownBy Await.result(futureResult)
   }
 
   "A OptionalFloatParams" should "be parsed as a list of floats" in {
@@ -123,7 +123,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a float" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "true"), ("foo", "5.123"))
     val futureResult: Future[Seq[Float]] = OptionalFloatParams("foo")(request)
-    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
+    a [RequestErrors] should be thrownBy Await.result(futureResult)
   }
 
 
@@ -139,6 +139,6 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a double" in {
     val request: HttpRequest = Request.apply(("foo", "45543245.435"), ("foo", "non-number"))
     val futureResult: Future[Seq[Double]] = OptionalDoubleParams("foo")(request)
-    a [RequestReaderErrors] should be thrownBy Await.result(futureResult)
+    a [RequestErrors] should be thrownBy Await.result(futureResult)
   }
 }

--- a/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s):
+ * Jens Halm
+ */
+package io.finch.request
+
+import com.twitter.finagle.httpx.Request
+import com.twitter.util.{Await, Future}
+import io.finch._
+import org.scalatest.{Matchers, FlatSpec}
+import items._
+
+class RequestReaderCompanionSpec extends FlatSpec with Matchers {
+
+  "The RequestReaderCompanion" should "support a facotry method based on a funciton that reads from the request" in {
+    val request: HttpRequest = Request.apply(("foo", "5"))
+    val futureResult: Future[String] = RequestReader(ParamItem("foo"))(_.params.get("foo")).failIfEmpty(request)
+    Await.result(futureResult) shouldBe "5"
+  }
+
+  it should "support a factory method based on a constant Future" in {
+    val request: HttpRequest = Request.apply(("foo", ""))
+    val futureResult: Future[Int] = RequestReader.const(1.toFuture)(request)
+    Await.result(futureResult) shouldBe 1
+  }
+  
+  it should "support a factory method based on a constant value" in {
+    val request: HttpRequest = Request.apply(("foo", ""))
+    val futureResult: Future[Int] = RequestReader.value(1)(request)
+    Await.result(futureResult) shouldBe 1
+  }
+  
+  it should "support a factory method based on a constant exception" in {
+    val request: HttpRequest = Request.apply(("foo", ""))
+    val futureResult: Future[Int] = RequestReader.exception(NotPresent(BodyItem))(request)
+    a [NotPresent] should be thrownBy Await.result(futureResult)
+  }
+  
+}

--- a/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
@@ -49,7 +49,7 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
 
   it should "raise a RequestReader error for invalid values" in {
     val oddReader = fooReader.should("be odd") { _ % 2 != 0 }
-    a [RequestReaderError] should be thrownBy Await.result(oddReader(request))
+    a [RequestError] should be thrownBy Await.result(oddReader(request))
   }
 
   it should "allow valid values in a for-comprehension" in {
@@ -63,7 +63,7 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
     val readFoo: RequestReader[Int] = for {
       foo <- fooReader if foo % 2 != 0
     } yield foo
-    a [RequestReaderError] should be thrownBy Await.result(readFoo(request))
+    a [RequestError] should be thrownBy Await.result(readFoo(request))
   }
 
   "A RequestReader with a predefined validation rule" should "allow valid values" in {
@@ -78,7 +78,7 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
 
   it should "raise a RequestReader error for invalid values" in {
     val oddReader = fooReader.shouldNot(beEven)
-    a [RequestReaderError] should be thrownBy Await.result(oddReader(request))
+    a [RequestError] should be thrownBy Await.result(oddReader(request))
   }
   
   it should "allow valid values based on two rules combined with and" in {
@@ -88,7 +88,7 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
   
   it should "raise a RequestReader error if one of two rules combined with and fails" in {
     val andReader = fooReader.should(beEven and beSmallerThan(2))
-    a [RequestReaderError] should be thrownBy Await.result(andReader(request))
+    a [RequestError] should be thrownBy Await.result(andReader(request))
   }
   
   it should "allow valid values based on two rules combined with or" in {
@@ -98,7 +98,7 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
   
   it should "raise a RequestReader error if one of two rules combined with or in a negation fails" in {
     val andReader = fooReader.shouldNot(beEven or beSmallerThan(12))
-    a [RequestReaderError] should be thrownBy Await.result(andReader(request))
+    a [RequestError] should be thrownBy Await.result(andReader(request))
   }
   
   it should "allow to reuse a validation rule with optional readers" in {
@@ -108,7 +108,7 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
   
   it should "raise a RequestReader error if a rule for a non-empty optional value fails" in {
     val optReader = OptionalIntParam("bar").should(beEven)
-    a [RequestReaderError] should be thrownBy Await.result(optReader(request))
+    a [RequestError] should be thrownBy Await.result(optReader(request))
   }
   
   it should "skip validation when applied to an empty optional value" in {

--- a/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -81,7 +81,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a boolean" in {
     val request: HttpRequest = Request.apply(("foo", "true"), ("foo", "5"))
     val futureResult: Future[Seq[Boolean]] = RequiredBooleanParams("foo")(request)
-    intercept[RequestReaderErrors] {
+    intercept[RequestErrors] {
       Await.result(futureResult)
     }
   }
@@ -99,7 +99,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not an integer" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = RequiredIntParams("foo")(request)
-    intercept[RequestReaderErrors] {
+    intercept[RequestErrors] {
       Await.result(futureResult)
     }
   }
@@ -117,7 +117,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a long" in {
     val request: HttpRequest = Request.apply(("foo", "false"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = RequiredLongParams("foo")(request)
-    intercept[RequestReaderErrors] {
+    intercept[RequestErrors] {
       Await.result(futureResult)
     }
   }
@@ -135,7 +135,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a float" in {
     val request: HttpRequest = Request.apply(("foo", "non-number"), ("foo", "true"))
     val futureResult: Future[Seq[Float]] = RequiredFloatParams("foo")(request)
-    intercept[RequestReaderErrors] {
+    intercept[RequestErrors] {
       Await.result(futureResult)
     }
   }
@@ -153,7 +153,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   it should "produce an error if one of the params is not a double" in {
     val request: HttpRequest = Request.apply(("foo", "45543245.435"), ("foo", "non-number"))
     val futureResult: Future[Seq[Double]] = RequiredDoubleParams("foo")(request)
-    intercept[RequestReaderErrors] {
+    intercept[RequestErrors] {
       Await.result(futureResult)
     }
   }

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -141,7 +141,7 @@ case class PostUserTicket(userId: Long, ticketId: Long, db: Main.Db) extends Ser
   // A request reader that reads ticket object from the http request.
   // A ticket object is represented by json object serialized in request body.
   val ticket: RequestReader[Ticket] = for {
-    json <- RequiredBody[Json]
+    json <- RequiredBody.as[Json]
   } yield Ticket(ticketId, json[String]("label").getOrElse("N/A"))
 
   def apply(req: AuthRequest) = for {

--- a/docs.md
+++ b/docs.md
@@ -123,8 +123,6 @@ transformations will be performed. Reader Monad is sort of famous abstraction th
 ### Query String Params
 
 The following readers are available in Finch:
-* `io.finch.request.EmptyReader` - throws an exception instead of reading
-* `io.finch.request.ConstReader` - fetches a const value from the request
 * `io.finch.request.RequiredParam` - fetches required params within specified type
 * `io.finch.request.OptionalParam` - fetches optional params within specified type
 * `io.finch.request.RequiredParams` - fetches required multi-value params into the list
@@ -136,7 +134,7 @@ case class User(name: String, age: Int, city: String)
 // Define a new request reader composed from provided out-of-the-box readers.
 val user: RequestReader[User] = for {
   name <- RequiredParam("name")
-  age <- RequiredIntParam("age")
+  age <- RequiredParam("age").as[Int]
   city <- OptionalParam("city")
 } yield User(name, age, city.getOrElse("Novosibirsk"))
 
@@ -155,12 +153,12 @@ val user: Json = service(req) handle {
 }
 ```
 
-Optional request readers such as `OptionalIntParam` are quite often used for fetching pagination details.
+Optional request readers such as `OptionalParam` are quite often used for fetching pagination details.
 
 ```scala
 val pagination: RequestReader[(Int, Int)] = for {
-  offset <- OptionalIntParam("offset")
-  limit <- OptionalIntParam("limit")
+  offset <- OptionalParam("offset").as[Int]
+  limit <- OptionalParam("limit").as[Int]
 } yield (offset.getOrElse(0), math.min(limit.getOrElse(50), 50))
 
 val service = new Service[HttpRequest, HttpResponse] {
@@ -171,15 +169,15 @@ val service = new Service[HttpRequest, HttpResponse] {
 ```
 
 #### A `io.finch.request.RequiredParam` reader makes sure that
-* param is presented in the request (otherwise it throws `ParamNoFound(param)` exception)
-* param is not empty (otherwise it throws `ValidationFailed(param, rule)` exception)
-* param may be converted to a requested type `RequiredIntParam`, `RequiredLongParam` or `RequiredBooleanParam`
-(otherwise it throws `ValidationFailed(param, rule)` exception).
+* param is present in the request (otherwise it throws `NotPresent` exception)
+* param is not empty (otherwise it throws `NotParsed` exception)
+* param may be converted to a requested type through calling `as[Int]`, `as[Float]`, etc.
+(otherwise it throws a `NotParsed` exception).
 
-#### An `io.finch.request.OptionalParam` returns
-* `Future[Some[A]]` if param is presented in the request and may be converted to a requested type `OptionalIntParam`,
-`OptionalLongParam` or `OptionalBooleanParam`
-* `Future.None` otherwise.
+#### An `io.finch.request.OptionalParam.as[A]` returns
+* `Future[Some[A]]` if param is present in the request and can be converted to the requested type
+* `Future.None` if the param is missing.
+* `NotParsed` exception if the param is present, but cannot be converted to the requested type
 
 
 ### Improved Error Handling with Applicative Syntax
@@ -192,7 +190,7 @@ case class User(name: String, age: Int, city: String)
 
 val user: RequestReader[User] = 
   (RequiredParam("name") ~
-  RequiredIntParam("age") ~
+  RequiredParam("age").as[Int] ~
   OptionalParam("city")) map {
     case name ~ age ~ city => 
       User(name, age, city.getOrElse("Novosibirsk"))
@@ -227,23 +225,23 @@ case class User(name: String, age: Int)
 // monadic syntax
 val adult: RequestReader[User] = for {
   name <- RequiredParam("name")
-  age <- RequiredIntParam("age").should("be greater than 18"){ _ > 18 }
+  age <- RequiredParam("age").as[Int].should("be greater than 18"){ _ > 18 }
 } yield User(name, age)
 
 // applicative syntax  
 val adult2: RequestReader[User] = 
   (RequiredParam("name") ~
-  RequiredIntParam("age").should("be greater than 18"){ _ > 18 }) map {
+  RequiredParam("age").as[Int].should("be greater than 18"){ _ > 18 }) map {
     case name ~ age => User(name, age)
 }
   
 // reusable validators
-val beNonNegative = ValidationRule[Int]("be non-negative") { _ >= 0 }
-def beSmallerThan(value: Int) = ValidationRule[Int](s"be smaller than $value") { _ < value }
+val bePositive = ValidationRule[Int]("be non-negative") { _ > 0 }
+def beLessThan(value: Int) = ValidationRule[Int](s"be less than $value") { _ < value }
   
 val child: RequestReader[User] = 
   (RequiredParam("name") ~
-  RequiredIntParam("age").should(beNonNegative and beSmallerThan(18))) map {
+  RequiredParam("age").as[Int].should(bePositive and beLessThan(18))) map {
     case name ~ age => User(name, age)
 }
 ```
@@ -275,15 +273,14 @@ case class NotValid(item: RequestItem, rule: String) // when a validation rule d
 
 All the readers have companion readers that can read multiple-value params `List[A]` instead of single-value params `A`.
 Multiple-value readers have `s` postfix in their names. So, `Param` has `Params`, `OptionalParam` has `OptionalParams`
-and finally `RequiredParam` has `RequiredParams` companions. There are also typed versions for every reader, like
-`IntParams` or even `OptionalLongParams`.
+and finally `RequiredParam` has `RequiredParams` companions.
 
-Thus, the following HTTP params `a=1,2,3&b=4&b=5` might be fetched with `RequiredIntParams` reader like this:
+Thus, the following HTTP params `a=1,2,3&b=4&b=5` might be fetched with `RequiredParams` reader like this:
 
 ```scala
-val reader: RequestReader[(Int, Int)] = for {
- a <- RequiredIntParams("a")
- b <- RequiredIntParams("b")
+val reader: RequestReader[(List[Int], List[Int])] = for {
+ a <- RequiredParams("a").as[Int]
+ b <- RequiredParams("b").as[Int]
 } yield (a, b)
 
 val (a, b): (List[Int], List[Int]) = reader(request)
@@ -301,13 +298,13 @@ The HTTP headers may also be read with `RequestReader`. The following pre-define
 
 An HTTP body may be fetched from the HTTP request using the following readers:
 
-* `io.finch.request.RequiredArrayBody` - fetches the HTTP body as `Array[Byte]` or throws a `BodyNotFound` exception
-* `io.finch.request.OptionalArrayBody` - fetches the HTTP body as `Option[Array[Byte]]`
-* `io.finch.request.RequiredStringBody` - fetches the HTTP body as `String` or throws a `BodyNotFound` exception
-* `io.finch.request.OptionalStringBody` - fetches the HTTP body as `Option[String]`
+* `io.finch.request.RequiredBody` - fetches the HTTP body as `String` or throws a `NotPresent` exception
+* `io.finch.request.OptionalBody` - fetches the HTTP body as `Option[String]`
+* `io.finch.request.RequiredBinaryBody` - fetches the HTTP body as `Array[Byte]` or throws a `NotPresent` exception
+* `io.finch.request.OptionalBinaryBody` - fetches the HTTP body as `Option[Array[Byte]]`
 
 Finch supports pluggable request decoders. In fact, any type `A` my be read from the request body using either:
-`io.finch.request.RequiredBody[A]` or `io.finch.request.OptionalBody[A]` if there is an implicit value of type 
+`io.finch.request.RequiredBody.as[A]` or `io.finch.request.OptionalBody.as[A]` if there is an implicit value of type 
 `DecodeRequest[A]` available in the scope. The `DecodeRequest[A]` abstraction may be described as function 
 `String => Try[A]`. Thus, any decoders may be easily defined to use the functionality of body readers. Note, that 
 the body type (i.e., `Double`) should be always explicitly defined for both `RequiredBody` and `OptionalBody`.
@@ -319,7 +316,7 @@ implicit val decodeDouble = new DecodeRequest[Double] {
   
 }
 val req: HttpRequest = ???
-val readDouble: RequestReader[Double] = RequiredBody[Double]
+val readDouble: RequestReader[Double] = RequiredBody.as[Double]
 ```
 
 
@@ -448,7 +445,7 @@ import io.finch.json._
 import io.finch.request._
 
 vaj j: Json = Json.obj("a" -> 10)
-val i: RequestReader[Json] = RequiredBody[Json]
+val i: RequestReader[Json] = RequiredBody.as[Json]
 val o: HttpResponse = Ok(Json.arr("a", "b", "c")
 
 ```
@@ -477,7 +474,7 @@ implicit val objectMapper: ObjectMapper = new ObjectMapper().registerModule(Defa
 case class Foo(id: Int, s: String)
 
 val ok: HttpResponse = Ok(Foo(10, "foo")) // will be encoded as JSON
-val foo: RequestReader[Foo] = RequiredBody[Foo] // a request reader that reads Foo
+val foo: RequestReader[Foo] = RequiredBody.as[Foo] // a request reader that reads Foo
 ```
 
 

--- a/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
+++ b/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
@@ -71,10 +71,10 @@ class JacksonSpec extends FlatSpec with Matchers {
     req.content = body
     req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, body.length.toString)
 
-    val rFoo: RequestReader[Foo] = RequiredBody[Foo]
-    val foo: Future[Foo] = RequiredBody[Foo](req)
-    val roFoo: RequestReader[Option[Foo]] = OptionalBody[Foo]
-    val oFoo: Future[Option[Foo]] = OptionalBody[Foo](req)
+    val rFoo: RequestReader[Foo] = RequiredBody.as[Foo]
+    val foo: Future[Foo] = RequiredBody.as[Foo].apply(req)
+    val roFoo: RequestReader[Option[Foo]] = OptionalBody.as[Foo]
+    val oFoo: Future[Option[Foo]] = OptionalBody.as[Foo].apply(req)
 
     val expectedFoo = Foo("bar", 42)
     Await.result(rFoo(req)) shouldBe expectedFoo

--- a/json/src/test/scala/io/finch/json/JsonSpec.scala
+++ b/json/src/test/scala/io/finch/json/JsonSpec.scala
@@ -198,9 +198,9 @@ class JsonSpec extends FlatSpec with Matchers {
     req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, jsonBody.length.toString)
 
     val ok: HttpResponse = Ok(json)
-    val j: RequestReader[Json] = RequiredBody[Json]
-    val k: Future[Json] = RequiredBody[Json](req)
-    val o = OptionalBody[Json](req)
+    val j: RequestReader[Json] = RequiredBody.as[Json]
+    val k: Future[Json] = RequiredBody.as[Json].apply(req)
+    val o = OptionalBody.as[Json].apply(req)
     val s: Service[Json, HttpResponse] = TurnIntoHttp[Json]
 
     ok.getContentString() shouldBe Json.encode(json)


### PR DESCRIPTION
This is the last of 5 PRs extracted from #162.

It is exactly as reviewed in the discussion PR except for:

* Renamed `RequestReaderErrors` and `RequestReaderError` to `RequestErrors` and `RequestError`
* Deprecated `Required/OptionalArrayBody` in favour of `Required/OptionalBinaryBody`
* Rewrote the description below to capture all the discussions that happened in the meantime


## PR 5: Deprecate APIs which are now supported in a more generic way or have been renamed

The recent series of PRs has made the request package more feature-rich and consistent. This would be a great opportunity to deprecate some of the older APIs which are now covered in a more generic way.
This would help keeping the public API simple and minimal and avoid confusion caused by having multiple ways to do the same thing.

In particular this PR suggests the following deprecations:

* Deprecate all hard-coded readers that did type conversions to numbers and booleans in favour of the new `as[A]` method
  (e.g. deprecate `RequiredIntParam("foo")` in favour of `RequiredParam("foo").as[Int]`
* Deprecate `Required/OptionalArrayBody` in favour of `Required/OptionalBinaryBody`
* Deprecate `Required/OptionalStringBody` in favour of `Required/OptionalBody`
* Deprecate `ConstReader` and `EmptyReader` in favour of new factory methods `const`, `value` and `exception` in `RequestReader`

The above deprecations would introduce a grace period for everyone using those APIs. I think in particular for the heavily used `XxIntParam` readers it is nicer to give users some time. Seeing deprecation warnings that explicitly tell you what to use instead also makes it quite easy to modify your code base.

On top of the soft deprecations, this PR also introduces two breaking changes:

* Renamed `RequestReaderErrors` and `RequestReaderError` to `RequestErrors` and `RequestError` (but we have breaking changes in all other error types anyway)
* Removed `XxBody[A]` implementations in favour of `XxBody.as[A]`. Deprecation would have been difficult here due to the name clash.

In general it would be nice to get feedback from people having a code base that uses these Finch APIs.

This PR also updates `docs.md` to use the new API instead of the deprecated one.

Each of the recent PRs added some documentation for the new features, but I feel like I ruined the structure in the process as it makes the docs quite patchy. If there is interest I'd volunteer to do a 6th PR for rewriting the section for the request package over the weekend. I'd open an issue first that describes my ideas for the new structure. The APIs in the request package are now quite simple and consistent and it would be nice if the docs would capture this. It would also be nice to have more of the sample code written in applicative style.