### PR TITLE
Disable JMH plugin for non-benchmark projects with main classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ lazy val demo = project
   .settings(moduleName := "finch-demo")
   .settings(allSettings)
   .settings(noPublish)
+  .disablePlugins(JmhPlugin)
   .dependsOn(core, argonaut)
 
 lazy val playground = project
@@ -135,6 +136,7 @@ lazy val playground = project
   .settings(allSettings)
   .settings(noPublish)
   .settings(coverageExcludedPackages := "io\\.finch\\.playground\\..*")
+  .disablePlugins(JmhPlugin)
   .dependsOn(core, jackson)
 
 lazy val jawn = project


### PR DESCRIPTION
Fixes #271. Sorry, that was my fault—didn't realize the JMH plugin would try to instrument classes that didn't have benchmarks in them. Now `sbt demo/run` and `sbt playground/run` both work.