### PR TITLE
Upgrade to Shapeless 2.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val testDependencies = Seq(
 
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
-    "com.chuusai" %% "shapeless" % "2.2.1",
+    "com.chuusai" %% "shapeless" % "2.2.2",
     "com.twitter" %% "finagle-httpx" % "6.25.0",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)


### PR DESCRIPTION
Shapeless 2.2.2 fixes a binary compatibility issue in 2.2.1 and may also help with dependency resolution problems we're seeing.