### PR TITLE
Fix 249: Shapeless-powered Router

### DIFF
--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -22,9 +22,6 @@
 
 package io
 
-import com.twitter.finagle.httpx.path.Path
-import io.finch.response.{Ok, EncodeResponse}
-
 import com.twitter.finagle.httpx
 import com.twitter.util.Future
 import com.twitter.finagle.Service

--- a/core/src/main/scala/io/finch/route/Router0.scala
+++ b/core/src/main/scala/io/finch/route/Router0.scala
@@ -121,3 +121,24 @@ object ** extends Router0 {
   def apply(route: Route): Option[Route] = Some(Nil)
   override def toString = "**"
 }
+
+object Router0 {
+
+  /**
+   * Implicit class that provides `::` on any [[Router0]] to support building HList routers.
+   */
+  final implicit class ValueRouter0Ops[B](self: B)(implicit ev: B => Router0) {
+
+    /**
+     * Composes this [[Router0]] with the given `that` [[RouterN]] in terms of logical **and**.
+     */
+    def ::[A](that: RouterN[A]): RouterN[A] =
+      that.andThen(self)
+
+    /**
+     * Composes this [[Router0]] with the given `that` [[Router0]] in terms of logical **and**.
+     */
+    def ::(that: Router0): Router0 =
+      that.andThen(self)
+  }
+}

--- a/core/src/main/scala/io/finch/route/RouterN.scala
+++ b/core/src/main/scala/io/finch/route/RouterN.scala
@@ -28,6 +28,7 @@ import io.finch._
 import io.finch.request._
 import io.finch.response._
 import shapeless._
+import shapeless.ops.function.FnToProduct
 
 /**
  * A router that extracts some value of the type `A` from the given route.
@@ -176,6 +177,10 @@ object RouterN {
    * Implicit class that provides `:+:` and other operations on any coproduct router.
    */
   final implicit class CoproductRouterNOps[C <: Coproduct](self: RouterN[C]) {
+
+    /**
+     * Composes this [[RouterN]] with the given `that` [[RouterN]] in term of logical **or**.
+     */
     def :+:[A](that: RouterN[A]): RouterN[A :+: C] =
       new RouterN[A :+: C] {
         def apply(route: Route): Option[(Route, A :+: C)] =
@@ -194,9 +199,13 @@ object RouterN {
   }
 
   /**
-   * Implicit class that provides `:+:` on any router.
+   * Implicit class that provides `:+:` and `::` on any router.
    */
   final implicit class ValueRouterNOps[B](self: RouterN[B]) {
+
+    /**
+     * Composes this [[RouterN]] with the given `that` [[RouterN]] in term of logical **or**.
+     */
     def :+:[A](that: RouterN[A]): RouterN[A :+: B :+: CNil] =
       new RouterN[A :+: B :+: CNil] {
         def apply(route: Route): Option[(Route, A :+: B :+: CNil)] =
@@ -212,6 +221,42 @@ object RouterN {
 
         override def toString = s"(${that.toString}|${self.toString})"
       }
+
+    /**
+     * Composes this [[RouterN]] with the given `that` [[RouterN]] in terms of logical **and**.
+     */
+    def ::[A](that: RouterN[A]): RouterN[A :: B :: HNil] =
+      that :: self.map(_ :: HNil)
+
+    /**
+     * Composes this [[RouterN]] with the given `that` [[RouterN]] in terms of logical **and**.
+     */
+    def ::(that: Router0): RouterN[B] =
+      that.andThen(self)
+  }
+
+  /**
+   * Implicit class that provides `::` on any HList router.
+   */
+  final implicit class HListRouterNOps[L <: HList](val self: RouterN[L]) {
+
+    /**
+     * Composes this [[RouterN]] with the given `that` [[RouterN]] in terms of logical **and**.
+     */
+    def ::[A](that: RouterN[A]): RouterN[A :: L] =
+      for { a <- that; b <- self } yield a :: b
+
+    /**
+     * Composes this [[RouterN]] with the given `that` [[Router0]] in terms of logical **and**.
+     */
+    def ::(that: Router0): RouterN[L] =
+      that.andThen(self)
+
+    /**
+     * Applies a `FunctionN` with the appropriate arity and types to the elements of this [[shapeless.HList]].
+     */
+    def />[F, I](fn: F)(implicit ftp: FnToProduct.Aux[F, L => I]): RouterN[I] =
+      self.map(ftp(fn))
   }
 
   /**

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -298,4 +298,23 @@ class RouterSpec extends FlatSpec with Matchers {
 
     Await.result(s(httpx.Request("/foo"))).contentString shouldBe Ok("bar").contentString
   }
+
+  it should "be viewable as HList Router" in {
+    val ins: (Int, String) => Boolean = (_, _) => true
+
+    val r1: Router[Boolean] = (Get :: int :: string) /> ins
+    val r2: Router[String] =
+      (Get :: "foo" :: int :: 123 :: string) /> { (i: Int, s: String) =>
+        s + i
+      }
+    val r3: Router[Int] = "foo" :: "bar" :: 123 :: int
+
+    val route1 = List(MethodToken(Method.Get), PathToken("123"), PathToken("foo"))
+    val route2 = List(MethodToken(Method.Get), PathToken("foo"), PathToken("123"), PathToken("123"), PathToken("foo"))
+    val route3 = List(PathToken("foo"), PathToken("bar"), PathToken("123"), PathToken("123"))
+
+    r1(route1) shouldBe Some((Nil, true))
+    r2(route2) shouldBe Some((Nil, "foo123"))
+    r3(route3) shouldBe Some((Nil, 123))
+  }
 }


### PR DESCRIPTION
This work is in progress. I haven't deprecated the `/` type yet, but planning to do so. I was trying to follow the style/ideas @travisbrown used for request readers.

I added just one test for now.