### PR TITLE
Allow a RequestReader to be used as a Finagle Service

### DIFF
--- a/core/src/main/scala/io/finch/request/RequestReader.scala
+++ b/core/src/main/scala/io/finch/request/RequestReader.scala
@@ -26,6 +26,7 @@
 
 package io.finch.request
 
+import com.twitter.finagle.Service
 import com.twitter.util.{Throw, Return, Future}
 import io.finch._
 import io.finch.request.items._
@@ -130,6 +131,16 @@ trait RequestReader[A] { self =>
    *         Otherwise the future fails with a ''NotValid'' error.
    */
   def shouldNot(rule: ValidationRule[A]): RequestReader[A] = shouldNot(rule.description)(rule.apply)
+
+  /**
+   * Allows this reader to be used as a Finagle `Service` through
+   * "fixing" the type of the request it can handle.
+   *
+   * @return this reader as a Finagle Service for the specified request type
+   */
+  def asService[Req](implicit ev: Req => HttpRequest): Service[Req, A] = new Service[Req, A] {
+    def apply(req: Req) = self.apply(req)
+  }
 }
 
 /**
@@ -180,4 +191,3 @@ object RequestReader {
       def apply[Req](req: Req)(implicit ev: Req => HttpRequest) = f(req)
     }
 }
-

--- a/core/src/test/scala/io/finch/request/ReaderAsServiceSpec.scala
+++ b/core/src/test/scala/io/finch/request/ReaderAsServiceSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s):
+ * Jens Halm
+ */
+package io.finch.request
+
+import org.scalatest.{Matchers, FlatSpec}
+import com.twitter.util.{Future, Await}
+import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.Service
+import io.finch.HttpRequest
+
+class ReaderAsServiceSpec extends FlatSpec with Matchers {
+
+  
+  "A RequestReader" should "be usable as a Finagle Service" in {
+    case class MyRequest(request: HttpRequest)
+    
+    implicit def extractRequest(req: MyRequest): HttpRequest = req.request
+    
+    val request: MyRequest = MyRequest(Request(("foo", "5")))
+    val reader: RequestReader[Int] = RequiredParam("foo").as[Int]
+    val service: Service[MyRequest, Int] = reader.asService[MyRequest]
+    val result = service(request)
+    Await.result(result) shouldBe 5
+  }
+  
+}


### PR DESCRIPTION
In this case I might be missing something obvious which makes this PR obsolete. But I was wondering about the ways to combine a reader with Finagle Services and found examples like this in the documentation:

```scala
val user: RequestReader[User] = for {
  name <- RequiredParam("name")
  age <- RequiredParam("age").as[Int]
  city <- OptionalParam("city")
} yield User(name, age, city.getOrElse("Novosibirsk"))

val service = new Service[HttpRequest, Json] {
  def apply(req: HttpRequest) = for {
    u <- user(req)
  } yield Json.obj(
    "name" -> u.name,
    "age" -> u.age,
    "city" -> u.city
  )
}
```

This shows the use of a reader **inside** a service implementation. This is convenient for small and simple services, but for a bigger application I might prefer to have the reader itself as a pluggable service:

```scala
case class MyRequest(request: HttpRequest)

val userReader: RequestReader[User] = ???

val userService: Service[MyRequest, User] = userReader.asService[MyRequest]

val profileService: Service[User, UserProfile] = ???

userService ! profileService ! TurnIntoHttp[UserProfile]
```

The reader becomes usable as a Finagle service through "fixing" the request type it can handle.
This way, apart from using the reader inside a service implementation, it can also be composed
with existing services that only deal with domain objects and not with anything HTTP.

This PR implements the `asService[Req]` method shown above.

Is this a bad idea? Can the same be achieved by other means?

If this PR is seen as useful it would be cool to squeeze it into 0.5.0.