### PR TITLE
Make DecodeRequest invariant and remove DecodeMagnet

### DIFF
--- a/core/src/main/scala/io/finch/request/LowPriorityRequestReaderImplicits.scala
+++ b/core/src/main/scala/io/finch/request/LowPriorityRequestReaderImplicits.scala
@@ -17,12 +17,11 @@ trait LowPriorityRequestReaderImplicits {
    * Creates a [[io.finch.request.DecodeMagnet DecodeMagnet]] from
    * [[io.finch.request.DecodeAnyRequest DecodeAnyRequest]].
    */
-  implicit def magnetFromAnyDecode[A](implicit d: DecodeAnyRequest, tag: ClassTag[A]): DecodeMagnet[A] =
-    new DecodeMagnet[A] {
-      def apply(): DecodeRequest[A] = new DecodeRequest[A] {
-        def apply(req: String): Try[A] = d(req)(tag)
-      }
-    }
+  implicit def decodeRequestFromAnyDecode[A](
+    implicit d: DecodeAnyRequest, tag: ClassTag[A]
+  ): DecodeRequest[A] = new DecodeRequest[A] {
+    def apply(req: String): Try[A] = d(req)(tag)
+  }
 
   /**
    * Adds a `~>` and `~~>` compositors to `RequestReader` to compose it with function of one argument.

--- a/core/src/test/scala/io/finch/request/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/request/DecodeSpec.scala
@@ -41,7 +41,7 @@ class DecodeSpec extends FlatSpec with Matchers {
       def apply(s: String): Try[BigDecimal] = Try(BigDecimal(s))
     }
 
-    decode[ScalaNumber]("12345.25") shouldBe Return(BigDecimal(12345.25))
+    decode[BigDecimal]("12345.25") shouldBe Return(BigDecimal(12345.25))
   }
   
   "A RequestReader for a String" should "allow for type conversions based on implicit DecodeRequest" in {


### PR DESCRIPTION
This is a discussion PR—I don't expect it to be a candidate for merging, and before it becomes one it would need some changes to the docs. This may be a discussion that's been had before, and if so we can just close this.

As I've been working on other stuff in Finch (that I promised to finish up last night :frowning:) I've been finding the `DecodeMagnet` stuff a little noisy, and it's not hard to get rid of if you're willing to make `DecodeRequest` invariant (so that you don't get the compiler trying to serve up instances for `Nothing` in weird places).

I'm personally of the opinion that type classes should be invariant by default, and that anything else should take some justification, in part because of the inference and implicit resolution problems we're seeing here.

Making `DecodeRequest` only requires one change to one test, and it's pretty minor. We'd have to explain the decision to users, but I don't think that would be too difficult or undesirable (especially since this change would let us remove the handwaving about `DecodeMagnet`).

Anyone strongly in favor of covariance here?