### PR TITLE
Consider using codecov.io instead of coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
-after_success: sbt ++$TRAVIS_SCALA_VERSION coveralls
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ close as possible to the bare metal Finagle API.
 Badges
 ------
 [![Build Status](https://img.shields.io/travis/finagle/finch/master.svg)](https://travis-ci.org/finagle/finch)
-[![Coverage Status](https://img.shields.io/coveralls/finagle/finch/master.svg)](https://coveralls.io/r/finagle/finch?branch=master)
+[![Coverage Status](https://img.shields.io/codecov/c/github/codecov/finagle/finch/master.svg)](https://codecov.io/github/finagle/finch)
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat-green.svg)](https://gitter.im/finagle/finch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.finagle/finch_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.finagle/finch_2.11)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")


### PR DESCRIPTION
I've been becoming increasingly frustrated with coveralls. It has some uptime issues, doesn't always pick up reports, and the tooling is not great. codecov.io seems to have more features and a really slick browser plugin that integrates coverage data right onto github. It also seems to have taken some initiative on the tooling front and doesn't require you to conform to their api, they transform standard scoverage reports to work in their system (which means we have one less plugin to rely on and thus one less point of failure). I can't speak to the uptime yet because I haven't been using it very long.

I think we should consider moving in a version or two, especially if we keep having issues with coveralls. I'd encourage you to look at [this branch](https://codecov.io/github/rpless/finch?branch=codecov-test) on my fork and let me know what you think. Also definitely check out the browser plugin.