### PR TITLE
Fix benchmarks and clean up demo imports

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/service.scala
@@ -41,7 +41,7 @@ class FinchUserService(implicit
     body.as[User].apply(req).flatMap(db.update).map(_ => NoContent())
   }
 
-  val deleteUsers: Service[HttpRequest, HttpResponse] =
+  def deleteUsers: Service[HttpRequest, HttpResponse] =
     Service.const(db.delete().map(count => Ok(s"$count users deleted")))
 
   val users: Service[HttpRequest, HttpResponse] = (

--- a/demo/src/main/scala/io/finch/demo/endpoint.scala
+++ b/demo/src/main/scala/io/finch/demo/endpoint.scala
@@ -22,17 +22,11 @@
 
 package io.finch.demo
 
-import argonaut.{EncodeJson, Json}
-import com.twitter.finagle.Service
-import com.twitter.util.Future
-import io.finch.demo.model.Ticket
+import io.finch.demo.model.{Ticket, User}
+import io.finch.demo.service._
 import io.finch.route._
 
 object endpoint {
-
-  import model._
-  import service._
-
   val getUser: Endpoint[AuthRequest, User] = Get  / "users" / long /> GetUser
   val postUser: Endpoint[AuthRequest, User] = Post / "users" /> PostUser
   val getUsers: Endpoint[AuthRequest, List[User]] = Get  / "users" /> GetAllUsers


### PR DESCRIPTION
A recent change from `def` to `val` in the definition of the benchmark deletion service meant the benchmarks weren't running properly (it'd be nice to have this tested). I'm also including a bit of completely unrelated import clean-up.