### PR TITLE
Begin to abstract JSON testing tools

### DIFF
--- a/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
@@ -1,69 +1,29 @@
 package io.finch.argonaut
 
-import argonaut.Argonaut._
 import argonaut._
-import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.Request
-import com.twitter.util.{Await,Return}
-import io.finch._
-import io.finch.request._
-import io.finch.response.TurnIntoHttp
-import org.jboss.netty.handler.codec.http.HttpHeaders
+import argonaut.Argonaut._
+import io.finch.test.json._
+import org.scalatest.prop.Checkers
 import org.scalatest.{FlatSpec, Matchers}
 
-object ArgonautSpec {
-  case class TestUser(id: Int, name: String)
+class ArgonautSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
 
-  // This codec could also be made implicit
-  def testUserCodec: CodecJson[TestUser] = casecodec2(TestUser.apply, TestUser.unapply)("id", "name")
+  implicit val exampleCaseClassCodecJson: CodecJson[ExampleCaseClass] =
+    casecodec3(ExampleCaseClass.apply, ExampleCaseClass.unapply)("a", "b", "c")
 
-  implicit def encodeTestUser: EncodeJson[TestUser] =
-    EncodeJson((user: TestUser) => ("name" := user.name) ->: ("id" := user.id) ->: jEmptyObject)
+ implicit val exampleNestedCaseClassCodecJson: CodecJson[ExampleNestedCaseClass] =
+    casecodec5(ExampleNestedCaseClass.apply, ExampleNestedCaseClass.unapply)(
+      "string",
+      "double",
+      "long",
+      "ints",
+      "example"
+    )
 
-  implicit def decodeTestUser: DecodeJson[TestUser] =
-    DecodeJson(c => for {
-      name <- (c --\ "name").as[String]
-      id   <- (c --\ "id").as[Int]
-    } yield TestUser(id, name))
-}
-
-class ArgonautSpec extends FlatSpec with Matchers {
-  import io.finch.argonaut.ArgonautSpec._
-
-  val str = "{\"id\":42,\"name\":\"bob\"}"
-  val badJson = "{\"id\":42"
-  val invalidStructure = "{\"id\":42}"
-  val exampleUser = TestUser(42, "bob")
-
-  "An ArgonautDecode" should "decode json string into a data structure" in {
-    decodeArgonaut(testUserCodec)(str) shouldBe Return(exampleUser)
-  }
-
-  it should "fail if the string is not valid json" in {
-    decodeArgonaut(testUserCodec)(badJson).isThrow shouldBe true
-  }
-
-  it should "fail if the decoder could not decode the string into data" in {
-    decodeArgonaut(testUserCodec)(invalidStructure).isThrow shouldBe true
-  }
-
-  it should "be compatible with finch-core's requests" in {
-    val req = Request()
-    req.setContentString(str)
-    req.setContentTypeJson()
-    req.headerMap.update(HttpHeaders.Names.CONTENT_LENGTH, str.length.toString)
-
-    val user: TestUser = Await.result(body.as[TestUser].apply(req))
-    user shouldBe exampleUser
-  }
-
-  "An ArgonautEncode" should "encode a data structure into a json string" in {
-    encodeArgonaut(testUserCodec)(exampleUser) shouldBe str
-  }
-
-  it should "be compatible with finch-core's responses" in {
-    val service: Service[TestUser, HttpResponse] = TurnIntoHttp[TestUser]
-    val result = Await.result(service(exampleUser))
-    result.getContentString() shouldBe str
-  }
+  "The Argonaut codec provider" should "encode a case class as JSON" in encodeNestedCaseClass
+  it should "decode a case class from JSON" in decodeNestedCaseClass
+  it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson
+  it should "encode a list of case class instances as JSON" in encodeCaseClassList
+  it should "decode a list of case class instances from JSON" in decodeCaseClassList
+  it should "provide encoders with the correct content type" in checkContentType
 }

--- a/build.sbt
+++ b/build.sbt
@@ -22,14 +22,17 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
+val testDependencies = Seq(
+  "org.scalacheck" %% "scalacheck" % "1.12.2",
+  "org.scalatest" %% "scalatest" % "2.2.4"
+)
+
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
     "com.chuusai" %% "shapeless" % "2.2.0-RC5",
     "com.twitter" %% "finagle-httpx" % "6.25.0",
-    "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
-  ),
+  ) ++ testDependencies.map(_ % "test"),
   scalacOptions ++= compilerOptions ++ (
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 11)) => Seq("-Ywarn-unused-import")
@@ -107,6 +110,15 @@ lazy val core = project
   .settings(moduleName := "finch-core")
   .settings(allSettings)
 
+lazy val test = project
+  .settings(moduleName := "finch-test")
+  .settings(allSettings)
+  .settings(coverageExcludedPackages := "io\\.finch\\.test\\..*")
+  .settings(
+    libraryDependencies ++= "io.argonaut" %% "argonaut" % "6.1" +: testDependencies
+  )
+  .dependsOn(core)
+
 lazy val json = project
   .settings(moduleName := "finch-json")
   .settings(allSettings)
@@ -140,13 +152,13 @@ lazy val argonaut = project
   .settings(moduleName := "finch-argonaut")
   .settings(allSettings)
   .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1")
-  .dependsOn(core)
+  .dependsOn(core, test % "test")
 
 lazy val jackson = project
   .settings(moduleName := "finch-jackson")
   .settings(allSettings)
   .settings(libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.2")
-  .dependsOn(core)
+  .dependsOn(core, test % "test")
 
 lazy val json4s = project
   .settings(moduleName := "finch-json4s")
@@ -155,7 +167,7 @@ lazy val json4s = project
     "org.json4s" %% "json4s-jackson" % "3.2.11",
     "org.json4s" %% "json4s-ext" % "3.2.11")
   )
-  .dependsOn(core)
+  .dependsOn(core, test % "test")
 
 lazy val auth = project
   .settings(moduleName := "finch-auth")

--- a/core/src/main/scala/io/finch/request/package.scala
+++ b/core/src/main/scala/io/finch/request/package.scala
@@ -531,10 +531,10 @@ package object request extends LowPriorityRequestReaderImplicits {
     def apply(req: String): Try[A]
   }
 
-  /**
-   * Convenience method for creating new [[io.finch.request.DecodeRequest DecodeRequest]] instances.
-   */
   object DecodeRequest {
+    /**
+     * Convenience method for creating new [[io.finch.request.DecodeRequest DecodeRequest]] instances.
+     */
     def apply[A](f: String => Try[A]): DecodeRequest[A] = new DecodeRequest[A] {
       def apply(value: String): Try[A] = f(value)
     }

--- a/core/src/main/scala/io/finch/response/package.scala
+++ b/core/src/main/scala/io/finch/response/package.scala
@@ -155,10 +155,10 @@ package object response {
     def contentType: String
   }
 
-  /**
-   * Convenience method for creating new [[io.finch.response.EncodeResponse EncodeResponse]] instances.
-   */
   object EncodeResponse {
+    /**
+     * Convenience method for creating new [[io.finch.response.EncodeResponse EncodeResponse]] instances.
+     */
     def apply[A](ct: String)(fn: A => String): EncodeResponse[A] = new EncodeResponse[A] {
       def apply(rep: A): String = fn(rep)
       def contentType: String = ct

--- a/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
@@ -1,63 +1,17 @@
 package io.finch.json4s
 
-import com.twitter.finagle.httpx.Request
-import com.twitter.io.Buf.Utf8
-import com.twitter.util.{Await, Future, Return}
-import io.finch.request.RequestReader
-import io.finch.request._
-import io.finch.response._
+import io.finch.test.json.JsonCodecProviderProperties
 import org.json4s.DefaultFormats
-import org.json4s.ext.JodaTimeSerializers
+import org.scalatest.prop.Checkers
 import org.scalatest.{Matchers, FlatSpec}
 
-class Json4sSpec extends FlatSpec with Matchers{
+class Json4sSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
+  implicit val formats = DefaultFormats
 
-  implicit val formats = DefaultFormats ++ JodaTimeSerializers.all
-
-  private def bar = Bar(1, true)
-  private def barJson = """{"x":1,"y":true}"""
-
-  "Json4sEncode" should "encode a case class into JSON" in {
-    encodeJson[Bar].apply(bar) shouldBe barJson
-  }
-
-  it should "decode a case class from JSON" in {
-    decodeJson[Bar].apply(barJson) shouldBe Return(bar)
-  }
-
-  it should "fail given invalid JSON" in {
-    val invalidJson = """{"x": {, "y": true}"""
-    decodeJson[Bar].apply(invalidJson).isThrow shouldBe true
-  }
-
-  it should "work w/o exceptions with ResponseBuilder" in {
-    Ok(bar).getContentString() shouldBe barJson
-  }
-
-  it should "work with higher kinded types" in {
-    val list = List(1, 2, 3)
-    val encode = encodeJson[List[Int]]
-    val decode = decodeJson[List[Int]]
-
-    encode(list) shouldBe "[1,2,3]"
-    decode("[1,2,3]") shouldBe Return(List(1, 2, 3))
-  }
-
-  it should "work w/o exceptions with RequestReader" in {
-    val b = Utf8(barJson)
-    val req = Request()
-    req.setContentTypeJson()
-    req.contentLength = b.length
-    req.content = b
-
-    val rFoo: RequestReader[Bar] = body.as[Bar]
-    val foo: Future[Bar] = body.as[Bar].apply(req)
-    val roFoo: RequestReader[Option[Bar]] = bodyOption.as[Bar]
-    val oFoo: Future[Option[Bar]] = bodyOption.as[Bar].apply(req)
-
-    Await.result(rFoo(req)) shouldBe bar
-    Await.result(foo) shouldBe bar
-    Await.result(roFoo(req)) shouldBe Some(bar)
-    Await.result(oFoo) shouldBe Some(bar)
-  }
+  "The Json4s codec provider" should "encode a case class as JSON" in encodeNestedCaseClass
+  it should "decode a case class from JSON" in decodeNestedCaseClass
+  it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson
+  it should "encode a list of case class instances as JSON" in encodeCaseClassList
+  it should "decode a list of case class instances from JSON" in decodeCaseClassList
+  it should "provide encoders with the correct content type" in checkContentType
 }


### PR DESCRIPTION
There's currently a lot of duplication and inconsistency across the tests for the `argonaut`, `json4s`, and `jackson` projects, and the tests that are in place now only validate a few hand-rolled cases. Testing against JSON strings is also fragile, since most libraries don't make guarantees about the order of fields in objects, and since our API doesn't make any guarantees about whitespace (at least I think it doesn't?).

This PR is a quick sketch of some abstractions that allow us to test most (or all) of the functionality of these subprojects in a few lines:

```
"The Argonaut codec provider" should "encode a case class instance as JSON" in encodeFoo
it should "decode a case class instance from JSON" in decodeFoo
it should "encode a list of case class instances as JSON" in encodeFooList
it should "decode a list of case class instances from JSON" in decodeFooList
```

I haven't removed any of the existing tests, although a lot of them are redundant now. If other people are interested in this approach I can do that clean-up, etc.

I've also done a bit of minor rearranging in the `argonaut` tests.