### PR TITLE
Update to Shapeless 2.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val testDependencies = Seq(
 
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.chuusai" %% "shapeless" % "2.2.0",
+    "com.chuusai" %% "shapeless" % "2.2.1",
     "com.twitter" %% "finagle-httpx" % "6.25.0",
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ) ++ testDependencies.map(_ % "test"),


### PR DESCRIPTION
I don't think any of the bug fixes and performance improvements in 2.2.1 affect us, but we might as well update before the 0.7.0 release.