### PR TITLE
Use Shapeless's HList for request reader composition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,11 @@ lazy val compilerOptions = Seq(
 
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
+    "com.chuusai" %% "shapeless" % "2.2.0-RC4",
     "com.twitter" %% "finagle-httpx" % "6.25.0",
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
+    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ),
   scalacOptions ++= compilerOptions ++ (
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/core/src/main/scala/io/finch/request/RequestReader.scala
+++ b/core/src/main/scala/io/finch/request/RequestReader.scala
@@ -73,9 +73,10 @@ trait PRequestReader[R, A] { self =>
     def apply(req: R): Future[B] = self(req) flatMap fn
   }
 
-  /**
+   /**
    * Composes this request reader with the given `that` request reader.
    */
+  @deprecated("~ is deprecated in favor of HList-based composition", "0.7.0")
   def ~[S, B](that: PRequestReader[S, B])(
     implicit ev: R %> S
   ): PRequestReader[R, A ~ B] = new PRequestReader[R, A ~ B] {

--- a/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
@@ -34,12 +34,11 @@ class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
   case class MyReq(http: HttpRequest, i: Int)
   implicit val reqEv: MyReq %> HttpRequest = View(_.http)
 
-  val reader: RequestReader[(Int, Double, Int)] =
-    param("a").as[Int] ~
-    param("b").as[Double] ~
-    param("c").as[Int] map {
-      case a ~ b ~ c => (a, b, c)
-    }
+  val reader: RequestReader[(Int, Double, Int)] = (
+    param("a").as[Int] ::
+    param("b").as[Double] ::
+    param("c").as[Int]
+  ).asTuple
   
   def extractNotParsedTargets (result: Try[(Int, Double, Int)]): AnyRef = {
     (result handle {
@@ -88,7 +87,7 @@ class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
 
   it should "be polymorphic in terms of request type" in {
     val i: PRequestReader[MyReq, Int] = RequestReader(_.i)
-    val a = i ~ param("a") ~> (_ + _)
+    val a = (i :: param("a")) ~> ((_: Int) + (_: String))
     val b = for {
       ii <- i
       aa <- param("a")

--- a/playground/src/main/scala/io/finch/playground/Main.scala
+++ b/playground/src/main/scala/io/finch/playground/Main.scala
@@ -48,7 +48,7 @@ object Main extends App {
 
   // POST /groups?name=foo -> Group
   val postGroup: AuthMicro[Group] =
-    currentUser ~ param("name") ~> Group
+    (currentUser :: param("name")).as[Group]
 
   // PUT /user/groups/:group -> User
   def putUserGroup(group: String): AuthMicro[User] =


### PR DESCRIPTION
I'm still working on the heterogeneous router, but I wanted to go ahead and post the `RequestReader` changes since they're more straightforward, and since #242 is now broken out into its own issue.

A few points for discussion:

* I'm using Shapeless 2.2.0 even though it's still a release candidate, since the release is likely to happen before 0.7.0 is ready otherwise. The only change that would be necessary (I believe) to go with 2.1 is in the `build.sbt`—before 2.2 plain old `%%` didn't work because `_2.10.4` had to be specified for 2.10.
* I don't see any way to get rid of the boilerplate for `~>` and `~~>` without requiring the types of their arguments to be fully specified, which is annoying. I've provided commented-out generic implementations, but I've left the (modified) boilerplate-y versions for now.
* I'm tempted to put the implicit classes that can't be made value classes in 2.10 because of [SI-8011](https://issues.scala-lang.org/browse/SI-8011) in version specific source trees, now that this is super easy in SBT 0.13.8. I haven't yet, though.
* One small annoyance: `a ~ b ~> f` now needs parentheses: `(a :: b) ~> f`.
* Otherwise I've only changed one test, to use a new `.tupled` method instead of explicitly mapping a tuple out of the `~`.
* I went ahead and made it so that a "bigger" request for `a` is fine in e.g. `a :: param("foo")` since this seems to fit common usage.

The syntax in #242 is supported verbatim:

``` scala
case class User(id: Int, name: String)
val user: RequestReader[User] = (param("id").as[Int] :: param("name")).as[User]
```

Thanks to Shapeless's `Generic`.