### PR TITLE
Json4s encode/decode module implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Finch uses multi-project structure and contains of the following _modules_:
 * [`finch-jawn`](jawn) - the JSON API support for the [Jawn](https://github.com/non/jawn) library
 * [`finch-argonaut`](argonaut) - the JSON API support for the [Argonaut](http://argonaut.io/) library
 * [`finch-jackson`](jackson) - the JSON API support for the [Jackson](http://jackson.codehaus.org/) library
+* [`finch-json4s`](json4s) - the JSON API support for the [JSON4S](http://json4s.org/) library
 
 Installation
 ------------

--- a/build.sbt
+++ b/build.sbt
@@ -155,6 +155,16 @@ lazy val jackson = project
   .dependsOn(core)
   .disablePlugins(CoverallsPlugin)
 
+lazy val json4s = project
+  .settings(moduleName := "finch-json4s")
+  .settings(allSettings)
+  .settings(libraryDependencies ++= Seq(
+    "org.json4s" %% "json4s-jackson" % "3.2.11",
+    "org.json4s" %% "json4s-ext" % "3.2.11")
+  )
+  .dependsOn(core)
+  .disablePlugins(CoverallsPlugin)
+
 lazy val auth = project
   .settings(moduleName := "finch-auth")
   .settings(allSettings)

--- a/docs/json.md
+++ b/docs/json.md
@@ -49,7 +49,21 @@ val ok: HttpResponse = Ok(Foo(10, "foo")) // will be encoded as JSON
 val foo: RequestReader[Foo] = body.as[Foo] // a request reader that reads Foo
 ```
 
+### Json4s
+
+The `finch-json4s` module provides the support for the [JSON4S][7] library. The library usage looks as follows:
+
+```scala
+import io.finch.json4s._
+implicit val formats = DefaultFormats ++ JodaTimeSerializers.all
+case class Bar(x: Int, y: Boolean)
+
+val ok: HttpResponse = Ok(Bar(1, true)) // will be encoded as JSON
+val foo: RequestReader[Bar] = body.as[Bar] // a request reader that reads Bar
+```
+
 [3]: https://github.com/finagle/finch/blob/master/json/src/main/scala/io/finch/json/Json.scala
 [4]: http://argonaut.io
 [5]: https://github.com/non/jawn
 [6]: http://jackson.codehaus.org/
+[7]: http://json4s.org/

--- a/json4s/README.md
+++ b/json4s/README.md
@@ -1,0 +1,15 @@
+The `finch-json4s` module provides the Finch library a support for the [JSON4S](http://json4s.org/) library.
+
+Installation
+------------
+Use the following _sbt_ snippet:
+
+```scala
+libraryDependencies ++= Seq(
+  "com.github.finagle" %% "finch-json4s" % "0.6.0"
+)
+```
+
+Documentation
+-------------
+See section [Json4s](/docs/json.md#json4s).

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -1,0 +1,30 @@
+package io.finch
+
+import com.twitter.util.Try
+import io.finch.request.DecodeRequest
+import io.finch.response.EncodeResponse
+import org.json4s._
+import org.json4s.jackson.JsonMethods
+import org.json4s.jackson.Serialization._
+
+package object json4s {
+
+  /**
+   * @param formats json4s `Formats` to use for decoding
+   * @tparam A the type of data to decode into
+   */
+  //@TODO get rid of Manifest as soon as json4s migrates to new reflection API
+  implicit def decodeJson[A : Manifest](implicit formats: Formats): DecodeRequest[A] = DecodeRequest(
+    input => Try(JsonMethods.parse(input).extract[A])
+  )
+
+  /**
+   * @param formats json4s `Formats` to use for decoding
+   * @tparam A the type of data to encode
+   * @return
+   */
+  implicit def encodeJson[A <: AnyRef](implicit formats: Formats): EncodeResponse[A] = EncodeResponse("application/json") { out: A =>
+    write(out)
+  }
+
+}

--- a/json4s/src/test/scala/io/finch/json4s/Bar.scala
+++ b/json4s/src/test/scala/io/finch/json4s/Bar.scala
@@ -1,0 +1,3 @@
+package io.finch.json4s
+
+case class Bar(x: Int, y: Boolean)

--- a/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
@@ -1,0 +1,63 @@
+package io.finch.json4s
+
+import com.twitter.finagle.httpx.Request
+import com.twitter.io.Buf.Utf8
+import com.twitter.util.{Await, Future, Return}
+import io.finch.request.RequestReader
+import io.finch.request._
+import io.finch.response._
+import org.json4s.DefaultFormats
+import org.json4s.ext.JodaTimeSerializers
+import org.scalatest.{Matchers, FlatSpec}
+
+class Json4sSpec extends FlatSpec with Matchers{
+
+  implicit val formats = DefaultFormats ++ JodaTimeSerializers.all
+
+  private def bar = Bar(1, true)
+  private def barJson = """{"x":1,"y":true}"""
+
+  "Json4sEncode" should "encode a case class into JSON" in {
+    encodeJson[Bar].apply(bar) shouldBe barJson
+  }
+
+  it should "decode a case class from JSON" in {
+    decodeJson[Bar].apply(barJson) shouldBe Return(bar)
+  }
+
+  it should "fail given invalid JSON" in {
+    val invalidJson = """{"x": {, "y": true}"""
+    decodeJson[Bar].apply(invalidJson).isThrow shouldBe true
+  }
+
+  it should "work w/o exceptions with ResponseBuilder" in {
+    Ok(bar).getContentString() shouldBe barJson
+  }
+
+  it should "work with higher kinded types" in {
+    val list = List(1, 2, 3)
+    val encode = encodeJson[List[Int]]
+    val decode = decodeJson[List[Int]]
+
+    encode(list) shouldBe "[1,2,3]"
+    decode("[1,2,3]") shouldBe Return(List(1, 2, 3))
+  }
+
+  it should "work w/o exceptions with RequestReader" in {
+    val b = Utf8(barJson)
+    val req = Request()
+    req.setContentTypeJson()
+    req.contentLength = b.length
+    req.content = b
+
+    val rFoo: RequestReader[Bar] = body.as[Bar]
+    val foo: Future[Bar] = body.as[Bar].apply(req)
+    val roFoo: RequestReader[Option[Bar]] = bodyOption.as[Bar]
+    val oFoo: Future[Option[Bar]] = bodyOption.as[Bar].apply(req)
+
+    Await.result(rFoo(req)) shouldBe bar
+    Await.result(foo) shouldBe bar
+    Await.result(roFoo(req)) shouldBe Some(bar)
+    Await.result(oFoo) shouldBe Some(bar)
+  }
+}


### PR DESCRIPTION
We are using json4s in our project since it provides powerful functional API to operate with AST and some neat extensions (mongo objectid, joda date time (de)serialization).

I suppose it would be useful to have this module like an optional one.