### PR TITLE
Add sketch of coproduct endpoints

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/model.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/model.scala
@@ -25,7 +25,7 @@ class UserDb {
 
   def all: Future[List[User]] = Future.value(users.synchronized(users.values.toList))
 
-  def delete: Future[Int] = Future.value(
+  def delete(): Future[Int] = Future.value(
     users.synchronized {
       val count = users.size
       users.clear()

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
@@ -30,29 +30,26 @@ class FinchUserService(implicit
 
   def allUsers: Service[HttpRequest, List[User]] = Service.const(db.all)
 
-  val createUser: Service[HttpRequest, Long] = Service.mk { req =>
+  val createUser: Service[HttpRequest, HttpResponse] = Service.mk { req =>
     for {
       NewUserInfo(name, age) <- body.as[NewUserInfo].apply(req)
-      user <- db.add(name, age)
-    } yield user
+      id <- db.add(name, age)
+    } yield Created.withHeaders("Location" -> s"/users/$id")()
   }
 
-  val updateUser: Service[HttpRequest, Unit] = Service.mk { req =>
-    body.as[User].apply(req).flatMap(db.update)
+  val updateUser: Service[HttpRequest, HttpResponse] = Service.mk { req =>
+    body.as[User].apply(req).flatMap(db.update).map(_ => NoContent())
   }
 
-  def deleteUsers: Service[HttpRequest, Int] = Service.const(db.delete)
-
-  def toHttp[A](f: A => HttpResponse): Service[A, HttpResponse] = Service.mk(a => f(a).toFuture)
+  def deleteUsers: Service[HttpRequest, HttpResponse] =
+    Service.const(db.delete().map(count => Ok(s"$count users deleted")))
 
   val users: Endpoint[HttpRequest, HttpResponse] =
-    (Get / "users" / long /> getUser).map(_ ! toHttp(Ok(_))) |
-    (Get / "users" /> allUsers).map(_ ! toHttp(Ok(_))) |
-    (Post / "users" /> createUser).map(
-      _ ! toHttp(id => Created.withHeaders("Location" -> s"/users/$id")())
-    ) |
-    (Put / "users" /> updateUser).map(_ ! toHttp(_ => NoContent())) |
-    (Delete / "users" /> deleteUsers).map(_ ! toHttp(count => Ok(s"$count users deleted")))
+    Get    / "users" / long /> getUser :|:
+    Get    / "users" /> allUsers       :|:
+    Post   / "users" /> createUser     :|:
+    Put    / "users" /> updateUser     :|:
+    Delete / "users" /> deleteUsers
 
   val handleExceptions = new SimpleFilter[HttpRequest, HttpResponse] {
     def apply(req: HttpRequest, service: Service[HttpRequest, HttpResponse]): Future[HttpResponse] =

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -99,10 +99,10 @@ object Demo {
   }
 
   // An API endpoint.
-  val api: Service[AuthRequest, ToJson] = users | tickets
+  val api: Service[AuthRequest, Json] = users | tickets
 
   // An HTTP endpoint with exception handler and Auth filter.
   val backend: Service[HttpRequest, HttpResponse] =
-    handleExceptions ! authorize ! (api ! TurnModelIntoJson ! TurnIntoHttp[Json])
+    handleExceptions ! authorize ! (api ! TurnIntoHttp[Json])
 
 }

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -99,10 +99,9 @@ object Demo {
   }
 
   // An API endpoint.
-  val api: Service[AuthRequest, Json] = users | tickets
+  val api: Endpoint[AuthRequest, HttpResponse] = users | tickets
 
   // An HTTP endpoint with exception handler and Auth filter.
   val backend: Service[HttpRequest, HttpResponse] =
-    handleExceptions ! authorize ! (api ! TurnIntoHttp[Json])
-
+    handleExceptions ! authorize ! api
 }

--- a/demo/src/main/scala/io/finch/demo/endpoint.scala
+++ b/demo/src/main/scala/io/finch/demo/endpoint.scala
@@ -25,27 +25,23 @@ package io.finch.demo
 import argonaut.{EncodeJson, Json}
 import com.twitter.finagle.Service
 import com.twitter.util.Future
+import io.finch.HttpResponse
+import io.finch.argonaut._
+import io.finch.demo.model.Ticket
+import io.finch.response._
 import io.finch.route._
 
 object endpoint {
 
   import service._
 
-  implicit class JsonEndpoint[Req, Rep](endpoint: Endpoint[Req, Rep]) {
-    def toJson(implicit encoding: EncodeJson[Rep]): Endpoint[Req, Json] = endpoint.map { service =>
-      new Service[Req, Json] {
-        def apply(req: Req): Future[Json] = service(req).map(encoding(_))
-      }
-    }
-  }
-
   // User endpoint.
-  val users: Endpoint[AuthRequest, Json] =
-    (Get / "users" / long /> GetUser).toJson |
-    (Post / "users" /> PostUser).toJson |
-    (Get / "users" /> GetAllUsers).toJson
+  val users: Endpoint[AuthRequest, HttpResponse] =
+    Get / "users" / long /> GetUser :|:
+    Post / "users" /> PostUser      :|:
+    Get / "users" /> GetAllUsers
 
   // Ticket endpoint.
-  val tickets: Endpoint[AuthRequest, Json] =
-    (Post / "users" / long / "tickets" /> PostUserTicket).toJson
+  val tickets: Endpoint[AuthRequest, Ticket] =
+    Post / "users" / long / "tickets" /> PostUserTicket
 }

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -66,7 +66,7 @@ package object demo {
     private val map = new ConcurrentHashMap[Long, User]().asScala
 
     def select(id: Long): Future[Option[User]] = map.get(id).toFuture
-    def all: Future[Seq[User]] = map.values.toSeq.toFuture
+    def all: Future[Users] = new Users(map.values.toList).toFuture
     def insert(id: Long, u: User): Future[User] = {
       map += (id -> u)
       u.toFuture

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -66,7 +66,7 @@ package object demo {
     private val map = new ConcurrentHashMap[Long, User]().asScala
 
     def select(id: Long): Future[Option[User]] = map.get(id).toFuture
-    def all: Future[Users] = new Users(map.values.toList).toFuture
+    def all: Future[List[User]] = map.values.toList.toFuture
     def insert(id: Long, u: User): Future[User] = {
       map += (id -> u)
       u.toFuture

--- a/demo/src/main/scala/io/finch/demo/service.scala
+++ b/demo/src/main/scala/io/finch/demo/service.scala
@@ -22,8 +22,9 @@
 
 package io.finch.demo
 
-import com.twitter.util.Future
+import argonaut._, Argonaut._
 import com.twitter.finagle.Service
+import com.twitter.util.Future
 
 import io.finch._
 
@@ -42,8 +43,8 @@ object service {
   }
 
   // A REST service that fetches all users.
-  object GetAllUsers extends Service[AuthRequest, Seq[User]] {
-    def apply(req: AuthRequest): Future[Seq[User]] = Db.all
+  object GetAllUsers extends Service[AuthRequest, Users] {
+    def apply(req: AuthRequest): Future[Users] = Db.all
   }
 
   // A REST service that inserts a new user with `userId`.

--- a/demo/src/main/scala/io/finch/demo/service.scala
+++ b/demo/src/main/scala/io/finch/demo/service.scala
@@ -22,7 +22,6 @@
 
 package io.finch.demo
 
-import argonaut._, Argonaut._
 import com.twitter.finagle.Service
 import com.twitter.util.Future
 
@@ -43,8 +42,8 @@ object service {
   }
 
   // A REST service that fetches all users.
-  object GetAllUsers extends Service[AuthRequest, Users] {
-    def apply(req: AuthRequest): Future[Users] = Db.all
+  object GetAllUsers extends Service[AuthRequest, List[User]] {
+    def apply(req: AuthRequest): Future[List[User]] = Db.all
   }
 
   // A REST service that inserts a new user with `userId`.


### PR DESCRIPTION
I'm super unsatisfied with this, but I've been through so many iterations that I just want to get something up so I can continue iterating in public at least.

I've included the commits made and mentioned in @penland365's #258, since I wanted to show off the new syntax in the demo project. I've also updated the service benchmark to use `:|:`, and the results look about the same (I'm rerunning with `-prof gc` now).

As a quick overview of usage, you write something like this:

``` scala
val users: Endpoint[HttpRequest, HttpResponse] =
  Get    / "users" / long /> getUser :|:
  Get    / "users" /> allUsers       :|:
  Post   / "users" /> createUser     :|:
  Put    / "users" /> updateUser     :|:
  Delete / "users" /> deleteUsers
```

And if all of the composed endpoints return either `Response` or something with an `EncodeResponse` instance, you'll get a service-able endpoint. Notably the types of the individual endpoints don't have to all be the same.