### PR TITLE
Finch client Spike - Do Not Merge

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -180,3 +180,12 @@ lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")
   .settings(allSettings)
   .dependsOn(core, argonaut, jackson, json4s)
+
+lazy val client = project
+  .settings(moduleName := "finch-client")
+  .settings(allSettings)
+  .settings(libraryDependencies ++= Seq(
+    "io.argonaut" %% "argonaut" % "6.1",
+    "org.spire-math" %% "cats-std" % "0.1.0-SNAPSHOT")
+  )
+  .dependsOn(core)

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,14 @@
+The `finch-client` module provides an attempt at a finch styled rest-client.
+
+Useage
+------------
+```scala
+val connection = FinchRequest(Connection("api.github.com"), Path("/users/penland365"))
+val resource = for {
+    i <- Get(rReq) // Http Verb is the function to send the request
+    j <- Future.value(i.toList.head) // Get returns a String Xor Resource
+    k <- Future.value(j.as[Json]) // requires a DecodeResource TypeClass
+    l <- Future.value(k.getOrDefault(YourDefaultResourceHere))
+  } yield l
+val = Ok(headerMap, argonaut.Json)
+```

--- a/client/src/main/scala/io/finch/client/DecodeResource.scala
+++ b/client/src/main/scala/io/finch/client/DecodeResource.scala
@@ -1,0 +1,28 @@
+package io.finch
+package client
+
+import argonaut._, Argonaut._
+import com.twitter.io.Buf
+import com.twitter.io.Buf.Utf8
+
+trait DecodeResource[A] {
+  def apply(buf: Buf): A 
+}
+
+object DecodeResource {
+
+  implicit def decodeStringResource: DecodeResource[String] = new DecodeResource[String] {
+    def apply(buf: Buf): String = asString(buf)
+  }
+  
+  implicit def decodeJsonResource: DecodeResource[Json] = new DecodeResource[Json] {
+    def apply(buf: Buf): Json = asString(buf)
+      .parseOption
+      .getOrElse(jEmptyObject)
+  }
+  
+  def asString(buf: Buf): String = Utf8.unapply(buf) match {
+    case Some(x) => x
+    case None    => ""
+  }
+}

--- a/client/src/main/scala/io/finch/client/package.scala
+++ b/client/src/main/scala/io/finch/client/package.scala
@@ -1,19 +1,30 @@
 package io.finch
 
 import argonaut._, Argonaut._
+import cats.data.Xor
 import com.twitter.finagle.httpx.path.Path
+import com.twitter.io.Buf
+import com.twitter.io.Buf._
+import com.twitter.util.Future
 
 package object client {
 
+  type Result = String Xor Resource
+
   implicit def decodeStrResource: DecodeResource[String] = new DecodeResource[String] {
-      def apply(r: Resource): String = r.body 
-    }
+    def apply(r: Resource): String = asString(r) 
+  }
 
   implicit def decodeJsonResource: DecodeResource[Json] = new DecodeResource[Json] {
-    def apply(r: Resource): Json = r.body.parseOption.getOrElse(jEmptyObject)
-  }  
-  
-  case class Resource(body: String) {
+    def apply(r: Resource): Json = asString(r).parseOption.getOrElse(jEmptyObject)
+  }
+
+  private[client] def asString(r: Resource): String = Utf8.unapply(r.body) match {
+    case Some(x) => x
+    case None    => ""
+  }
+
+  case class Resource(body: Buf) {
     def as[A](implicit d: DecodeResource[A]): A = d(this)
   }
 

--- a/client/src/main/scala/io/finch/client/package.scala
+++ b/client/src/main/scala/io/finch/client/package.scala
@@ -1,0 +1,25 @@
+package io.finch
+
+import argonaut._, Argonaut._
+import com.twitter.finagle.httpx.path.Path
+
+package object client {
+
+  implicit def decodeStrResource: DecodeResource[String] = new DecodeResource[String] {
+      def apply(r: Resource): String = r.body 
+    }
+
+  implicit def decodeJsonResource: DecodeResource[Json] = new DecodeResource[Json] {
+    def apply(r: Resource): Json = r.body.parseOption.getOrElse(jEmptyObject)
+  }  
+  
+  case class Resource(body: String) {
+    def as[A](implicit d: DecodeResource[A]): A = d(this)
+  }
+
+  trait DecodeResource[A] {
+    def apply(resource: Resource): A 
+  }
+
+  case class FinchRequest(conn: Connection, path: Path)
+}

--- a/client/src/main/scala/io/finch/client/package.scala
+++ b/client/src/main/scala/io/finch/client/package.scala
@@ -1,36 +1,11 @@
 package io.finch
 
-import argonaut._, Argonaut._
 import cats.data.Xor
 import com.twitter.finagle.httpx.path.Path
-import com.twitter.io.Buf
-import com.twitter.io.Buf._
-import com.twitter.util.Future
 
 package object client {
 
-  type Result = String Xor Resource
-
-  implicit def decodeStrResource: DecodeResource[String] = new DecodeResource[String] {
-    def apply(r: Resource): String = asString(r) 
-  }
-
-  implicit def decodeJsonResource: DecodeResource[Json] = new DecodeResource[Json] {
-    def apply(r: Resource): Json = asString(r).parseOption.getOrElse(jEmptyObject)
-  }
-
-  private[client] def asString(r: Resource): String = Utf8.unapply(r.body) match {
-    case Some(x) => x
-    case None    => ""
-  }
-
-  case class Resource(body: Buf) {
-    def as[A](implicit d: DecodeResource[A]): A = d(this)
-  }
-
-  trait DecodeResource[A] {
-    def apply(resource: Resource): A 
-  }
+  type Result[A] = String Xor Resource[A]
 
   case class FinchRequest(conn: Connection, path: Path)
 }

--- a/client/src/main/scala/io/finch/client/resources.scala
+++ b/client/src/main/scala/io/finch/client/resources.scala
@@ -1,0 +1,27 @@
+package io.finch
+package client
+
+import com.twitter.finagle.httpx.{HeaderMap, Response}
+import com.twitter.io.Buf
+
+sealed trait Resource[A] { 
+  val headers: HeaderMap
+  val content: A
+  def as[B](implicit ev: A => Buf, d: DecodeResource[B]): Resource[B] = 
+    Ok(headers, d(content))
+}
+
+object Resource {
+  def fromResponse(resp: Response): Resource[Buf] = resp.statusCode match {
+    case 200 => Ok(resp.headerMap, resp.content)
+    case 201 => Created(resp.headerMap, resp.content)
+    case 202 => Accepted(resp.headerMap, resp.content)
+    case _   => Shruggie(resp.headerMap, resp.content) 
+  }
+}
+
+case class Ok[A](headers: HeaderMap, content: A) extends Resource[A]
+case class Created[A](headers: HeaderMap, content: A) extends Resource[A]
+case class Accepted[A](headers: HeaderMap, content: A) extends Resource[A]
+
+case class Shruggie[A](headers: HeaderMap, content: A) extends Resource[A]

--- a/client/src/main/scala/io/finch/client/verbs.scala
+++ b/client/src/main/scala/io/finch/client/verbs.scala
@@ -1,0 +1,40 @@
+package io.finch
+package client
+
+import com.twitter.finagle.httpx._
+import com.twitter.finagle.{Httpx, Service}
+import com.twitter.io.Buf._
+import com.twitter.util.Future
+
+sealed trait Verb extends Service[FinchRequest, Resource] {
+
+  def apply(fReq: FinchRequest): Future[Resource] = {
+     val req = RequestBuilder()
+       .url("https://" + fReq.conn.host + fReq.path)
+       .addHeader("Host", fReq.conn.host) 
+       .addHeader("User-Agent", "finch/0.7.0")
+       .build(httpVerb(), None)
+  
+     fReq.conn(req) map { r =>
+        val body = Utf8.unapply(r.content) match {
+          case Some(x) => x
+          case None    => ""
+        }
+        new Resource(body)
+      }
+  }
+
+  private[this] def httpVerb(): Method = this match {
+    case Get => Method.Get
+  }
+}
+
+case object Get extends Verb
+
+case class Connection(host: String, port: Int = 443) extends Service[Request, Response] {
+  val client = new Httpx.Client()
+    .withTlsWithoutValidation()
+    .newService(host + ":" + port.toString, host)
+
+  def apply(req: Request): Future[Response] = client(req)
+}


### PR DESCRIPTION
This is a quick spike around what I think a `finch-client` could look like, at least for my typical use cases.  It's heavily biased towards a `RESTFul` style.  A small syntax showing useage is in the `README` for the package.  Quick synopsis:

1. Create a Finch request w/ a host and an endpoint (finagle.Path)
2. Make the actual Http request w/ an Http `Verb` => `Get(finchRequest)`
3. `Verb` returns a `String Xor Resource` from `Cats` to handle failures better ( super shallow w/ this right now )
4. A `Resource` is simply and HttpResponse Status like `Ok` parameterized on the response content type => `Ok(twitter.io.Buf)` or a `Ok(String)` or `Ok(argonaut.Json)`
5. Right now I've got two implicit DecodeResource TypeClasses for `String` and `json.Argonaut`.

Thoughts on this style?  Love it?  Hate it?  It needs a lot of work, but this is much closer to what I envision that my partial baked gist I put in gitter and then yanked out on Friday.