### PR TITLE
Use -Yrepl-class-based to avoid getSimpleName errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ val baseSettings = Seq(
       case _ => Seq.empty
     }
   ),
-  scalacOptions in (Compile, console) := compilerOptions,
+  scalacOptions in (Compile, console) := compilerOptions :+ "-Yrepl-class-based",
   wartremoverWarnings in (Compile, compile) ++= Warts.allBut(Wart.NoNeedForMonad, Wart.Null, Wart.DefaultArguments)
 )
 


### PR DESCRIPTION
`NotParsed` currently uses `.getSimpleName` in error strings, which causes "Malformed class name" problems for types defined in the REPL.

We may want to change this eventually, but in the meantime enabling `-Yrepl-class-based` for REPL sessions fixes the issue, and as far as I can tell doesn't break anything (I can run through the examples in [my new hands-on tutorial draft](https://github.com/travisbrown/finch/blob/topic/tutorial/docs/tutorial.md), for example).