### PR TITLE
Add missing Finagle import to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This "Hello World!" example is built with the `0.6.0-SNAPSHOT` version of `finch
 import io.finch._
 import io.finch.route._
 import io.finch.response._
+import com.twitter.finagle.Httpx
 
 Httpx.serve(":8080",
   Get / "hello" /> Ok("Hello, world!").toFuture: Endpoint[HttpRequest, HttpResponse]


### PR DESCRIPTION
Very minor thing, but would help Finch beginners (like me) get started: Httpx isn't imported in the README.md example. I needed to find this class on my own before the example would work. This PR adds an import for it.