### PR TITLE
Use shields.io for slightly more consistent badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ close as possible to the bare metal Finagle API.
 
 Badges
 ------
-[![Build Status](https://travis-ci.org/finagle/finch.svg?branch=master)](https://travis-ci.org/finagle/finch)
-[![Coverage Status](https://coveralls.io/repos/finagle/finch/badge.svg?branch=master)](https://coveralls.io/r/finagle/finch?branch=master)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/finagle/finch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.finagle/finch_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.finagle/finch_2.11)
+[![Build Status](https://img.shields.io/travis/finagle/finch/master.svg)](https://travis-ci.org/finagle/finch)
+[![Coverage Status](https://img.shields.io/coveralls/finagle/finch/master.svg)](https://coveralls.io/r/finagle/finch?branch=master)
+[![Gitter](https://img.shields.io/badge/gitter-join%20chat-green.svg)](https://gitter.im/finagle/finch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.finagle/finch_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.finagle/finch_2.11)
 
 Modules
 -------


### PR DESCRIPTION
This is probably too trivial for words, but when coveralls is down (which is often), our badges look like this:

![screen shot 2015-04-29 at 6 02 13 am](https://cloud.githubusercontent.com/assets/316049/7391372/80a4c0ec-ee35-11e4-866e-d3c3ba904a7f.png)

If we switch to [shields.io](http://shields.io/) we could have this:

![screen shot 2015-04-29 at 6 02 39 am](https://cloud.githubusercontent.com/assets/316049/7391388/b4abb0a8-ee35-11e4-8771-2468ff8ba2a7.png)

The fact that the gitter badge is more consistent in size and style with the others is a nice bonus.