### PR TITLE
Fix #315: Extend Smash to detect HNils

### DIFF
--- a/core/src/main/scala/io/finch/route/Smash.scala
+++ b/core/src/main/scala/io/finch/route/Smash.scala
@@ -34,7 +34,19 @@ trait MidPrioritySmash extends LowPrioritySmash {
   }
 }
 
-object Smash extends MidPrioritySmash {
+trait HighPrioritySmash extends MidPrioritySmash {
+  implicit def smashIHNil[A]: Aux[A, HNil, A] = new Smash[A, HNil] {
+    type Out = A
+    def apply(a: A, b: HNil): Out = a
+  }
+
+  implicit def smashHNIlI[B]: Aux[HNil, B, B] = new Smash[HNil, B] {
+    type Out = B
+    def apply(a: HNil, b: B): Out = b
+  }
+}
+
+object Smash extends HighPrioritySmash {
   def apply[A, B](implicit smash: Smash[A, B]): Aux[A, B, smash.Out] = smash
 
   def smash[A, B](a: A, b: B)(implicit smash: Smash[A, B]): smash.Out =

--- a/core/src/main/scala/io/finch/route/package.scala
+++ b/core/src/main/scala/io/finch/route/package.scala
@@ -23,7 +23,7 @@
 package io.finch
 
 import com.twitter.finagle.Service
-import shapeless.HNil
+import shapeless._
 
 /**
  * This package contains various of functions and types that enable _router combinators_ in Finch. A Finch
@@ -62,6 +62,10 @@ package object route {
    * An alias for [[io.finch.route.Router Router]] that maps route to a [[com.twitter.finagle.Service Service]].
    */
   type Endpoint[A, B] = Router[Service[A, B]]
+
+  type Router0 = Router[HNil]
+  type Router2[A, B] = Router[A :: B :: HNil]
+  type Router3[A, B, C] = Router[A :: B :: C :: HNil]
 
   private[route] def stringToSomeValue[A](fn: String => A)(s: String): Option[A] =
     try Some(fn(s)) catch { case _: IllegalArgumentException => None }

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -45,12 +45,12 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   val emptyRoute = List(MethodToken(Method.Get))
 
   "A Router" should "extract single string" in {
-    val r = Get / string
-    r(route) shouldBe Some((route.drop(2), "a" :: HNil))
+    val r: Router[String] = Get / string
+    r(route) shouldBe Some((route.drop(2), "a"))
   }
 
   it should "extract multiple strings" in {
-    val r = Get / string / "1" / string
+    val r: Router2[String, String] = Get / string / "1" / string
     r(route) shouldBe Some((route.drop(4), "a" :: "b" :: HNil))
   }
 
@@ -59,65 +59,65 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "match method only once" in {
-    val r = Get / Get
+    val r: Router0 = Get / Get
     r(route) shouldBe None
   }
 
   it should "match string" in {
-    val r = Get / "a"
+    val r: Router0 = Get / "a"
     r.exec(route) shouldBe Some(route.drop(2))
   }
 
   it should "match 2 or more strings" in {
-    val r = Get / "a" / 1 / "b"
+    val r: Router0 = Get / "a" / 1 / "b"
     r.exec(route) shouldBe Some(route.drop(4))
   }
 
   it should "not match if one of the routers failed" in {
-    val r = Get / "a" / 2
+    val r: Router0 = Get / "a" / 2
     r(route) shouldBe None
   }
 
   it should "not match if the method is missing" in {
-    val r = "a" / "b"
+    val r: Router0 = "a" / "b"
     r(route) shouldBe None
   }
 
   it should "be able to skip route tokens" in {
-    val r = * / "a"
+    val r: Router0 = * / "a"
     r.exec(route) shouldBe Some(route.drop(2))
   }
 
   it should "match either one or other matcher" in {
-    val r = (Get | Post) / ("a" | "b")
+    val r: Router0 = (Get | Post) / ("a" | "b")
     r.exec(route) shouldBe Some(route.drop(2))
   }
 
   it should "match int" in {
-    val r = Get / "a" / 1
+    val r: Router0 = Get / "a" / 1
     r.exec(route) shouldBe Some(route.drop(3))
   }
 
   it should "be able to not match int if it's a different value" in {
-    val r = Get / "a" / 2
+    val r: Router0 = Get / "a" / 2
     r(route) shouldBe None
   }
 
   it should "be able to skip one route tokens" in {
-    val r = Get / *
+    val r: Router0 = Get / *
     r.exec(route) shouldBe Some(route.drop(2))
   }
 
   it should "be able to match the whole route" in {
-    val r1 = Get / *
-    val r2 = Get / * / * / * / *
+    val r1: Router0 = Get / *
+    val r2: Router0 = Get / * / * / * / *
     r1.exec(route) shouldBe Some(route.drop(2))
     r2.exec(route) shouldBe Some(Nil)
   }
 
   it should "support DSL for string and int extractors" in {
-    val r1 = Get / "a" / int / string
-    val r2 = Get / "a" / int("1") / "b" / int("2")
+    val r1: Router2[Int, String] = Get / "a" / int / string
+    val r2: Router2[Int, Int] = Get / "a" / int("1") / "b" / int("2")
 
     r1(route) shouldBe Some((route.drop(4), 1 :: "b" :: HNil))
     r2(route) shouldBe Some((Nil, 1 :: 2 :: HNil))
@@ -125,10 +125,10 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
 
   it should "support DSL for boolean marchers and extractors" in {
     val route = List(PathToken("flag"), PathToken("true"))
-    val r1 = "flag" / boolean
-    val r2 = "flag" / true
+    val r1: Router[Boolean] = "flag" / boolean
+    val r2: Router0 = "flag" / true
 
-    r1(route) shouldBe Some((Nil, true :: HNil))
+    r1(route) shouldBe Some((Nil, true))
     r2.exec(route) shouldBe Some(Nil)
   }
 
@@ -142,29 +142,29 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "be composable as an endpoint" in {
-    val r1 = Get / "a" / int /> { _ + 10 }
-    val r2 = Get / "b" / int / int /> { _ + _ }
-    val r3 = r1 | r2
+    val r1: Router[Int] = Get / "a" / int /> { _ + 10 }
+    val r2: Router[Int] = Get / "b" / int / int /> { _ + _ }
+    val r3: Router[Int] = r1 | r2
 
     r3(route) shouldBe Some((route.drop(3), 11))
   }
 
   it should "maps to value" in {
-    val r = Get /> 10
+    val r: Router[Int] = Get /> 10
     r(route) shouldBe Some((route.tail, 10))
   }
 
   it should "skip all the route tokens" in {
-    val r = Get / "a" / **
+    val r: Router0 = Get / "a" / **
     r.exec(route) shouldBe Some(Nil)
   }
 
   it should "converts into a string" in {
-    val r1 = Get
-    val r2 = Get / "a" / true / 1
-    val r3 = Get / ("a" | "b") / int / long / string
-    val r4 = Get / string("name") / int("id") / boolean("flag") / "foo"
-    val r5 = Post / *
+    val r1: Router0 = Get
+    val r2: Router0 = Get / "a" / true / 1
+    val r3: Router3[Int, Long, String] = Get / ("a" | "b") / int / long / string
+    val r4: Router3[String, Int, Boolean] = Get / string("name") / int("id") / boolean("flag") / "foo"
+    val r5: Router0 = Post / *
 
     r1.toString shouldBe "GET"
     r2.toString shouldBe "GET/a/true/1"
@@ -174,9 +174,9 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "support the for-comprehension syntax" in {
-    val r1 = for { a :: b :: HNil <- Get / string / int } yield a + b
-    val r2 = for { a :: b :: c :: HNil <- Get / "a" / int / string / int } yield b + c + a
-    val r3 = r1 | r2
+    val r1: Router[String] = for { a :: b :: HNil <- Get / string / int } yield a + b
+    val r2: Router[String] = for { a :: b :: c :: HNil <- Get / "a" / int / string / int } yield b + c + a
+    val r3: Router[String] = r1 | r2
 
     r1(route) shouldBe Some((route.drop(3), "a1"))
     r2(route) shouldBe Some((Nil, "b21"))
@@ -197,8 +197,8 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     val a = List(PathToken("a"), PathToken("10"))
     val b = List(PathToken("a"))
 
-    val r1 = "a" | "b" | ("a" / 10)
-    val r2 = ("a" / 10) | "b" |  "a"
+    val r1: Router0 = "a" | "b" | ("a" / 10)
+    val r2: Router0 = ("a" / 10) | "b" |  "a"
 
     r1.exec(a) shouldBe Some(Nil)
     r1.exec(b) shouldBe Some(Nil)
@@ -227,10 +227,10 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "handle the empty route well" in {
-    val r1 = Get / * / * / **
-    val r2 = Get / int / string / boolean
-    val r3 = Get / "a" / "b" / "c"
-    val r4 = Post
+    val r1: Router0 = Get / * / * / **
+    val r2: Router3[Int, String, Boolean] = Get / int / string / boolean
+    val r3: Router0 = Get / "a" / "b" / "c"
+    val r4: Router0 = Post
 
     r1.exec(emptyRoute) shouldBe Some(Nil)
     r2.exec(emptyRoute) shouldBe None
@@ -239,7 +239,7 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "use the first router if both eats the same number of tokens" in {
-    val r =
+    val r: Router[String]=
       Get /> "root" |
       Get / "foo" /> "foo"
 


### PR DESCRIPTION
This addresses #315. `Smash` now handles `HNil` as a special case of `HList`, so `smash[HNil, A] => A` and vice-versa. I also tried to get rid of boilerplate classes `RArrowN` and replaced them with Shapeless `FnToProduct`. Finally, this PR adds a type alias `Router0 = Router[HNil]`.

It's ready to be reviewed.