### PR TITLE
Fix problem with benchmark service definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val benchmarks = project
   .settings(parallelExecution in IntegrationTest := false)
   .settings(coverageExcludedPackages := "io\\.finch\\.benchmarks\\.service\\.UserServiceBenchmark")
   .settings(
-    javaOptions in (IntegrationTest, run) ++= Seq(
+    javaOptions in run ++= Seq(
       "-Djava.net.preferIPv4Stack=true",
       "-XX:+AggressiveOpts",
       "-XX:+UseParNewGC",


### PR DESCRIPTION
A fix for the problem mentioned in #302. I've also changed the `benchmarks` project configuration so that the benchmarks themselves are run with the extra JVM arguments.