### PR TITLE
Fix the media type of plain text responses

### DIFF
--- a/core/src/main/scala/io/finch/response/package.scala
+++ b/core/src/main/scala/io/finch/response/package.scala
@@ -41,13 +41,13 @@ import com.twitter.util.Future
  *   val ok: HttpResponse = Ok("Hello, World!")
  * }}}
  *
- * In addition to `plain/text` responses, the `ResponseBuilder` is able to build any response, whose `content-type` is
+ * In addition to `text/plain` responses, the `ResponseBuilder` is able to build any response, whose `content-type` is
  * specified by an implicit type-class [[io.finch.response.EncodeResponse EncodeResponse]] instance. In fact, any type
  * `A` may be passed to a `RequestReader` if there is a corresponding `EncodeRequest[A]` instance available in the
  * scope.
  *
  * {{{
- *   implicit val encodeBigInt = EncodeResponse[BigInt]("plain/text") { _.toString }
+ *   implicit val encodeBigInt = EncodeResponse[BigInt]("text/plain") { _.toString }
  *   val ok: HttpResponse = Ok(BigInt(100))
  * }}}
  */
@@ -198,5 +198,5 @@ package object response {
   /**
    * Allows to pass raw strings to [[io.finch.response.ResponseBuilder ResponseBuilder]].
    */
-  implicit val encodeString: EncodeResponse[String] = EncodeResponse("plain/text")(s => s)
+  implicit val encodeString: EncodeResponse[String] = EncodeResponse("text/plain")(s => s)
 }

--- a/core/src/test/scala/io/finch/response/ResponseBuilderSpec.scala
+++ b/core/src/test/scala/io/finch/response/ResponseBuilderSpec.scala
@@ -34,10 +34,11 @@ class ResponseBuilderSpec extends FlatSpec with Matchers {
     rep.status shouldBe Status.Ok
   }
 
-  it should "set plain test as its content string" in {
+  it should "set plain text as its content string" in {
     val str = "Some Content!"
     val rep = ResponseBuilder(Status.Ok)(str)
     rep.getContentString() shouldBe str
+    rep.mediaType shouldBe Some("text/plain")
   }
 
   it should "only include that headers that are set on it" in {

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ of any type. In fact, `ResponseBuilder` is a function that takes some content an
 depending on a content. There are plenty of predefined builders that might be used directly.
 
 ```scala
- val ok: HttpResponse = Ok("Hello, world!") // plain/text HTTP response with status code 200
+ val ok: HttpResponse = Ok("Hello, world!") // text/plain HTTP response with status code 200
 ```
 
 ## Table of Contents

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ val title = paramOption("title").withDefault("")
 ```
 
 Finally, we define a service `hello` that actually greets users. The HTTP response `OK 200` is _built_ with
-[response builder](response.md) `Ok` that takes a string and returns a `plain/text` HTTP response.  
+[response builder](response.md) `Ok` that takes a string and returns a `text/plain` HTTP response.  
 
 ```scala
 def hello(name: String) = new Service[HttpRequest, HttpResponse] {

--- a/docs/response.md
+++ b/docs/response.md
@@ -10,7 +10,7 @@
 An entry point into the construction of HTTP responses in Finch is the `io.finch.response.ResponseBuilder` class. It
 supports building of three types of responses:
 
-* `plain/text` within string in the response body
+* `text/plain` within string in the response body
 * empty response of given HTTP status
 * a type defined by implicit instance of `EncodeResponse[A]`
 
@@ -22,7 +22,7 @@ import io.finch.argonaut._
 import io.finch.response._
 
 val a = Ok() // an empty response with status 200
-val b = NotFound("body") // 'plain/text' response with status 404
+val b = NotFound("body") // 'text/plain' response with status 404
 val c = Created(Json.obj("id" -> 42)) // 'application/json' response with status 201
 ```
 


### PR DESCRIPTION
The built-in implicit `EncodeResponse` for strings is incorrectly defining the media type to be `plain/text`. This causes some browsers to download the response as a file instead of rendering it on screen. HAProxy is very picky about the media type as well and fails any health check that outputs this value.

This PR fixes the media type to the correct value of `text/plain`. 