### PR TITLE
Add coproduct routers

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/model.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/model.scala
@@ -25,7 +25,7 @@ class UserDb {
 
   def all: Future[List[User]] = Future.value(users.synchronized(users.values.toList))
 
-  def delete: Future[Int] = Future.value(
+  def delete(): Future[Int] = Future.value(
     users.synchronized {
       val count = users.size
       users.clear()

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
@@ -30,29 +30,26 @@ class FinchUserService(implicit
 
   def allUsers: Service[HttpRequest, List[User]] = Service.const(db.all)
 
-  val createUser: Service[HttpRequest, Long] = Service.mk { req =>
+  val createUser: Service[HttpRequest, HttpResponse] = Service.mk { req =>
     for {
       NewUserInfo(name, age) <- body.as[NewUserInfo].apply(req)
-      user <- db.add(name, age)
-    } yield user
+      id <- db.add(name, age)
+    } yield Created.withHeaders("Location" -> s"/users/$id")()
   }
 
-  val updateUser: Service[HttpRequest, Unit] = Service.mk { req =>
-    body.as[User].apply(req).flatMap(db.update)
+  val updateUser: Service[HttpRequest, HttpResponse] = Service.mk { req =>
+    body.as[User].apply(req).flatMap(db.update).map(_ => NoContent())
   }
 
-  def deleteUsers: Service[HttpRequest, Int] = Service.const(db.delete)
-
-  def toHttp[A](f: A => HttpResponse): Service[A, HttpResponse] = Service.mk(a => f(a).toFuture)
+  def deleteUsers: Service[HttpRequest, HttpResponse] =
+    Service.const(db.delete().map(count => Ok(s"$count users deleted")))
 
   val users: Endpoint[HttpRequest, HttpResponse] =
-    (Get / "users" / long /> getUser).map(_ ! toHttp(Ok(_))) |
-    (Get / "users" /> allUsers).map(_ ! toHttp(Ok(_))) |
-    (Post / "users" /> createUser).map(
-      _ ! toHttp(id => Created.withHeaders("Location" -> s"/users/$id")())
-    ) |
-    (Put / "users" /> updateUser).map(_ ! toHttp(_ => NoContent())) |
-    (Delete / "users" /> deleteUsers).map(_ ! toHttp(count => Ok(s"$count users deleted")))
+    Get    / "users" / long /> getUser :|:
+    Get    / "users" /> allUsers       :|:
+    Post   / "users" /> createUser     :|:
+    Put    / "users" /> updateUser     :|:
+    Delete / "users" /> deleteUsers
 
   val handleExceptions = new SimpleFilter[HttpRequest, HttpResponse] {
     def apply(req: HttpRequest, service: Service[HttpRequest, HttpResponse]): Future[HttpResponse] =

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
@@ -45,10 +45,10 @@ class FinchUserService(implicit
     Service.const(db.delete().map(count => Ok(s"$count users deleted")))
 
   val users: Endpoint[HttpRequest, HttpResponse] =
-    Get    / "users" / long /> getUser :|:
-    Get    / "users" /> allUsers       :|:
-    Post   / "users" /> createUser     :|:
-    Put    / "users" /> updateUser     :|:
+    Get    / "users" / long /> getUser :+:
+    Get    / "users" /> allUsers       :+:
+    Post   / "users" /> createUser     :+:
+    Put    / "users" /> updateUser     :+:
     Delete / "users" /> deleteUsers
 
   val handleExceptions = new SimpleFilter[HttpRequest, HttpResponse] {

--- a/build.sbt
+++ b/build.sbt
@@ -24,12 +24,12 @@ lazy val compilerOptions = Seq(
 
 val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.12.2",
-  "org.scalatest" %% "scalatest" % "2.2.4"
+  "org.scalatest" %% "scalatest" % "2.2.5"
 )
 
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.chuusai" %% "shapeless" % "2.2.0-RC5",
+    "com.chuusai" %% "shapeless" % "2.2.0",
     "com.twitter" %% "finagle-httpx" % "6.25.0",
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ) ++ testDependencies.map(_ % "test"),
@@ -144,8 +144,8 @@ lazy val jawn = project
   .settings(allSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.spire-math" %% "jawn-parser" % "0.7.2",
-      "org.spire-math" %% "jawn-ast" % "0.7.2"
+      "org.spire-math" %% "jawn-parser" % "0.7.4",
+      "org.spire-math" %% "jawn-ast" % "0.7.4"
     )
   )
   .dependsOn(core)

--- a/core/src/main/scala/io/finch/request/ToRequest.scala
+++ b/core/src/main/scala/io/finch/request/ToRequest.scala
@@ -1,0 +1,25 @@
+package io.finch.request
+
+import io.finch.HttpRequest
+
+/**
+ * A type class that provides a conversion from some type to a [[HttpRequest]].
+ */
+trait ToRequest[R] {
+  def apply(r: R): HttpRequest
+}
+
+object ToRequest {
+  /**
+   * A convenience method that supports creating a [[ToRequest]] instance from
+   * a function.
+   */
+  def apply[R](converter: R => HttpRequest): ToRequest[R] = new ToRequest[R] {
+    def apply(r: R): HttpRequest = converter(r)
+  }
+
+  /**
+   * An identity instance for [[HttpRequest]] itself.
+   */
+  implicit val requestIdentity: ToRequest[HttpRequest] = apply(identity)
+}

--- a/core/src/main/scala/io/finch/route/EndpointConversions.scala
+++ b/core/src/main/scala/io/finch/route/EndpointConversions.scala
@@ -1,0 +1,107 @@
+package io.finch.route
+
+import com.twitter.finagle.Service
+import com.twitter.util.Future
+import io.finch._
+import io.finch.request.{RequestReader, ToRequest}
+import io.finch.response.{EncodeResponse, Ok}
+import shapeless.{Coproduct, Poly1}
+import shapeless.ops.coproduct.Folder
+
+/**
+ * Implicit conversions to and from [[Endpoint]].
+ */
+trait EndpointConversions {
+  /**
+   * An implicit conversion that turns any coproduct endpoint where all elements
+   * can be converted into responses into an endpoint that returns responses.
+   */
+  implicit def coproductRouterToEndpoint[R: ToRequest, C <: Coproduct](
+    router: RouterN[C]
+  )(implicit
+    folder: Folder.Aux[EncodeAll.type, C, Service[R, HttpResponse]]
+  ): Endpoint[R, HttpResponse] = router.map(c => folder(c))
+
+  /**
+   * An implicit conversion that turns any endpoint with an output type that can
+   * be converted into a response into an endpoint that returns responses.
+   */
+  implicit def endpointToHttpResponse[A, B](e: Endpoint[A, B])(implicit
+    encoder: EncodeResponse[B]
+  ): Endpoint[A, HttpResponse] = e.map { service =>
+    new Service[A, HttpResponse] {
+      def apply(a: A): Future[HttpResponse] = service(a).map(b => Ok(encoder(b)))
+    }
+  }
+
+  /**
+   * Implicitly converts the given `Router[Service[_, _]]` into a service.
+   */
+  implicit def endpointToService[Req, Rep](
+    r: RouterN[Service[Req, Rep]]
+  )(implicit ev: Req => HttpRequest): Service[Req, Rep] = new Service[Req, Rep] {
+    def apply(req: Req): Future[Rep] = r(requestToRoute[Req](req)) match {
+      case Some((Nil, service)) => service(req)
+      case _ => RouteNotFound(s"${req.method.toString.toUpperCase} ${req.path}").toFutureException[Rep]
+    }
+  }
+
+  /**
+   * A polymorphic function value that accepts types that can be transformed
+   * into a Finagle service from a request-like type to a [[HttpResponse]].
+   */
+  object EncodeAll extends Poly1 {
+    /**
+     * Transforms an [[HttpResponse]] directly into a constant service.
+     */
+    implicit def response[R: ToRequest]: Case.Aux[HttpResponse, Service[R, HttpResponse]] =
+      at(r => Service.const(r.toFuture))
+
+    /**
+     * Transforms an encodable value into a constant service.
+     */
+    implicit def encodeable[R: ToRequest, A: EncodeResponse]: Case.Aux[A, Service[R, HttpResponse]] =
+      at(a => Service.const(Ok(a).toFuture))
+
+    /**
+     * Transforms an [[HttpResponse]] in a future into a constant service.
+     */
+    implicit def futureResponse[R: ToRequest]: Case.Aux[Future[HttpResponse], Service[R, HttpResponse]] =
+      at(Service.const(_))
+
+    /**
+     * Transforms an encodeable value in a future into a constant service.
+     */
+    implicit def futureEncodeable[R: ToRequest, A: EncodeResponse]: Case.Aux[Future[A], Service[R, HttpResponse]] =
+      at(fa => Service.const(fa.map(Ok(_))))
+
+    /**
+     * Transforms a [[RequestReader]] into a service.
+     */
+    implicit def requestReader[R: ToRequest, A: EncodeResponse]: Case.Aux[RequestReader[A], Service[R, HttpResponse]] =
+      at(reader => Service.mk(req => reader(implicitly[ToRequest[R]].apply(req)).map(Ok(_))))
+
+    /**
+     * An identity transformation for services that return an [[HttpResponse]].
+     * Note that the service may have a static type that is more specific than
+     * `Service[R, HttpResponse]`.
+     */
+    implicit def serviceResponse[S, R](implicit
+      ev: S => Service[R, HttpResponse],
+      tr: ToRequest[R]
+    ): Case.Aux[S, Service[R, HttpResponse]] =
+      at(s => Service.mk(req => ev(s)(req)))
+
+    /**
+     * A transformation for services that return an encodeable value. Note that
+     * the service may have a static type that is more specific than
+     * `Service[R, A]`.
+     */
+    implicit def serviceEncodeable[S, R, A](implicit
+      ev: S => Service[R, A],
+      tr: ToRequest[R],
+      ae: EncodeResponse[A]
+    ): Case.Aux[S, Service[R, HttpResponse]] =
+      at(s => Service.mk(req => ev(s)(req).map(Ok(_))))
+  }
+}

--- a/core/src/main/scala/io/finch/route/Router0.scala
+++ b/core/src/main/scala/io/finch/route/Router0.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015, by Vladimir Kostyukov and Contributors.
+ *
+ * This file is a part of a Finch library that may be found at
+ *
+ *      https://github.com/finagle/finch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor(s): -
+ */
+
+package io.finch.route
+
+/**
+ * A router that match the given route to some predicate.
+ */
+trait Router0 { self =>
+
+  /**
+   * Matches the given `route` to some predicate and returns `Some` of the _rest_ of the route in case of success or
+   * `None` otherwise.
+   */
+  def apply(route: Route): Option[Route]
+
+  /**
+   * Maps this router to the given value `a`.
+   */
+  def map[A](a: => A): RouterN[A] = new RouterN[A] {
+    def apply(route: Route): Option[(Route, A)] = for {
+      r <- self(route)
+    } yield (r, a)
+    override def toString = self.toString
+  }
+
+  /**
+   * Sequentially composes this router with the given `that` [[io.finch.route.RouterN RouterN]].
+   */
+  def andThen[A](that: => RouterN[A]): RouterN[A] = new RouterN[A] {
+    def apply(route: Route): Option[(Route, A)] =
+      self(route) flatMap { r => that(r) }
+    override def toString = s"${self.toString}/${that.toString}"
+  }
+
+  /**
+   * Sequentially composes this router with the given `that` [[io.finch.route.Router0 Router0]].
+   */
+  def andThen(that: => Router0): Router0 = new Router0 {
+    def apply(route: Route): Option[Route] =
+      self(route) flatMap { r => that(r) }
+    override def toString = s"${self.toString}/${that.toString}"
+  }
+
+  /**
+   * Sequentially composes this router with the given `that` router. The resulting router will succeed if either this or
+   * `that` routers are succeed.
+   *
+   * Router composition via `orElse` operator happens in a _greedy_ manner: it minimizes the output route tail. Thus,
+   * if both of the routers can handle the given `route` the router is being chosen is that which eats more.
+   */
+  def orElse(that: Router0): Router0 = new Router0 {
+    def apply(route: Route): Option[Route] = (self(route), that(route)) match {
+      case (aa @ Some(a), bb @ Some(b)) =>
+        if (a.length <= b.length) aa else bb
+      case (a, b) => a orElse b
+    }
+
+    override def toString = s"(${self.toString}|${that.toString})"
+  }
+
+  /**
+   * Sequentially composes this router with the given `that` router. The resulting router will succeed only if both this
+   * and `that` routers are succeed.
+   */
+  def /(that: Router0): Router0 =
+    this andThen that
+
+  /**
+   * Sequentially composes this router with the given `that` router. The resulting router will succeed only if both this
+   * and `that` routers are succeed.
+   */
+  def /[A](that: RouterN[A]): RouterN[A] =
+    this andThen that
+
+  /**
+   * Maps this router to some value.
+   */
+  def />[A](a: => A): RouterN[A] =
+    this map a
+
+  /**
+   * Sequentially composes this router with the given `that` router. The resulting router will succeed if either this or
+   * `that` routers are succeed.
+   */
+  def |(that: Router0): Router0 =
+    this orElse that
+}

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -99,10 +99,10 @@ object Demo {
   }
 
   // An API endpoint.
-  val api: Service[AuthRequest, ToJson] = users | tickets
+  val api: Service[AuthRequest, Json] = users | tickets
 
   // An HTTP endpoint with exception handler and Auth filter.
   val backend: Service[HttpRequest, HttpResponse] =
-    handleExceptions ! authorize ! (api ! TurnModelIntoJson ! TurnIntoHttp[Json])
+    handleExceptions ! authorize ! (api ! TurnIntoHttp[Json])
 
 }

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -99,10 +99,9 @@ object Demo {
   }
 
   // An API endpoint.
-  val api: Service[AuthRequest, Json] = users | tickets
+  val api: Endpoint[AuthRequest, HttpResponse] = users | tickets
 
   // An HTTP endpoint with exception handler and Auth filter.
   val backend: Service[HttpRequest, HttpResponse] =
-    handleExceptions ! authorize ! (api ! TurnIntoHttp[Json])
-
+    handleExceptions ! authorize ! api
 }

--- a/demo/src/main/scala/io/finch/demo/endpoint.scala
+++ b/demo/src/main/scala/io/finch/demo/endpoint.scala
@@ -30,18 +30,17 @@ import io.finch.argonaut._
 import io.finch.demo.model.Ticket
 import io.finch.response._
 import io.finch.route._
-import shapeless._
 
 object endpoint {
 
+  import model.User
   import service._
 
   // User endpoint.
-  val users: Endpoint[AuthRequest, HttpResponse] = coproductRouterToEndpoint[AuthRequest, GetUser :+: PostUser.type :+: GetAllUsers.type :+: CNil](
-    Get / "users" / long /> GetUser :|:
-    Post / "users" /> PostUser      :|:
-    Get / "users" /> GetAllUsers
-  )
+  val users: Endpoint[AuthRequest, HttpResponse] =
+    Get  / "users" / long /> GetUser :+:
+    Post / "users" /> PostUser       :+:
+    Get  / "users" /> GetAllUsers
 
   // Ticket endpoint.
   val tickets: Endpoint[AuthRequest, Ticket] =

--- a/demo/src/main/scala/io/finch/demo/endpoint.scala
+++ b/demo/src/main/scala/io/finch/demo/endpoint.scala
@@ -30,16 +30,18 @@ import io.finch.argonaut._
 import io.finch.demo.model.Ticket
 import io.finch.response._
 import io.finch.route._
+import shapeless._
 
 object endpoint {
 
   import service._
 
   // User endpoint.
-  val users: Endpoint[AuthRequest, HttpResponse] =
+  val users: Endpoint[AuthRequest, HttpResponse] = coproductRouterToEndpoint[AuthRequest, GetUser :+: PostUser.type :+: GetAllUsers.type :+: CNil](
     Get / "users" / long /> GetUser :|:
     Post / "users" /> PostUser      :|:
     Get / "users" /> GetAllUsers
+  )
 
   // Ticket endpoint.
   val tickets: Endpoint[AuthRequest, Ticket] =

--- a/demo/src/main/scala/io/finch/demo/endpoint.scala
+++ b/demo/src/main/scala/io/finch/demo/endpoint.scala
@@ -25,27 +25,23 @@ package io.finch.demo
 import argonaut.{EncodeJson, Json}
 import com.twitter.finagle.Service
 import com.twitter.util.Future
+import io.finch.HttpResponse
+import io.finch.argonaut._
+import io.finch.demo.model.Ticket
+import io.finch.response._
 import io.finch.route._
 
 object endpoint {
 
   import service._
 
-  implicit class JsonEndpoint[Req, Rep](endpoint: Endpoint[Req, Rep]) {
-    def toJson(implicit encoding: EncodeJson[Rep]): Endpoint[Req, Json] = endpoint.map { service =>
-      new Service[Req, Json] {
-        def apply(req: Req): Future[Json] = service(req).map(encoding(_))
-      }
-    }
-  }
-
   // User endpoint.
-  val users: Endpoint[AuthRequest, Json] =
-    (Get / "users" / long /> GetUser).toJson |
-    (Post / "users" /> PostUser).toJson |
-    (Get / "users" /> GetAllUsers).toJson
+  val users: Endpoint[AuthRequest, HttpResponse] =
+    Get / "users" / long /> GetUser :|:
+    Post / "users" /> PostUser      :|:
+    Get / "users" /> GetAllUsers
 
   // Ticket endpoint.
-  val tickets: Endpoint[AuthRequest, Json] =
-    (Post / "users" / long / "tickets" /> PostUserTicket).toJson
+  val tickets: Endpoint[AuthRequest, Ticket] =
+    Post / "users" / long / "tickets" /> PostUserTicket
 }

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -66,7 +66,7 @@ package object demo {
     private val map = new ConcurrentHashMap[Long, User]().asScala
 
     def select(id: Long): Future[Option[User]] = map.get(id).toFuture
-    def all: Future[Seq[User]] = map.values.toSeq.toFuture
+    def all: Future[Users] = new Users(map.values.toList).toFuture
     def insert(id: Long, u: User): Future[User] = {
       map += (id -> u)
       u.toFuture

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -66,7 +66,7 @@ package object demo {
     private val map = new ConcurrentHashMap[Long, User]().asScala
 
     def select(id: Long): Future[Option[User]] = map.get(id).toFuture
-    def all: Future[Users] = new Users(map.values.toList).toFuture
+    def all: Future[List[User]] = map.values.toList.toFuture
     def insert(id: Long, u: User): Future[User] = {
       map += (id -> u)
       u.toFuture

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -22,7 +22,7 @@
 
 package io.finch
 
-import io.finch.route.ToRequest
+import io.finch.request.ToRequest
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -22,6 +22,8 @@
 
 package io.finch
 
+import io.finch.route.ToRequest
+
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -47,6 +49,11 @@ package object demo {
   // A custom request type that wraps an `HttpRequest`.
   // We prefer composition over inheritance.
   case class AuthRequest(http: HttpRequest)
+
+  object AuthRequest {
+    implicit val toRequest: ToRequest[AuthRequest] =
+      ToRequest[AuthRequest](_.http)
+  }
 
   // We define an implicit view from `AuthRequest to `HttpRequest`,
   // so we can get two benefits:

--- a/demo/src/main/scala/io/finch/demo/service.scala
+++ b/demo/src/main/scala/io/finch/demo/service.scala
@@ -22,8 +22,9 @@
 
 package io.finch.demo
 
-import com.twitter.util.Future
+import argonaut._, Argonaut._
 import com.twitter.finagle.Service
+import com.twitter.util.Future
 
 import io.finch._
 
@@ -42,8 +43,8 @@ object service {
   }
 
   // A REST service that fetches all users.
-  object GetAllUsers extends Service[AuthRequest, Seq[User]] {
-    def apply(req: AuthRequest): Future[Seq[User]] = Db.all
+  object GetAllUsers extends Service[AuthRequest, Users] {
+    def apply(req: AuthRequest): Future[Users] = Db.all
   }
 
   // A REST service that inserts a new user with `userId`.

--- a/demo/src/main/scala/io/finch/demo/service.scala
+++ b/demo/src/main/scala/io/finch/demo/service.scala
@@ -22,7 +22,6 @@
 
 package io.finch.demo
 
-import argonaut._, Argonaut._
 import com.twitter.finagle.Service
 import com.twitter.util.Future
 
@@ -43,8 +42,8 @@ object service {
   }
 
   // A REST service that fetches all users.
-  object GetAllUsers extends Service[AuthRequest, Users] {
-    def apply(req: AuthRequest): Future[Users] = Db.all
+  object GetAllUsers extends Service[AuthRequest, List[User]] {
+    def apply(req: AuthRequest): Future[List[User]] = Db.all
   }
 
   // A REST service that inserts a new user with `userId`.


### PR DESCRIPTION
This is an implementation of coproduct routers as discussed in #270, which this pull request supersedes.

I've also rebased and made some version updates (including to Shapeless 2.2.0 final). Still needs a little cleanup and work on documentation and tests, which I should be able to get to tomorrow (I'm on vacation today).