### PR TITLE
Change EncodeResponse to treat response body as Array[Byte]

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/package.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/package.scala
@@ -51,5 +51,5 @@ package object argonaut {
    * @return Create a Finch ''EncodeJson'' from an argonaut ''EncodeJson''
    */
   implicit def encodeArgonaut[A](implicit encode: EncodeJson[A]): EncodeResponse[A] =
-    EncodeResponse("application/json")(encode.encode(_).nospaces)
+    EncodeResponse.fromString[A]("application/json")(encode.encode(_).nospaces)
 }

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -258,7 +258,7 @@ class RouterSpec extends FlatSpec with Matchers {
     case class Item(s: String)
 
     implicit val encodeItem: EncodeResponse[Item] =
-      EncodeResponse("text/plain")(_.s)
+      EncodeResponse.fromString("text/plain")(_.s)
 
     implicit val decodeItem: DecodeRequest[Item] =
       DecodeRequest(s => Return(Item(s)))

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -23,6 +23,8 @@
 package io.finch
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.twitter.io.Buf
+import com.twitter.io.Buf.Utf8
 import io.finch.request.DecodeAnyRequest
 import io.finch.response.EncodeAnyResponse
 import com.twitter.util.Try
@@ -41,7 +43,7 @@ package object jackson {
 
   implicit def encodeJackson(implicit mapper: ObjectMapper): EncodeAnyResponse =
     new EncodeAnyResponse {
-      def apply[A](rep: A): String = mapper.writeValueAsString(rep)
+      def apply[A](rep: A): Buf = Utf8(mapper.writeValueAsString(rep))
       def contentType: String = "application/json"
     }
 }

--- a/jawn/src/main/scala/io/finch/jawn/package.scala
+++ b/jawn/src/main/scala/io/finch/jawn/package.scala
@@ -25,6 +25,7 @@ package io.finch
 
 import _root_.jawn.ast.{CanonicalRenderer, JValue}
 import _root_.jawn.{Facade, Parser}
+import com.twitter.io.Buf.Utf8
 import io.finch.request.DecodeRequest
 import io.finch.response.EncodeResponse
 import com.twitter.util.{Return, Throw}
@@ -55,5 +56,5 @@ package object jawn {
    */
   @deprecated("Finch Jawn is deprecated in favor of other JSON libraries.", "0.7.0")
   implicit val encodeJawn: EncodeResponse[JValue] =
-    EncodeResponse("application/json")(CanonicalRenderer.render)
+    EncodeResponse("application/json")(Utf8.apply _ compose CanonicalRenderer.render)
 }

--- a/json/src/main/scala/io/finch/json/package.scala
+++ b/json/src/main/scala/io/finch/json/package.scala
@@ -29,7 +29,7 @@ import com.twitter.util.{Try, Throw, Return}
 
 package object json {
   @deprecated("encodeFinchJson is deprecated as part of the Finch JSON deprecation.", "0.7.0")
-  implicit val encodeFinchJson = EncodeResponse[Json]("application/json")(Json.encode)
+  implicit val encodeFinchJson = EncodeResponse.fromString[Json]("application/json")(Json.encode)
 
   @deprecated("decodeFinchJson is deprecated as part of the Finch JSON deprecation.", "0.7.0")
   implicit val decodeFinchJson = DecodeRequest[Json] { json =>

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -24,7 +24,5 @@ package object json4s {
    * @return
    */
   implicit def encodeJson[A <: AnyRef](implicit formats: Formats): EncodeResponse[A] =
-    EncodeResponse("application/json") { out: A =>
-      write(out)
-    }
+    EncodeResponse.fromString[A]("application/json") { write(_) }
 }

--- a/test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
+++ b/test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
@@ -2,6 +2,7 @@ package io.finch.test.json
 
 import argonaut.{CodecJson, DecodeJson, EncodeJson, Parse}
 import argonaut.Argonaut.{casecodec3, casecodec5}
+import com.twitter.io.Buf.Utf8
 import com.twitter.util.Return
 import io.finch.request._
 import io.finch.response._
@@ -54,7 +55,7 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
    */
   def encodeNestedCaseClass(implicit encoder: EncodeResponse[ExampleNestedCaseClass]): Unit =
     check { (e: ExampleNestedCaseClass) =>
-      Parse.decodeOption(encoder(e))(exampleNestedCaseClassCodecJson) === Some(e)
+      Parse.decodeOption(Utf8.unapply(encoder(e)).get)(exampleNestedCaseClassCodecJson) === Some(e)
     }
 
   /**
@@ -84,7 +85,7 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
    */
   def encodeCaseClassList(implicit encoder: EncodeResponse[List[ExampleNestedCaseClass]]): Unit =
     check { (es: List[ExampleNestedCaseClass]) =>
-      Parse.decodeOption(encoder(es))(exampleNestedCaseClassListCodecJson) === Some(es)
+      Parse.decodeOption(Utf8.unapply(encoder(es)).getOrElse(""))(exampleNestedCaseClassListCodecJson) === Some(es)
     }
 
   /**


### PR DESCRIPTION
Finch's current `EncodeResponse` implementation imposes HTTP response to be a String. This limitation causes binary content to be encoded as a String. Therefore bytes invalid as UTF-8 string might be silently replaced to other bytes (this behaviour is not specified by the language spec. see [here](http://docs.oracle.com/javase/8/docs/api/java/lang/String.html#String-byte:A-java.lang.String-)). To get rid of this unwanted behaviour, I made these changes:

1. Change `EncodeResponse#apply` to return `Array[Byte]` instead of `String`
2. Now set Content-Type header with `contentType=` instead of `setContentType` because the latter method decides the content to be a text and appends `;charset=utf-8` to the header.

**NOTE:** This is a breaking change since it may affect all the user-defined `EncodeResponse`s.