### PR TITLE
Add lift for creating RequestReaders where None represents failure

### DIFF
--- a/core/src/main/scala/io/finch/request/RequestReader.scala
+++ b/core/src/main/scala/io/finch/request/RequestReader.scala
@@ -103,6 +103,14 @@ trait PRequestReader[R, A] { self =>
   def withFilter(p: A => Boolean): PRequestReader[R, A] = self.should("not fail validation")(p)
 
   /**
+   * Lifts this request reader into one that always succeeds, with an empty option representing failure.
+   */
+  def lift: PRequestReader[R, Option[A]] = new PRequestReader[R, Option[A]] {
+    val item = self.item
+    def apply(req: R): Future[Option[A]] = self(req).liftToTry.map(_.toOption)
+  }
+
+  /**
    * Validates the result of this request reader using a `predicate`. The rule is used for error reporting.
    *
    * @param rule text describing the rule being validated

--- a/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
@@ -52,6 +52,11 @@ class RequestReaderValidationSpec extends FlatSpec with Matchers {
     a [RequestError] shouldBe thrownBy(Await.result(oddReader(request)))
   }
 
+  it should "be lift-able into an optional reader that always succeeds" in {
+    val oddReader = fooReader.should("be odd") { _ % 2 != 0 }
+    Await.result(oddReader.lift(request)) shouldBe None
+  }
+
   it should "allow valid values in a for-comprehension" in {
     val readFoo: RequestReader[Int] = for {
       foo <- fooReader if foo % 2 == 0


### PR DESCRIPTION
As discussed [on gitter](https://gitter.im/finagle/finch?at=553ef441f04b5ab74ce9ce31).