### PR TITLE
Fix #171: Empty Strings

### DIFF
--- a/core/src/test/scala/io/finch/request/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/HeaderSpec.scala
@@ -55,6 +55,13 @@ class HeaderSpec extends FlatSpec with Matchers {
     Await.result(futureResult) shouldBe None
   }
 
+  it should "be None if it's empty" in {
+    val request = Request()
+    request.headerMap.update("Location", "")
+    val futureResult = OptionalHeader("Location")(request)
+    Await.result(futureResult) shouldBe None
+  }
+
   "A Header Reader" should "have a matching RequestItem" in {
     val header = "Location"
     RequiredHeader(header).item shouldBe items.HeaderItem(header)

--- a/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
@@ -36,8 +36,14 @@ class OptionalParamSpec extends FlatSpec with Matchers {
     Await.result(futureResult) shouldBe Some("5")
   }
 
-  it should "produce an error if the param is empty" in {
+  it should "return none if the param is not present" in {
     val request: HttpRequest = Request()
+    val futureResult: Future[Option[String]] = OptionalParam("foo")(request)
+    Await.result(futureResult) shouldBe None
+  }
+
+  it should "return none if the param is empty" in {
+    val request: HttpRequest = Request("foo" -> "")
     val futureResult: Future[Option[String]] = OptionalParam("foo")(request)
     Await.result(futureResult) shouldBe None
   }

--- a/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
@@ -30,10 +30,10 @@ import items._
 
 class RequestReaderCompanionSpec extends FlatSpec with Matchers {
 
-  "The RequestReaderCompanion" should "support a facotry method based on a funciton that reads from the request" in {
+  "The RequestReaderCompanion" should "support a factory method based on a function that reads from the request" in {
     val request: HttpRequest = Request(("foo", "5"))
-    val futureResult: Future[String] = RequestReader(ParamItem("foo"))(_.params.get("foo")).failIfEmpty(request)
-    Await.result(futureResult) shouldBe "5"
+    val futureResult: Future[Option[String]] = RequestReader(ParamItem("foo"))(_ => Some("5"))(request)
+    Await.result(futureResult) shouldBe Some("5")
   }
 
   it should "support a factory method based on a constant Future" in {


### PR DESCRIPTION
The following behaviour is implemented (required readers are untouched): optional readers read `None` if the underlying string value is empty. Therefore, the _real_ empty string param might be read as

```scala
val e1 = OptionalParam("empty") map { _.getOrElse("") }
val e2 = OptionalParam("empty") withDefault("") // further API
```