### PR TITLE
Aggregate coverage reports for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
-script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle
+script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 after_success: sbt ++$TRAVIS_SCALA_VERSION coveralls


### PR DESCRIPTION
It looks like we haven't had coverage reports on Coveralls since eab7aa0247d01b4b937010b13637d9ea2cb58e26. sbt-coveralls has been failing on our build because the reports haven't been aggregated, but its been failing silently because it now runs as an `after_script` on TravisCI. This PR aggregates the reports before trying to ship them to Coveralls.