### PR TITLE
Add integration tests for service benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
-script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test scalastyle && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test it:test scalastyle && sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/benchmarks/src/it/scala/io/finch/benchmarks/service/benchmark.scala
+++ b/benchmarks/src/it/scala/io/finch/benchmarks/service/benchmark.scala
@@ -1,0 +1,25 @@
+package io.finch.benchmarks.service
+
+import io.finch.benchmarks.service.argonaut.ArgonautBenchmark
+import io.finch.benchmarks.service.finagle.FinagleBenchmark
+import io.finch.benchmarks.service.jackson.JacksonBenchmark
+import io.finch.benchmarks.service.json4s.Json4sBenchmark
+import org.scalatest.{FlatSpec, Matchers}
+
+class BenchmarkTest extends FlatSpec with Matchers {
+  "The Argonaut benchmark" should "run successfully" in {
+    ArgonautBenchmark.main(Array.empty)
+  }
+
+  "The Finagle benchmark" should "run successfully" in {
+    FinagleBenchmark.main(Array.empty)
+  }
+
+  "The Jackson benchmark" should "run successfully" in {
+    JacksonBenchmark.main(Array.empty)
+  }
+
+  "The Json4s benchmark" should "run successfully" in {
+    Json4sBenchmark.main(Array.empty)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -180,4 +180,6 @@ lazy val auth = project
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")
   .settings(allSettings)
-  .dependsOn(core, argonaut, jackson, json4s)
+  .configs(IntegrationTest)
+  .settings(Defaults.itSettings)
+  .dependsOn(core, argonaut, jackson, json4s, test % "it")

--- a/build.sbt
+++ b/build.sbt
@@ -182,4 +182,5 @@ lazy val benchmarks = project
   .settings(allSettings)
   .configs(IntegrationTest)
   .settings(Defaults.itSettings)
+  .settings(parallelExecution in IntegrationTest := false)
   .dependsOn(core, argonaut, jackson, json4s, test % "it")


### PR DESCRIPTION
This gets the test coverage for finagle-benchmarks up to a reasonable level (and gives us some protection against breaking the benchmarks at the same time). We could still disable coverage reporting for finagle-benchmark (as in #285), but I think I'd vote not to.