### PR TITLE
Simplify disjunction for routers

### DIFF
--- a/core/src/main/scala/io/finch/route/Router.scala
+++ b/core/src/main/scala/io/finch/route/Router.scala
@@ -29,6 +29,8 @@ import io.finch.request._
 import io.finch.response._
 import shapeless._
 import shapeless.ops.function.FnToProduct
+import shapeless.ops.adjoin.Adjoin
+
 
 /**
  * A router that extracts some value of the type `A` from the given route.
@@ -125,6 +127,12 @@ trait Router[A] { self =>
   def withFilter(p: A => Boolean): Router[A] = self
 
   /**
+   * Compose this router with another in such a way that coproducts are flattened.
+   */
+  def :+:[B](that: Router[B])(implicit adjoin: Adjoin[B :+: A :+: CNil]): Router[adjoin.Out] =
+    that.map(b => adjoin(Inl(b))) orElse map(a => adjoin(Inr(Inl(a))))
+
+  /**
    * Converts this router to a Finagle service from a request-like type `R` to a [[HttpResponse]].
    */
   def toService[R: ToRequest](implicit ts: ToService[R, A]): Service[R, HttpResponse] = ts(this)
@@ -157,46 +165,6 @@ object Router {
       case Some((Nil, service)) => service(req)
       case _ => RouteNotFound(s"${req.method.toString.toUpperCase} ${req.path}").toFutureException[Rep]
     }
-  }
-
-  /**
-   * Base class for implicit classes that support `:+:` syntax for building routers.
-   */
-  abstract class CoproductRouterOps[S, C <: Coproduct](self: Router[S]) {
-    protected def right[A](s: S): A :+: C
-
-    def :+:[A](that: Router[A]): Router[A :+: C] =
-      new Router[A :+: C] {
-        def apply(route: Route): Option[(Route, A :+: C)] =
-          (that(route), self(route)) match {
-            case (Some((ar, av)), Some((sr, sv))) =>
-              if (ar.size <= sr.size) Some((ar, Inl(av))) else Some((sr, right(sv)))
-            case (a, s) =>
-              a.map {
-                case (r, v) => (r, Inl(v))
-              } orElse s.map {
-                case (r, v) => (r, right(v))
-              }
-          }
-
-        override def toString = s"(${that.toString}|${self.toString})"
-      }
-  }
-
-  /**
-   * Implicit class that provides `:+:` and other operations on any coproduct router.
-   */
-  final implicit class CoproductRouterOps1[C <: Coproduct](self: Router[C])
-    extends CoproductRouterOps[C, C](self) {
-    protected def right[A](c: C): A :+: C = Inr(c)
-  }
-
-  /**
-   * Implicit class that provides `:+:` on any router.
-   */
-  final implicit class CoproductRouterOps0[B](self: Router[B])
-    extends CoproductRouterOps[B, B :+: CNil](self) {
-    protected def right[A](b: B): A :+: B :+: CNil = Inr(Inl(b))
   }
 
   /**

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -34,7 +34,7 @@ import io.finch.route.tokens._
 
 import org.scalatest.{Matchers, FlatSpec}
 import org.scalatest.prop.Checkers
-import shapeless.{:+:, ::, CNil, HNil}
+import shapeless.{:+:, ::, CNil, HNil, Inl}
 
 class RouterSpec extends FlatSpec with Matchers with Checkers {
 
@@ -238,7 +238,7 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     r4.exec(emptyRoute) shouldBe None
   }
 
-  it should "use the first router if both eats the same number of tokens" in {
+  it should "use the first router if both eat the same number of tokens" in {
     val r: Router[String]=
       Get /> "root" |
       Get / "foo" /> "foo"
@@ -248,6 +248,15 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
 
     r(route1) shouldBe Some((Nil, "root"))
     r(route2) shouldBe Some((Nil, "foo"))
+  }
+
+  it should "combine coproduct routers appropriately" in {
+    val r1: Router[Int :+: String :+: CNil] = int :+: string
+    val r2: Router[String :+: Long :+: CNil] = string :+: long
+
+    val r: Router[Int :+: String :+: String :+: Long :+: CNil] = r1 :+: r2
+
+    r(PathToken("100") :: Nil) shouldBe Some((Nil, Inl(100)))
   }
 
   it should "convert a coproduct router into an endpoint" in {


### PR DESCRIPTION
This simplifies the `:+:` method on routers by adding the smash treatment for coproducts. This means that if we write the following:

```scala
val router = (int :+: string) :+: (string :+: long)
```

We get a `Router[Int :+: String :+: String :+: Long :+: CNil]`, not a router of a nested coproduct. This means that `router.toService` works with the router above.

Before this change you'd have to write the following to accomplish the same thing:

```scala
val router =
  (int :+: string).map(_.extendRightBy[String :+: Long :+: CNil]) orElse
  (string :+: long).map(_.extendLeftBy[Int :+: String :+: CNil])
```

This PR still needs tests, etc.—I just wanted to put it up for discussion and to address @IgorWolkov's [question on Gitter](https://gitter.im/finagle/finch?at=55800d03f1cd32e97eca8222).

(Note that the change in #315 isn't relevant for coproducts, since we'll never have a `Router[CNil]`.)