### PR TITLE
Add explicit type parameters to avoid inferring Nothing

### DIFF
--- a/core/src/main/scala/io/finch/route/Router.scala
+++ b/core/src/main/scala/io/finch/route/Router.scala
@@ -130,7 +130,9 @@ trait Router[A] { self =>
    * Compose this router with another in such a way that coproducts are flattened.
    */
   def :+:[B](that: Router[B])(implicit adjoin: Adjoin[B :+: A :+: CNil]): Router[adjoin.Out] =
-    that.map(b => adjoin(Inl(b))) orElse map(a => adjoin(Inr(Inl(a))))
+    that.map(b => adjoin(Inl[B, A :+: CNil](b))).orElse(
+      map(a => adjoin(Inr[B, A :+: CNil](Inl[A, CNil](a))))
+    )
 
   /**
    * Converts this router to a Finagle service from a request-like type `R` to a [[HttpResponse]].


### PR DESCRIPTION
I agree that #337 is reasonable, but this is a quick and easy fix for these instances.