### PR TITLE
Add a content type type member to response encoders

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/package.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/package.scala
@@ -27,7 +27,7 @@ package io.finch
 import _root_.argonaut.{EncodeJson, Json, Parse, DecodeJson}
 import io.finch.request.DecodeRequest
 import io.finch.request.RequestError
-import io.finch.response.EncodeResponse
+import io.finch.response.{ EncodeJsonResponse, EncodeResponse }
 import com.twitter.util.{Try, Throw, Return}
 
 package object argonaut {
@@ -50,6 +50,6 @@ package object argonaut {
    * @tparam A The type of data that the ''EncodeJson'' will encode use to create the json string
    * @return Create a Finch ''EncodeJson'' from an argonaut ''EncodeJson''
    */
-  implicit def encodeArgonaut[A](implicit encode: EncodeJson[A]): EncodeResponse[A] =
-    EncodeResponse.fromString[A]("application/json")(encode.encode(_).nospaces)
+  implicit def encodeArgonaut[A](implicit encode: EncodeJson[A]): EncodeJsonResponse[A] =
+    EncodeResponse("application/json").fromString[A](encode.encode(_).nospaces)
 }

--- a/core/src/main/scala/io/finch/response/package.scala
+++ b/core/src/main/scala/io/finch/response/package.scala
@@ -24,6 +24,8 @@
 
 package io.finch
 
+import shapeless.Witness
+
 /**
  * This package enables a reasonable approach of building HTTP responses using the
  * [[io.finch.response.ResponseBuilder ResponseBuilder]] abstraction. The `ResponseBuilder` provides an immutable way
@@ -46,4 +48,10 @@ package io.finch
  *   val ok: HttpResponse = Ok(BigInt(100))
  * }}}
  */
-package object response
+package object response {
+  type EncodeTextResponse[-A] = EncodeResponse.Aux[A, Witness.`"text/plain"`.T]
+  type EncodeJsonResponse[-A] = EncodeResponse.Aux[A, Witness.`"application/json"`.T]
+  type EncodeBinaryResponse[-A] = EncodeResponse.Aux[A, Witness.`"application/octet-stream"`.T]
+
+  type EncodeAnyJsonResponse = EncodeAnyResponse.Aux[Witness.`"application/json"`.T]
+}

--- a/core/src/test/scala/io/finch/response/EncodeSpec.scala
+++ b/core/src/test/scala/io/finch/response/EncodeSpec.scala
@@ -34,11 +34,11 @@ class EncodeSpec extends FlatSpec with Matchers {
   private def encode[A](obj: A)(implicit e: EncodeResponse[A]): Buf = e(obj)
   "A EncodeJson" should "be accepted as implicit instance of subclass" in {
     implicit def seqEncodeJson[A](implicit ea: EncodeResponse[A]): EncodeResponse[Seq[A]] =
-      EncodeResponse.fromString[Seq[A]]("application/json") {
+      EncodeResponse("application/json").fromString[Seq[A]] {
         seq => seq.map { e => Utf8.unapply(ea(e)).getOrElse("") }.mkString("[", ", ", "]")
       }
 
-    implicit val scalaNumberEncodeJson = EncodeResponse.fromString[ScalaNumber]("application/json")(s => s.toString)
+    implicit val scalaNumberEncodeJson = EncodeResponse("application/json").fromString[ScalaNumber](s => s.toString)
 
     Utf8.unapply(encode(Seq(BigDecimal(123l), BigDecimal(0l)))) shouldBe Some("[123, 0]")
     Utf8.unapply(encode(Vector(BigDecimal(123l), BigDecimal(0l)))) shouldBe Some("[123, 0]")

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -254,7 +254,7 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     case class Item(s: String)
 
     implicit val encodeItem: EncodeResponse[Item] =
-      EncodeResponse.fromString("text/plain")(_.s)
+      EncodeResponse("text/plain").fromString(_.s)
 
     implicit val decodeItem: DecodeRequest[Item] =
       DecodeRequest(s => Return(Item(s)))

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -25,11 +25,11 @@ package io.finch
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.twitter.io.Buf
 import com.twitter.io.Buf.Utf8
-import io.finch.request.DecodeAnyRequest
-import io.finch.response.EncodeAnyResponse
 import com.twitter.util.Try
-
+import io.finch.request.DecodeAnyRequest
+import io.finch.response.{ EncodeAnyResponse, EncodeAnyJsonResponse }
 import scala.reflect.ClassTag
+import shapeless.Witness
 
 package object jackson {
 
@@ -41,9 +41,8 @@ package object jackson {
       }
     }
 
-  implicit def encodeJackson(implicit mapper: ObjectMapper): EncodeAnyResponse =
-    new EncodeAnyResponse {
+  implicit def encodeJackson(implicit mapper: ObjectMapper): EncodeAnyJsonResponse =
+    new EncodeAnyResponse.Aux[Witness.`"application/json"`.T] {
       def apply[A](rep: A): Buf = Utf8(mapper.writeValueAsString(rep))
-      def contentType: String = "application/json"
     }
 }

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -24,5 +24,5 @@ package object json4s {
    * @return
    */
   implicit def encodeJson[A <: AnyRef](implicit formats: Formats): EncodeResponse[A] =
-    EncodeResponse.fromString[A]("application/json") { write(_) }
+    EncodeResponse("application/json").fromString[A] { write(_) }
 }


### PR DESCRIPTION
This is a quick proof of concept to follow up on the conversation in #328 this afternoon. The issue is that it's currently easy to accidentally use an `EncodeResponse[String]` instance that's intended for encoding strings as JSON when you just want to encode a string as plain text.

This change adds a type member to `EncodeResponse` that tracks the content type as a type-level string (this allows us to avoid enumerating content types as singleton objects or whatever).

The behavior is still the same when you don't specify the content type:

```scala
scala> import io.finch.response._
import io.finch.response.EncodeResponse

scala> implicitly[EncodeResponse[String]].apply("foo")
res0: com.twitter.io.Buf = ByteBuffer(3)

scala> import io.finch.argonaut._
import io.finch.argonaut._

scala> implicitly[EncodeResponse[String]].apply("foo")
res1: com.twitter.io.Buf = ByteBuffer(5)
```

But when you do specify the content type you'll get the instance you want:

```scala
scala> implicitly[EncodeTextResponse[String]].apply("foo")
res2: com.twitter.io.Buf = ByteBuffer(3)

scala> implicitly[EncodeJsonResponse[String]].apply("foo")
res3: com.twitter.io.Buf = ByteBuffer(5)
```

Here `EncodeTextResponse` and `EncodeJsonResponse` are just type aliases:

```scala
type EncodeTextResponse[-A] = EncodeResponse.Aux[A, Witness.`"text/plain"`.T]
type EncodeJsonResponse[-A] = EncodeResponse.Aux[A, Witness.`"application/json"`.T]
```

(The `Witness` syntax is handy but kind of unpleasant looking.)

Note that the usage of `EncodeResponse.apply` is changed up a bit in order to help Scala's type inference be a little more useful. Otherwise there are no changes to tests or examples.