### PR TITLE
Disable code coverage for benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,4 +179,5 @@ lazy val auth = project
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")
   .settings(allSettings)
+  .settings(coverageExcludedPackages := "io\\.finch\\.benchmarks\\..*")
   .dependsOn(core, argonaut, jackson, json4s)


### PR DESCRIPTION
Do I understand this correctly that we don't really need to cover benchmarks?