### PR TITLE
Add API docs URL to POM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,8 @@ lazy val publishSettings = Seq(
   publishArtifact in Test := false,
   licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   homepage := Some(url("https://github.com/finagle/finch")),
+  autoAPIMappings := true,
+  apiURL := Some(url("https://finagle.github.io/finch/docs/")),
   pomExtra := (
     <scm>
       <url>git://github.com/finagle/finch.git</url>


### PR DESCRIPTION
This is a nice little feature of SBT that adds the base URL of the API docs to the metadata in the POM so that projects that depend on Finch can have their own documentation automatically linked to Finch's.

See the [SBT documentation](http://www.scala-sbt.org/0.13/docs/Howto-Scaladoc.html#Define+the+location+of+API+documentation+for+a+library) for more detail.