### PR TITLE
Turn on -Xlint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ lazy val compilerOptions = Seq(
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
-  "-Xfuture"
+  "-Xfuture",
+  "-Xlint"
 )
 
 val testDependencies = Seq(


### PR DESCRIPTION
`-Xlint` actually provides "it is not recommended to define classes/objects inside of package objects" warnings (and no other new warnings, at a glance), so we might as well turn it on now that we're moving away from that pattern.