### PR TITLE
Fix #238: move implicit conversion toOptionalRule to ValidationRule companion object

### DIFF
--- a/core/src/main/scala/io/finch/request/ValidationRule.scala
+++ b/core/src/main/scala/io/finch/request/ValidationRule.scala
@@ -67,6 +67,20 @@ trait ValidationRule[A] { self =>
  * Allows the creation of reusable validation rules for [[io.finch.request.RequestReader RequestReader]]s.
  */
 object ValidationRule {
+  /**
+   * Implicit conversion that allows the same [[io.finch.request.ValidationRule ValudationRule]] to be used for required
+   * and optional values. If the optional value is non-empty, it gets validated (and validation may fail, producing an
+   * error), but if it is empty, it is always treated as valid.
+   *
+   * @param rule the validation rule to adapt for optional values
+   * @return a new validation rule that applies the specified rule to an optional value in case it is not empty
+   */
+  implicit def toOptionalRule[A](rule: ValidationRule[A]): ValidationRule[Option[A]] = {
+    ValidationRule(rule.description) {
+      case Some(value) => rule(value)
+      case None => true
+    }
+  }
 
   /**
    * Creates a new reusable [[io.finch.request.ValidationRule ValidationRule]] based on the specified predicate.

--- a/core/src/main/scala/io/finch/request/package.scala
+++ b/core/src/main/scala/io/finch/request/package.scala
@@ -236,21 +236,6 @@ package object request extends LowPriorityRequestReaderImplicits {
   }
 
   /**
-   * Implicit conversion that allows the same [[io.finch.request.ValidationRule ValudationRule]] to be used for required
-   * and optional values. If the optional value is non-empty, it gets validated (and validation may fail, producing an
-   * error), but if it is empty, it is always treated as valid.
-   *
-   * @param rule the validation rule to adapt for optional values
-   * @return a new validation rule that applies the specified rule to an optional value in case it is not empty
-   */
-  implicit def toOptionalRule[A](rule: ValidationRule[A]): ValidationRule[Option[A]] = {
-    ValidationRule(rule.description) {
-      case Some(value) => rule(value)
-      case None => true
-    }
-  }
-
-  /**
    * Implicit conversion that allows the same inline rules to be used for required and optional values. If the optional
    * value is non-empty, it gets validated (and validation may fail, producing error), but if it is empty, it is always
    * treated as valid.

--- a/core/src/main/scala/io/finch/route/package.scala
+++ b/core/src/main/scala/io/finch/route/package.scala
@@ -96,7 +96,7 @@ package object route {
 
   implicit def intToMatcher(i: Int): Router0 = new Matcher(i.toString)
   implicit def stringToMatcher(s: String): Router0 = new Matcher(s)
-  implicit def booleanToMather(b: Boolean): Router0 = new Matcher(b.toString)
+  implicit def booleanToMatcher(b: Boolean): Router0 = new Matcher(b.toString)
 
   /**
    * An universal matcher.


### PR DESCRIPTION
Also fixes a typo in the name of an implicit def (booleanToMatcher, route package object).