### PR TITLE
Use DecodeRequest in Router

### DIFF
--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -252,4 +252,16 @@ class RouterSpec extends FlatSpec with Matchers {
     r(route1) shouldBe Some((Nil, "root"))
     r(route2) shouldBe Some((Nil, "foo"))
   }
+
+  it should "support path to string conversion" in {
+    val a = path.as[Int]
+    val b = path("id").as[Long]
+    val c = path
+    val d = path("name")
+
+    a.toString shouldBe ":int"
+    b.toString shouldBe ":id"
+    c.toString shouldBe ":string"
+    d.toString shouldBe ":name"
+  }
 }


### PR DESCRIPTION
The idea is to reuse the `DecodeRequest` type in `Router`. It's inspired by the idea that we will be able to compose request readers and routers together. So the new API looks much more consistent:

```scala
val a = Get / path.as[Int] ? param("id").as[Int]
// vs
val b = Get / int ? param("id").as[Int]
```

