### PR TITLE
Remove type aliases `HttpRequest` and `HttpResponse`

### DIFF
--- a/auth/src/main/io/finch/auth/BasicallyAuthorize.scala
+++ b/auth/src/main/io/finch/auth/BasicallyAuthorize.scala
@@ -24,11 +24,12 @@ package io.finch.auth
 
 import io.finch._
 import io.finch.response._
+import com.twitter.finagle.httpx.{Response, Request}
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util.Base64StringEncoder
 
-case class BasicallyAuthorize(user: String, password: String) extends SimpleFilter[HttpRequest, HttpResponse] {
-  def apply(req: HttpRequest, service: Service[HttpRequest, HttpResponse]) = {
+case class BasicallyAuthorize(user: String, password: String) extends SimpleFilter[Request, Response] {
+  def apply(req: Request, service: Service[Request, Response]) = {
     val userInfo = s"$user:$password"
     val expected = "Basic " + Base64StringEncoder.encode(userInfo.getBytes)
 

--- a/auth/src/test/io/finch/auth/BasicallyAuthorizeSpec.scala
+++ b/auth/src/test/io/finch/auth/BasicallyAuthorizeSpec.scala
@@ -23,10 +23,10 @@
 package io.finch.auth
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Request, Status}
+import com.twitter.finagle.httpx.{Response, Request, Status}
 import com.twitter.util.{Await, Base64StringEncoder, Future}
 import io.finch.response.Ok
-import io.finch.{HttpRequest, HttpResponse, _}
+import io.finch.auth.BasicallyAuthorize
 import org.scalatest.{Matchers, FlatSpec}
 
 class BasicallyAuthorizeSpec extends FlatSpec with Matchers {
@@ -53,7 +53,7 @@ class BasicallyAuthorizeSpec extends FlatSpec with Matchers {
 
   private def encode(user: String, password: String) = "Basic " + Base64StringEncoder.encode(s"$user:$password".getBytes)
 
-  private def okService() = new Service[HttpRequest, HttpResponse] {
-    override def apply(request: HttpRequest): Future[HttpResponse] = Ok().toFuture
+  private def okService() = new Service[Request, Response] {
+    override def apply(request: Request): Future[Response] = Ok().toFuture
   }
 }

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/UserService.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/UserService.scala
@@ -1,10 +1,10 @@
 package io.finch.benchmarks.service
 
 import com.twitter.finagle.Service
-import io.finch.{HttpRequest, HttpResponse}
+import com.twitter.finagle.httpx.{Response, Request}
 
 abstract class UserService {
   val db: UserDb = new UserDb
 
-  def backend: Service[HttpRequest, HttpResponse]
+  def backend: Service[Request, Response]
 }

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
@@ -1,7 +1,7 @@
 package io.finch.benchmarks.service
 
+import com.twitter.finagle.httpx.Response
 import com.twitter.util.Await
-import io.finch.HttpResponse
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
@@ -27,21 +27,21 @@ abstract class UserServiceBenchmark(service: () => UserService)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
-  def createUsers(): Seq[HttpResponse] = Await.result(runCreateUsers)
+  def createUsers(): Seq[Response] = Await.result(runCreateUsers)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
-  def getUsers(): Seq[HttpResponse] = Await.result(runGetUsers)
+  def getUsers(): Seq[Response] = Await.result(runGetUsers)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
-  def updateUsers(): Seq[HttpResponse] = Await.result(runUpdateUsers)
+  def updateUsers(): Seq[Response] = Await.result(runUpdateUsers)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
-  def getAllUsers(): HttpResponse = Await.result(runGetAllUsers)
+  def getAllUsers(): Response = Await.result(runGetAllUsers)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.AverageTime))
-  def deleteAllUsers(): HttpResponse = Await.result(runDeleteAllUsers)
+  def deleteAllUsers(): Response = Await.result(runDeleteAllUsers)
 }

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -24,14 +24,14 @@ package io.finch
 
 import com.twitter.util.Future
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.Method
+import com.twitter.finagle.httpx.{Response, Request, Method}
 import com.twitter.finagle.httpx.path.Path
 import com.twitter.finagle.httpx.service.NotFoundService
 
 /**
  * A REST API endpoint that primary defines a ''route'' and might be implicitly
  * converted into Finagle service ''Service[Req, Rep]'' if there is an implicit
- * view from ''Req'' to ''HttpRequest'' available in the scope.
+ * view from ''Req'' to ''Request'' available in the scope.
  *
  * @tparam Req the request type
  * @tparam Rep the response type
@@ -117,8 +117,8 @@ object Endpoint {
   /**
    * A robust 404 respond for missing endpoints.
    */
-  val NotFound: Endpoint[HttpRequest, HttpResponse] = new Endpoint[HttpRequest, HttpResponse] {
-    private val underlying = new NotFoundService[HttpRequest]
+  val NotFound: Endpoint[Request, Response] = new Endpoint[Request, Response] {
+    private val underlying = new NotFoundService[Request]
     override def route = { case _ => underlying }
   }
 
@@ -133,10 +133,10 @@ object Endpoint {
   /**
    * Allows to use an ''Endpoint'' when ''Service'' is expected. The implicit
    * conversion is possible if there is an implicit view from ''Req'' to
-   * ''HttpRequest'' available in the scope.
+   * ''Request'' available in the scope.
    *
    * {{{
-   *   val e: Endpoint[HttpRequest, HttpResponse] = ???
+   *   val e: Endpoint[Request, Response] = ???
    *   Httpx.serve(new InetSocketAddress(8081), e)
    * }}}
    *
@@ -147,7 +147,7 @@ object Endpoint {
    *
    * @return a service that delegates the requests to the underlying endpoint
    */
-  implicit def endpointToService[Req, Rep](e: Endpoint[Req, Rep])(implicit ev: Req => HttpRequest): Service[Req, Rep] =
+  implicit def endpointToService[Req, Rep](e: Endpoint[Req, Rep])(implicit ev: Req => Request): Service[Req, Rep] =
     new Service[Req, Rep] {
       def apply(req: Req): Future[Rep] = e.route(req.method -> Path(req.path))(req)
     }

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -22,10 +22,6 @@
 
 package io
 
-import com.twitter.finagle.httpx.path.Path
-import io.finch.response.{Ok, EncodeResponse}
-
-import com.twitter.finagle.httpx
 import com.twitter.util.Future
 import com.twitter.finagle.Service
 import com.twitter.finagle.Filter
@@ -43,7 +39,7 @@ import com.twitter.finagle.Filter
  * two routers in terms of the inclusive or operator.
  *
  * {{{
- *   val router: Endpoint[HttpRequest, HttpResponse] =
+ *   val router: Endpoint[Request, Response] =
  *     Get / ("users" | "user") / int /> GetUser
  * }}}
  *
@@ -68,20 +64,10 @@ import com.twitter.finagle.Filter
  * type depending on a content. There are plenty of predefined builders that might be used directly.
  *
  * {{{
- *   val ok: HttpResponse = Ok("Hello, world!") // plain/text HTTP response with status code 200
+ *   val ok: Response = Ok("Hello, world!") // plain/text HTTP response with status code 200
  * }}}
  */
 package object finch {
-
-  /**
-   * An alias for [[com.twitter.finagle.httpx.Request httpx.Request]].
-   */
-  type HttpRequest = httpx.Request
-
-  /**
-   * An alias for [[com.twitter.finagle.httpx.Response httpx.Response]].
-   */
-  type HttpResponse = httpx.Response
 
   /**
    * Alters any object within a `toFuture` method.

--- a/core/src/main/scala/io/finch/request/RequestReader.scala
+++ b/core/src/main/scala/io/finch/request/RequestReader.scala
@@ -26,6 +26,7 @@
 
 package io.finch.request
 
+import com.twitter.finagle.httpx.Request
 import com.twitter.util.Future
 import io.finch._
 import io.finch.request.items._
@@ -59,7 +60,7 @@ object RequestReader {
    * @param value the value the new reader should produce
    * @return a new reader that always produces the specified value
    */
-  def const[A](value: Future[A]): RequestReader[A] = embed[HttpRequest, A](MultipleItems)(_ => value)
+  def const[A](value: Future[A]): RequestReader[A] = embed[Request, A](MultipleItems)(_ => value)
 
   /**
    * Creates a new [[io.finch.request.RequestReader RequestReader]] that reads the result from the request.

--- a/core/src/main/scala/io/finch/request/ToRequest.scala
+++ b/core/src/main/scala/io/finch/request/ToRequest.scala
@@ -1,12 +1,12 @@
 package io.finch.request
 
-import io.finch.HttpRequest
+import com.twitter.finagle.httpx.Request
 
 /**
- * A type class that provides a conversion from some type to a [[HttpRequest]].
+ * A type class that provides a conversion from some type to a [[Request]].
  */
 trait ToRequest[R] {
-  def apply(r: R): HttpRequest
+  def apply(r: R): Request
 }
 
 object ToRequest {
@@ -14,12 +14,12 @@ object ToRequest {
    * A convenience method that supports creating a [[ToRequest]] instance from
    * a function.
    */
-  def apply[R](converter: R => HttpRequest): ToRequest[R] = new ToRequest[R] {
-    def apply(r: R): HttpRequest = converter(r)
+  def apply[R](converter: R => Request): ToRequest[R] = new ToRequest[R] {
+    def apply(r: R): Request = converter(r)
   }
 
   /**
-   * An identity instance for [[HttpRequest]] itself.
+   * An identity instance for [[Request]] itself.
    */
-  implicit val requestIdentity: ToRequest[HttpRequest] = apply(identity)
+  implicit val requestIdentity: ToRequest[Request] = apply(identity)
 }

--- a/core/src/main/scala/io/finch/response/EncodeResponse.scala
+++ b/core/src/main/scala/io/finch/response/EncodeResponse.scala
@@ -25,6 +25,7 @@
 package io.finch.response
 
 import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.Response
 import com.twitter.io.Buf
 import com.twitter.io.Buf.Utf8
 import com.twitter.util.Future
@@ -87,8 +88,8 @@ trait EncodeAnyResponse {
   def contentType: String
 }
 
-class TurnIntoHttp[A](val e: EncodeResponse[A]) extends Service[A, HttpResponse] {
-  def apply(req: A): Future[HttpResponse] = Ok(req)(e).toFuture
+class TurnIntoHttp[A](val e: EncodeResponse[A]) extends Service[A, Response] {
+  def apply(req: A): Future[Response] = Ok(req)(e).toFuture
 }
 
 /**
@@ -96,5 +97,5 @@ class TurnIntoHttp[A](val e: EncodeResponse[A]) extends Service[A, HttpResponse]
  * [[io.finch.response.EncodeResponse EncodeResponse]].
  */
 object TurnIntoHttp {
-  def apply[A](implicit e: EncodeResponse[A]): Service[A, HttpResponse] = new TurnIntoHttp[A](e)
+  def apply[A](implicit e: EncodeResponse[A]): Service[A, Response] = new TurnIntoHttp[A](e)
 }

--- a/core/src/main/scala/io/finch/response/Redirect.scala
+++ b/core/src/main/scala/io/finch/response/Redirect.scala
@@ -25,6 +25,7 @@
 package io.finch.response
 
 import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.{Response, Request}
 import com.twitter.finagle.httpx.path.Path
 import io.finch._
 
@@ -39,8 +40,8 @@ object Redirect {
    *
    * @return A Service that generates a redirect to the given url
    */
-  def apply(url: String): Service[HttpRequest, HttpResponse] = new Service[HttpRequest, HttpResponse] {
-    override def apply(req: HttpRequest) = SeeOther.withHeaders(("Location", url))().toFuture
+  def apply(url: String): Service[Request, Response] = new Service[Request, Response] {
+    override def apply(req: Request) = SeeOther.withHeaders(("Location", url))().toFuture
   }
 
   /**
@@ -50,5 +51,5 @@ object Redirect {
    *
    * @return A Service that generates a redirect to the given path
    */
-  def apply(path: Path): Service[HttpRequest, HttpResponse] = this(path.toString)
+  def apply(path: Path): Service[Request, Response] = this(path.toString)
 }

--- a/core/src/main/scala/io/finch/response/ResponseBuilder.scala
+++ b/core/src/main/scala/io/finch/response/ResponseBuilder.scala
@@ -24,7 +24,6 @@
 
 package io.finch.response
 
-import io.finch._
 import com.twitter.finagle.httpx.{Cookie, Response, Status}
 
 /**
@@ -76,7 +75,7 @@ case class ResponseBuilder(
    *
    * @param body the response body
    */
-  def apply[A](body: A)(implicit encode: EncodeResponse[A]): HttpResponse = {
+  def apply[A](body: A)(implicit encode: EncodeResponse[A]): Response = {
     val rep = Response(status)
     rep.contentType = contentType.getOrElse(encode.contentType)
     charset.orElse(encode.charset).foreach { c => rep.charset = c }
@@ -90,7 +89,7 @@ case class ResponseBuilder(
   /**
    * Builds an empty HTTP response.
    */
-  def apply(): HttpResponse = {
+  def apply(): Response = {
     val rep = Response(status)
     headers.foreach { case (k, v) => rep.headerMap.add(k, v) }
     cookies.foreach { rep.addCookie }

--- a/core/src/main/scala/io/finch/response/package.scala
+++ b/core/src/main/scala/io/finch/response/package.scala
@@ -33,7 +33,7 @@ package io.finch
  * instead of abstract `ResponseBuilder` itself.
  *
  * {{{
- *   val ok: HttpResponse = Ok("Hello, World!")
+ *   val ok: Response = Ok("Hello, World!")
  * }}}
  *
  * In addition to `text/plain` responses, the `ResponseBuilder` is able to build any response, whose `content-type` is
@@ -43,7 +43,7 @@ package io.finch
  *
  * {{{
  *   implicit val encodeBigInt = EncodeResponse[BigInt]("text/plain") { _.toString }
- *   val ok: HttpResponse = Ok(BigInt(100))
+ *   val ok: Response = Ok(BigInt(100))
  * }}}
  */
 package object response

--- a/core/src/main/scala/io/finch/route/RouterInput.scala
+++ b/core/src/main/scala/io/finch/route/RouterInput.scala
@@ -1,15 +1,15 @@
 package io.finch.route
 
-import io.finch.HttpRequest
+import com.twitter.finagle.httpx.Request
 
 /**
  * An input for [[Router]].
  */
-final case class RouterInput(request: HttpRequest, path: Seq[String]) {
+final case class RouterInput(request: Request, path: Seq[String]) {
   def headOption: Option[String] = path.headOption
   def drop(n: Int): RouterInput = copy(path = path.drop(n))
 }
 
 object RouterInput {
-  def apply(req: HttpRequest): RouterInput = RouterInput(req, req.path.split("/").toList.drop(1))
+  def apply(req: Request): RouterInput = RouterInput(req, req.path.split("/").toList.drop(1))
 }

--- a/core/src/main/scala/io/finch/route/ToService.scala
+++ b/core/src/main/scala/io/finch/route/ToService.scala
@@ -1,9 +1,9 @@
 package io.finch.route
 
 import com.twitter.finagle.Service
+import com.twitter.finagle.httpx.Response
 import com.twitter.util.Future
 import io.finch._
-import io.finch.HttpResponse
 import io.finch.request.{RequestReader, ToRequest}
 import io.finch.response.{EncodeResponse, NotFound, Ok}
 import scala.annotation.implicitNotFound
@@ -12,18 +12,18 @@ import shapeless.ops.coproduct.Folder
 
 /**
  * Represents a conversion from a router returning a result type `A` to a
- * Finagle service from a request-like type `R` to a [[HttpResponse]].
+ * Finagle service from a request-like type `R` to a [[Response]].
  */
 @implicitNotFound(
-"""You can only convert a router into a Finagle service from ${R} to an HttpResponse if ${R} can be
-converted into an HttpRequest, and if the result type of the router is one of the following:
+"""You can only convert a router into a Finagle service from ${R} to an Response if ${R} can be
+converted into an Request, and if the result type of the router is one of the following:
 
-  * An HttpResponse
+  * An Response
   * A value of a type with an EncodeResponse instance
-  * A future of an HttpResponse
+  * A future of an Response
   * A future of a value of a type with an EncodeResponse instance
   * A RequestReader that returns a value of a type with an EncodeResponse instance
-  * A Finagle service that returns an HttpResponse
+  * A Finagle service that returns an Response
   * A Finagle service that returns a value of a type with an EncodeResponse instance
   * A coproduct made up of some combination of the above
 
@@ -32,7 +32,7 @@ ${A} (or for some part of ${A}).
 """
 )
 trait ToService[R, A] {
-  def apply(router: Router[A]): Service[R, HttpResponse]
+  def apply(router: Router[A]): Service[R, Response]
 }
 
 object ToService extends LowPriorityToServiceInstances {
@@ -40,9 +40,9 @@ object ToService extends LowPriorityToServiceInstances {
    * An instance for coproducts with appropriately typed elements.
    */
   implicit def coproductRouterToService[R: ToRequest, C <: Coproduct](implicit
-    folder: Folder.Aux[EncodeAll.type, C, Service[R, HttpResponse]]
+    folder: Folder.Aux[EncodeAll.type, C, Service[R, Response]]
   ): ToService[R, C] = new ToService[R, C] {
-    def apply(router: Router[C]): Service[R, HttpResponse] = routerToService(router.map(folder(_)))
+    def apply(router: Router[C]): Service[R, Response] = routerToService(router.map(folder(_)))
   }
 }
 
@@ -51,14 +51,14 @@ trait LowPriorityToServiceInstances {
    * An instance for types that can be transformed into a Finagle service.
    */
   implicit def valueRouterToService[R: ToRequest, A](implicit
-    polyCase: EncodeAll.Case.Aux[A, Service[R, HttpResponse]]
+    polyCase: EncodeAll.Case.Aux[A, Service[R, Response]]
   ): ToService[R, A] = new ToService[R, A] {
-    def apply(router: Router[A]): Service[R, HttpResponse] =
+    def apply(router: Router[A]): Service[R, Response] =
       routerToService(router.map(polyCase(_)))
   }
 
-  protected def routerToService[R: ToRequest](r: Router[Service[R, HttpResponse]]): Service[R, HttpResponse] =
-    Service.mk[R, HttpResponse] { req =>
+  protected def routerToService[R: ToRequest](r: Router[Service[R, Response]]): Service[R, Response] =
+    Service.mk[R, Response] { req =>
       r(RouterInput(implicitly[ToRequest[R]].apply(req))) match {
         case Some((output, service)) if output.path.isEmpty => service(req)
         case _ => NotFound().toFuture
@@ -67,48 +67,48 @@ trait LowPriorityToServiceInstances {
 
   /**
    * A polymorphic function value that accepts types that can be transformed into a Finagle service from a request-like
-   * type to a [[HttpResponse]].
+   * type to a [[Response]].
    */
   protected object EncodeAll extends Poly1 {
     /**
-     * Transforms an [[HttpResponse]] directly into a constant service.
+     * Transforms an [[Response]] directly into a constant service.
      */
-    implicit def response[R: ToRequest]: Case.Aux[HttpResponse, Service[R, HttpResponse]] =
+    implicit def response[R: ToRequest]: Case.Aux[Response, Service[R, Response]] =
       at(r => Service.const(r.toFuture))
 
     /**
      * Transforms an encodeable value into a constant service.
      */
-    implicit def encodeable[R: ToRequest, A: EncodeResponse]: Case.Aux[A, Service[R, HttpResponse]] =
+    implicit def encodeable[R: ToRequest, A: EncodeResponse]: Case.Aux[A, Service[R, Response]] =
       at(a => Service.const(Ok(a).toFuture))
 
     /**
-     * Transforms an [[HttpResponse]] in a future into a constant service.
+     * Transforms an [[Response]] in a future into a constant service.
      */
-    implicit def futureResponse[R: ToRequest]: Case.Aux[Future[HttpResponse], Service[R, HttpResponse]] =
+    implicit def futureResponse[R: ToRequest]: Case.Aux[Future[Response], Service[R, Response]] =
       at(Service.const)
 
     /**
      * Transforms an encodeable value in a future into a constant service.
      */
-    implicit def futureEncodeable[R: ToRequest, A: EncodeResponse]: Case.Aux[Future[A], Service[R, HttpResponse]] =
+    implicit def futureEncodeable[R: ToRequest, A: EncodeResponse]: Case.Aux[Future[A], Service[R, Response]] =
       at(fa => Service.const(fa.map(Ok(_))))
 
     /**
      * Transforms a [[RequestReader]] into a service.
      */
-    implicit def requestReader[R: ToRequest, A: EncodeResponse]: Case.Aux[RequestReader[A], Service[R, HttpResponse]] =
+    implicit def requestReader[R: ToRequest, A: EncodeResponse]: Case.Aux[RequestReader[A], Service[R, Response]] =
       at(reader => Service.mk(req => reader(implicitly[ToRequest[R]].apply(req)).map(Ok(_))))
 
     /**
-     * An identity transformation for services that return an [[HttpResponse]].
+     * An identity transformation for services that return an [[Response]].
      *
-     * Note that the service may have a static type that is more specific than `Service[R, HttpResponse]`.
+     * Note that the service may have a static type that is more specific than `Service[R, Response]`.
      */
     implicit def serviceResponse[S, R](implicit
-      ev: S => Service[R, HttpResponse],
+      ev: S => Service[R, Response],
       tr: ToRequest[R]
-    ): Case.Aux[S, Service[R, HttpResponse]] =
+    ): Case.Aux[S, Service[R, Response]] =
       at(s => Service.mk(req => ev(s)(req)))
 
     /**
@@ -119,7 +119,7 @@ trait LowPriorityToServiceInstances {
       ev: S => Service[R, A],
       tr: ToRequest[R],
       ae: EncodeResponse[A]
-    ): Case.Aux[S, Service[R, HttpResponse]] =
+    ): Case.Aux[S, Service[R, Response]] =
       at(s => Service.mk(req => ev(s)(req).map(Ok(_))))
   }
 }

--- a/core/src/main/scala/io/finch/route/package.scala
+++ b/core/src/main/scala/io/finch/route/package.scala
@@ -38,8 +38,8 @@ import shapeless.ops.adjoin.Adjoin
  * `Service[Req, Rep]`. Thus, the following example is a valid Finch code:
  *
  * {{{
- *   def hello(s: String) = new Service[HttRequest, HttpResponse] {
- *     def apply(req: HttpRequest) = Ok(s"Hello $name!").toFuture
+ *   def hello(s: String) = new Service[HttRequest, Response] {
+ *     def apply(req: Request) = Ok(s"Hello $name!").toFuture
  *   }
  *
  *   Httpx.serve(

--- a/core/src/test/scala/io/finch/FilterOpsSpec.scala
+++ b/core/src/test/scala/io/finch/FilterOpsSpec.scala
@@ -23,23 +23,20 @@
 
 package io.finch
 
-
 import com.twitter.finagle.{SimpleFilter, Service}
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
-import io.finch.response.Ok
 import org.scalatest.{Matchers, FlatSpec}
-
 
 class FilterOpsSpec extends FlatSpec with Matchers {
 
-  private[finch] class PrefixFilter(val prefix: String) extends SimpleFilter[HttpRequest, String] {
-    def apply(req: HttpRequest, service: Service[HttpRequest, String]): Future[String] = {
+  private[finch] class PrefixFilter(val prefix: String) extends SimpleFilter[Request, String] {
+    def apply(req: Request, service: Service[Request, String]): Future[String] = {
       service(req) map { rep => prefix ++ rep }
     }
   }
 
-  val bar = Service.mk { (_: HttpRequest) => Future.value("bar") }
+  val bar = Service.mk { (_: Request) => Future.value("bar") }
   val req = Request("/")
 
   "FilterOps" should "allow for chaining a filter to a service" in {

--- a/core/src/test/scala/io/finch/ServiceOpsSpec.scala
+++ b/core/src/test/scala/io/finch/ServiceOpsSpec.scala
@@ -31,7 +31,7 @@ import io.finch.response.Ok
 import org.scalatest.{Matchers, FlatSpec}
 
 class ServiceOpsSpec extends FlatSpec with Matchers {
-  val foo = Service.mk { (_: HttpRequest) => Future.value("foo") }
+  val foo = Service.mk { (_: Request) => Future.value("foo") }
   val bar = Service.mk {
     (req: String) => {
       Future.value(Ok(req ++ "bar"))

--- a/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
@@ -22,7 +22,6 @@
  */
 package io.finch.request
 
-import io.finch.HttpRequest
 import org.scalatest.{FlatSpec, Matchers}
 
 import com.twitter.finagle.httpx.Request
@@ -31,8 +30,8 @@ import items._
 
 class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
 
-  case class MyReq(http: HttpRequest, i: Int)
-  implicit val reqEv: MyReq %> HttpRequest = View(_.http)
+  case class MyReq(http: Request, i: Int)
+  implicit val reqEv: MyReq %> Request = View(_.http)
 
   val reader: RequestReader[(Int, Double, Int)] = (
     param("a").as[Int] ::

--- a/core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/core/src/test/scala/io/finch/request/BodySpec.scala
@@ -26,7 +26,6 @@ package io.finch.request
 import com.twitter.finagle.httpx.Request
 import com.twitter.io.Buf.ByteArray
 import com.twitter.util.{Await, Future, Try}
-import io.finch.HttpRequest
 import org.scalatest.{FlatSpec, Matchers}
 import items._
 
@@ -35,13 +34,13 @@ class BodySpec extends FlatSpec with Matchers {
   val fooBytes = foo.getBytes("UTF-8")
 
   "A RequiredArrayBody" should "be properly read if it exists" in {
-    val request: HttpRequest = requestWithBody(fooBytes)
+    val request: Request = requestWithBody(fooBytes)
     val futureResult: Future[Array[Byte]] = binaryBody(request)
     Await.result(futureResult) shouldBe fooBytes
   }
 
   it should "produce an error if the body is empty" in {
-    val request: HttpRequest = requestWithBody(Array[Byte]())
+    val request: Request = requestWithBody(Array[Byte]())
     val futureResult: Future[Array[Byte]] = binaryBody(request)
     a [NotPresent] shouldBe thrownBy(Await.result(futureResult))
   }
@@ -51,13 +50,13 @@ class BodySpec extends FlatSpec with Matchers {
   }
 
   "An OptionalArrayBody" should "be properly read if it exists" in {
-    val request: HttpRequest = requestWithBody(fooBytes)
+    val request: Request = requestWithBody(fooBytes)
     val futureResult: Future[Option[Array[Byte]]] = binaryBodyOption(request)
     Await.result(futureResult).get shouldBe fooBytes
   }
 
   it should "produce an error if the body is empty" in {
-    val request: HttpRequest = requestWithBody(Array[Byte]())
+    val request: Request = requestWithBody(Array[Byte]())
     val futureResult: Future[Option[Array[Byte]]] = binaryBodyOption(request)
     Await.result(futureResult) shouldBe None
   }
@@ -67,25 +66,25 @@ class BodySpec extends FlatSpec with Matchers {
   }
 
   "A RequiredStringBody" should "be properly read if it exists" in {
-    val request: HttpRequest = requestWithBody(foo)
+    val request: Request = requestWithBody(foo)
     val futureResult: Future[String] = body(request)
     Await.result(futureResult) shouldBe foo
   }
 
   it should "produce an error if the body is empty" in {
-    val request: HttpRequest = requestWithBody("")
+    val request: Request = requestWithBody("")
     val futureResult: Future[String] = body(request)
     a [NotPresent] shouldBe thrownBy(Await.result(futureResult))
   }
 
   "An OptionalStringBody" should "be properly read if it exists" in {
-    val request: HttpRequest = requestWithBody(foo)
+    val request: Request = requestWithBody(foo)
     val futureResult: Future[Option[String]] = bodyOption(request)
     Await.result(futureResult) shouldBe Some(foo)
   }
 
   it should "produce an error if the body is empty" in {
-    val request: HttpRequest = requestWithBody("")
+    val request: Request = requestWithBody("")
     val futureResult: Future[Option[String]] = bodyOption(request)
     Await.result(futureResult) shouldBe None
   }
@@ -95,7 +94,7 @@ class BodySpec extends FlatSpec with Matchers {
       body <- binaryBody
     } yield body
 
-    val request: HttpRequest = requestWithBody(fooBytes)
+    val request: Request = requestWithBody(fooBytes)
     Await.result(reader(request)) shouldBe fooBytes
   }
 
@@ -115,11 +114,11 @@ class BodySpec extends FlatSpec with Matchers {
     Await.result(o) shouldBe Some(123)
   }
 
-  it should "work with custom request and its implicit view to HttpRequest" in {
+  it should "work with custom request and its implicit view to Request" in {
     implicit val decodeDouble = new DecodeRequest[Double] { // custom encoder
       def apply(req: String): Try[Double] = Try(req.toDouble)
     }
-    case class CReq(http: HttpRequest) // custom request
+    case class CReq(http: Request) // custom request
     implicit val cReqEv = (req: CReq) => req.http // implicit view
 
     val req = CReq(requestWithBody("42.0"))
@@ -150,11 +149,11 @@ class BodySpec extends FlatSpec with Matchers {
     a [NotParsed] shouldBe thrownBy(Await.result(o))
   }
 
-  private[this] def requestWithBody(body: String): HttpRequest = {
+  private[this] def requestWithBody(body: String): Request = {
     requestWithBody(body.getBytes("UTF-8"))
   }
 
-  private[this] def requestWithBody(body: Array[Byte]): HttpRequest = {
+  private[this] def requestWithBody(body: Array[Byte]): Request = {
     val r = Request()
     r.content = ByteArray.Owned(body)
     r.contentLength = body.length.toLong

--- a/core/src/test/scala/io/finch/request/CookieSpec.scala
+++ b/core/src/test/scala/io/finch/request/CookieSpec.scala
@@ -25,7 +25,6 @@ package io.finch.request
 
 import com.twitter.finagle.httpx.{Request, Cookie}
 import com.twitter.util.{Await, Future}
-import io.finch.HttpRequest
 import org.scalatest.{Matchers, FlatSpec}
 
 class CookieSpec extends FlatSpec with Matchers {
@@ -34,7 +33,7 @@ class CookieSpec extends FlatSpec with Matchers {
   val c = new Cookie(name, "some-random-value")
 
   "A ResponseBuilder" should "read a required cookie" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     request.addCookie(c)
     val futureResult: Future[Cookie] = cookie(name)(request)
 
@@ -42,7 +41,7 @@ class CookieSpec extends FlatSpec with Matchers {
   }
 
   it should "throw an exception if the require cookie does not exist" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     request.addCookie(c)
     val futureResult: Future[Cookie] = cookie("another-cookie")(request)
 
@@ -50,7 +49,7 @@ class CookieSpec extends FlatSpec with Matchers {
   }
 
   it should "read an optional cookie if it exists" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     request.addCookie(c)
     val futureResult: Future[Option[Cookie]] = cookieOption(name)(request)
 
@@ -58,7 +57,7 @@ class CookieSpec extends FlatSpec with Matchers {
   }
 
   it should "read None if the cookie name does not exist" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     val futureResult: Future[Option[Cookie]] = cookieOption(name)(request)
 
     Await.result(futureResult) shouldBe None

--- a/core/src/test/scala/io/finch/request/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/request/DecodeSpec.scala
@@ -27,7 +27,6 @@ import org.scalatest.{Matchers, FlatSpec}
 import com.twitter.util.{Try, Return, Await}
 import com.twitter.finagle.httpx.Request
 import scala.math._
-import io.finch.HttpRequest
 import scala.reflect.ClassTag
 
 class DecodeSpec extends FlatSpec with Matchers {
@@ -45,56 +44,56 @@ class DecodeSpec extends FlatSpec with Matchers {
   }
   
   "A RequestReader for a String" should "allow for type conversions based on implicit DecodeRequest" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val reader: RequestReader[Int] = param("foo").as[Int]
     val result = reader(request)
     Await.result(result) shouldBe 5
   }
   
   it should "fail if a type conversions based on implicit DecodeRequest fails" in {
-    val request: HttpRequest = Request(("foo", "foo"))
+    val request: Request = Request(("foo", "foo"))
     val reader: RequestReader[Int] = param("foo").as[Int]
     val result = reader(request)
     Await.result(result.liftToTry).isThrow shouldBe true
   }
   
   it should "allow for type conversions of optional parameters" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val reader: RequestReader[Option[Int]] = paramOption("foo").as[Int]
     val result = reader(request)
     Await.result(result) shouldBe Some(5)
   }
   
   it should "fail if a type conversions for an optional value fails" in {
-    val request: HttpRequest = Request(("foo", "foo"))
+    val request: Request = Request(("foo", "foo"))
     val reader: RequestReader[Option[Int]] = paramOption("foo").as[Int]
     val result = reader(request)
     Await.result(result.liftToTry).isThrow shouldBe true
   }
   
   it should "skip type conversion and succeed if the optional value is missing" in {
-    val request: HttpRequest = Request(("bar", "foo"))
+    val request: Request = Request(("bar", "foo"))
     val reader: RequestReader[Option[Int]] = paramOption("foo").as[Int]
     val result = reader(request)
     Await.result(result) shouldBe None
   }
   
   it should "allow for type conversions of a parameter list" in {
-    val request: HttpRequest = Request(("foo", "5,6,7"))
+    val request: Request = Request(("foo", "5,6,7"))
     val reader: RequestReader[Seq[Int]] = params("foo").as[Int]
     val result = reader(request)
     Await.result(result) shouldBe Seq(5,6,7)
   }
   
   it should "fail if a type conversion for an element in a parameter list fails" in {
-    val request: HttpRequest = Request(("foo", "5,foo,7"))
+    val request: Request = Request(("foo", "5,foo,7"))
     val reader: RequestReader[Seq[Int]] = params("foo").as[Int]
     val result = reader(request)
     Await.result(result.liftToTry).isThrow shouldBe true
   }
   
   it should "skip type conversion and succeed if a parameter list is empty" in {
-    val request: HttpRequest = Request(("bar", "foo"))
+    val request: Request = Request(("bar", "foo"))
     val reader: RequestReader[Seq[Int]] = params("foo").as[Int]
     val result = reader(request)
     Await.result(result).isEmpty shouldBe true
@@ -113,7 +112,7 @@ class DecodeSpec extends FlatSpec with Matchers {
       def apply(req: String): Try[Foo] = Return(new Foo(req))
     }   
     
-    val request: HttpRequest = Request(("foo", "foo"), ("bar", "bar"))
+    val request: Request = Request(("foo", "foo"), ("bar", "bar"))
     val reader: RequestReader[(Foo, Bar)] = for {
       foo <- param("foo").as[Foo]
       bar <- param("bar").as[Bar]

--- a/core/src/test/scala/io/finch/request/MultipartParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/MultipartParamSpec.scala
@@ -25,7 +25,6 @@ package io.finch.request
 
 import com.twitter.finagle.httpx.{Request, RequestBuilder}
 import com.twitter.util.{Await, Future}
-import io.finch.HttpRequest
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -95,24 +94,24 @@ class MultipartParamSpec extends FlatSpec with Matchers {
   }
 
   "An OptionalMultipartParam" should "be properly parsed when it exists" in {
-    val request: HttpRequest = requestFromBinaryFile("/upload.bytes")
+    val request: Request = requestFromBinaryFile("/upload.bytes")
     val futureResult: Future[Option[String]] = paramOption("type")(request)
     Await.result(futureResult) shouldBe Some("text")
   }
 
   it should "produce an error if the param is empty" in {
-    val request: HttpRequest = requestFromBinaryFile("/upload.bytes")
+    val request: Request = requestFromBinaryFile("/upload.bytes")
     val futureResult: Future[Option[String]] = paramOption("foo")(request)
     Await.result(futureResult) shouldBe None
   }
 
   it should "produce an error if the param name is present but not a param" in {
-    val request: HttpRequest = requestFromBinaryFile("/upload.bytes")
+    val request: Request = requestFromBinaryFile("/upload.bytes")
     val futureResult: Future[Option[String]] = paramOption("groups")(request)
     Await.result(futureResult) shouldBe None
   }
 
-  private[this] def requestFromBinaryFile(resourceName: String): HttpRequest = {
+  private[this] def requestFromBinaryFile(resourceName: String): Request = {
     val s = getClass.getResourceAsStream(resourceName)
     val b = Stream.continually(s.read).takeWhile(_ != -1).map(_.toByte).toArray
     Request.decodeBytes(b)

--- a/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
@@ -25,43 +25,42 @@ package io.finch.request
 
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
-import io.finch._
 import org.scalatest.{Matchers, FlatSpec}
 
 class OptionalParamSpec extends FlatSpec with Matchers {
 
   "An OptionalParam" should "be properly parsed when it exists" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val futureResult: Future[Option[String]] = paramOption("foo")(request)
     Await.result(futureResult) shouldBe Some("5")
   }
 
   it should "return none if the param is not present" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     val futureResult: Future[Option[String]] = paramOption("foo")(request)
     Await.result(futureResult) shouldBe None
   }
 
   it should "return none if the param is empty" in {
-    val request: HttpRequest = Request("foo" -> "")
+    val request: Request = Request("foo" -> "")
     val futureResult: Future[Option[String]] = paramOption("foo")(request)
     Await.result(futureResult) shouldBe None
   }
 
   it should "return provided default value if the param is empty" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     val futureResult: Future[String] = paramOption("foo").withDefault("bar")(request)
     Await.result(futureResult) shouldBe "bar"
   }
 
   it should "return provided alternative option if the param is empty" in {
-    val request: HttpRequest = Request()
+    val request: Request = Request()
     val futureResult: Future[Option[String]] = paramOption("foo").orElse(Some("bar"))(request)
     Await.result(futureResult) shouldBe Some("bar")
   }
 
   it should "return existing value even if default value is provided" in {
-    val request: HttpRequest = Request("foo" -> "baz")
+    val request: Request = Request("foo" -> "baz")
     val futureResult: Future[String] = paramOption("foo").withDefault("bar")(request)
     Await.result(futureResult) shouldBe "baz"
   }
@@ -73,63 +72,63 @@ class OptionalParamSpec extends FlatSpec with Matchers {
 
 
   "An OptionalBooleanParam" should "be parsed as an integer" in {
-    val request: HttpRequest = Request(("foo", "true"))
+    val request: Request = Request(("foo", "true"))
     val futureResult: Future[Option[Boolean]] = paramOption("foo").as[Boolean].apply(request)
     Await.result(futureResult) shouldBe Some(true)
   }
 
   it should "produce an error if the param is not a number" in {
-    val request: HttpRequest = Request(("foo", "non-boolean"))
+    val request: Request = Request(("foo", "non-boolean"))
     val futureResult: Future[Option[Boolean]] = paramOption("foo").as[Boolean].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "An OptionalIntParam" should "be parsed as an integer" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val futureResult: Future[Option[Int]] = paramOption("foo").as[Int].apply(request)
     Await.result(futureResult) shouldBe Some(5)
   }
 
   it should "produce an error if the param is not a number" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Option[Int]] = paramOption("foo").as[Int].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "An OptionalLongParam" should "be parsed as a long" in {
-    val request: HttpRequest = Request(("foo", "9000000000000000"))
+    val request: Request = Request(("foo", "9000000000000000"))
     val futureResult: Future[Option[Long]] = paramOption("foo").as[Long].apply(request)
     Await.result(futureResult) shouldBe Some(9000000000000000L)
   }
 
   it should "produce an error if the param is not a number" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Option[Long]] = paramOption("foo").as[Long].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
   "An OptionalFloatParam" should "be parsed as a double" in {
-    val request: HttpRequest = Request(("foo", "5.123"))
+    val request: Request = Request(("foo", "5.123"))
     val futureResult: Future[Option[Float]] = paramOption("foo").as[Float].apply(request)
     Await.result(futureResult) shouldBe Some(5.123f)
   }
 
   it should "produce an error if the param is not a number" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Option[Float]] = paramOption("foo").as[Float].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
   "An OptionalDoubleParam" should "be parsed as a float" in {
-    val request: HttpRequest = Request(("foo", "100.0"))
+    val request: Request = Request(("foo", "100.0"))
     val futureResult: Future[Option[Double]] = paramOption("foo").as[Double].apply(request)
     Await.result(futureResult) shouldBe Some(100.0)
   }
 
   it should "produce an error if the param is not a number" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Option[Double]] = paramOption("foo").as[Double].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }

--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -24,13 +24,12 @@ package io.finch.request
 
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
-import io.finch._
 import org.scalatest.{Matchers, FlatSpec}
 
 class OptionalParamsSpec extends FlatSpec with Matchers {
 
   "A OptionalParams" should "parse all of the url params with the same key" in {
-    val request: HttpRequest = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
+    val request: Request = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = params("foo")(request)
     val result: Seq[String] = Await.result(futureResult)
     result should have length 2
@@ -39,7 +38,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "return only params that are not the empty string" in {
-    val request: HttpRequest = Request(("foo", ""), ("bar", "6"), ("foo", "25"))
+    val request: Request = Request(("foo", ""), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = params("foo")(request)
     val result: Seq[String] = Await.result(futureResult)
     result should have length 1
@@ -47,13 +46,13 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "return Nil if the parameter does not exist at all" in {
-    val request: HttpRequest = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
+    val request: Request = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = params("baz")(request)
     Await.result(futureResult) shouldBe Nil
   }
 
   it should "return Nil if all of the values for that parameter ar the emptry string" in {
-    val request: HttpRequest = Request(("foo", ""), ("bar", "6"), ("foo", ""))
+    val request: Request = Request(("foo", ""), ("bar", "6"), ("foo", ""))
     val futureResult: Future[Seq[String]] = params("")(request)
     Await.result(futureResult) shouldBe Nil
   }
@@ -65,7 +64,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
 
 
   "A OptionalBooleanParams" should "be parsed as a list of booleans" in {
-    val request: HttpRequest = Request(("foo", "true"), ("foo", "false"))
+    val request: Request = Request(("foo", "true"), ("foo", "false"))
     val futureResult: Future[Seq[Boolean]] = params("foo").as[Boolean].apply(request)
     val result: Seq[Boolean] = Await.result(futureResult)
     result should have length 2
@@ -74,14 +73,14 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a boolean" in {
-    val request: HttpRequest = Request(("foo", "true"), ("foo", "5"))
+    val request: Request = Request(("foo", "true"), ("foo", "5"))
     val futureResult: Future[Seq[Boolean]] = params("foo").as[Boolean].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A OptionalIntParams" should "be parsed as a list of integers" in {
-    val request: HttpRequest = Request(("foo", "5"), ("foo", "255"))
+    val request: Request = Request(("foo", "5"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = params("foo").as[Int].apply(request)
     val result: Seq[Int] = Await.result(futureResult)
     result should have length 2
@@ -90,14 +89,14 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not an integer" in {
-    val request: HttpRequest = Request(("foo", "non-number"), ("foo", "255"))
+    val request: Request = Request(("foo", "non-number"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = params("foo").as[Int].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A OptionalLongParams" should "be parsed as a list of longs" in {
-    val request: HttpRequest = Request(("foo", "9000000000000000"), ("foo", "7500000000000000"))
+    val request: Request = Request(("foo", "9000000000000000"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = params("foo").as[Long].apply(request)
     val result: Seq[Long] = Await.result(futureResult)
     result should have length 2
@@ -106,13 +105,13 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a long" in {
-    val request: HttpRequest = Request(("foo", "false"), ("foo", "7500000000000000"))
+    val request: Request = Request(("foo", "false"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = params("foo").as[Long].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
   "A OptionalFloatParams" should "be parsed as a list of floats" in {
-    val request: HttpRequest = Request(("foo", "5.123"), ("foo", "536.22345"))
+    val request: Request = Request(("foo", "5.123"), ("foo", "536.22345"))
     val futureResult: Future[Seq[Float]] = params("foo").as[Float].apply(request)
     val result: Seq[Float] = Await.result(futureResult)
     result should have length 2
@@ -121,14 +120,14 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a float" in {
-    val request: HttpRequest = Request(("foo", "non-number"), ("foo", "true"), ("foo", "5.123"))
+    val request: Request = Request(("foo", "non-number"), ("foo", "true"), ("foo", "5.123"))
     val futureResult: Future[Seq[Float]] = params("foo").as[Float].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A OptionalDoubleParams" should "be parsed as a list of doubles" in {
-    val request: HttpRequest = Request(("foo", "100.0"), ("foo", "66566.45243"))
+    val request: Request = Request(("foo", "100.0"), ("foo", "66566.45243"))
     val futureResult: Future[Seq[Double]] = params("foo").as[Double].apply(request)
     val result: Seq[Double] = Await.result(futureResult)
     result should have length 2
@@ -137,7 +136,7 @@ class OptionalParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a double" in {
-    val request: HttpRequest = Request(("foo", "45543245.435"), ("foo", "non-number"))
+    val request: Request = Request(("foo", "45543245.435"), ("foo", "non-number"))
     val futureResult: Future[Seq[Double]] = params("foo").as[Double].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }

--- a/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
@@ -31,25 +31,25 @@ import items._
 class RequestReaderCompanionSpec extends FlatSpec with Matchers {
 
   "The RequestReaderCompanion" should "support a factory method based on a function that reads from the request" in {
-    val request: HttpRequest = Request(("foo", "5"))
-    val futureResult: Future[Option[String]] = RequestReader[HttpRequest, Option[String]](_ => Some("5"))(request)
+    val request: Request = Request(("foo", "5"))
+    val futureResult: Future[Option[String]] = RequestReader[Request, Option[String]](_ => Some("5"))(request)
     Await.result(futureResult) shouldBe Some("5")
   }
 
   it should "support a factory method based on a constant Future" in {
-    val request: HttpRequest = Request(("foo", ""))
+    val request: Request = Request(("foo", ""))
     val futureResult: Future[Int] = RequestReader.const(1.toFuture)(request)
     Await.result(futureResult) shouldBe 1
   }
   
   it should "support a factory method based on a constant value" in {
-    val request: HttpRequest = Request(("foo", ""))
+    val request: Request = Request(("foo", ""))
     val futureResult: Future[Int] = RequestReader.value(1)(request)
     Await.result(futureResult) shouldBe 1
   }
   
   it should "support a factory method based on a constant exception" in {
-    val request: HttpRequest = Request(("foo", ""))
+    val request: Request = Request(("foo", ""))
     val futureResult: Future[Int] = RequestReader.exception(NotPresent(BodyItem))(request)
     a [NotPresent] shouldBe thrownBy(Await.result(futureResult))
   }

--- a/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
@@ -24,25 +24,24 @@ package io.finch.request
 
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
-import io.finch.HttpRequest
 import org.scalatest.{Matchers, FlatSpec}
 
 class RequiredParamSpec extends FlatSpec with Matchers {
 
   "A RequiredParam" should "be properly parsed if it exists" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val futureResult: Future[String] = param("foo")(request)
     Await.result(futureResult) shouldBe "5"
   }
 
   it should "produce an error if the param is empty" in {
-    val request: HttpRequest = Request(("foo", ""))
+    val request: Request = Request(("foo", ""))
     val futureResult: Future[String] = param("foo")(request)
     a [NotValid] shouldBe thrownBy(Await.result(futureResult))
   }
 
   it should "produce an error if the param does not exist" in {
-    val request: HttpRequest = Request(("bar", "foo"))
+    val request: Request = Request(("bar", "foo"))
     val futureResult: Future[String] = param("foo")(request)
     a [NotPresent] shouldBe thrownBy(Await.result(futureResult))
   }
@@ -53,19 +52,19 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   }
 
   it should "return the correct result when mapped over" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val reader: RequestReader[String] = param("foo").map(_ * 3)
     Await.result(reader(request)) shouldBe "555"
   }
 
   it should "return the correct result when mapped over with arrow syntax" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val reader: RequestReader[String] = param("foo") ~> (_ * 3)
     Await.result(reader(request)) shouldBe "555"
   }
 
   it should "return the correct result when embedFlatMapped over" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val reader: RequestReader[String] = param("foo").embedFlatMap { foo =>
       Future.value(foo * 4)
     }
@@ -73,7 +72,7 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   }
 
   it should "return the correct result when embedFlatMapped over with arrow syntax" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val reader: RequestReader[String] = param("foo") ~~> { foo =>
       Future.value(foo * 4)
     }
@@ -81,64 +80,64 @@ class RequiredParamSpec extends FlatSpec with Matchers {
   }
 
   "A RequiredBooleanParam" should "be parsed as a boolean" in {
-    val request: HttpRequest = Request(("foo", "true"))
+    val request: Request = Request(("foo", "true"))
     val futureResult: Future[Boolean] = param("foo").as[Boolean].apply(request)
     Await.result(futureResult) shouldBe true
   }
 
   it should "produce an error if the param is not a boolean" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val futureResult: Future[Boolean] = param("foo").as[Boolean].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredIntParam" should "be parsed as an integer" in {
-    val request: HttpRequest = Request(("foo", "5"))
+    val request: Request = Request(("foo", "5"))
     val futureResult: Future[Int] = param("foo").as[Int].apply(request)
     Await.result(futureResult) shouldBe 5
   }
 
   it should "produce an error if the param is not an integer" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Int] = param("foo").as[Int].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredLongParam" should "be parsed as a long" in {
-    val request: HttpRequest = Request(("foo", "9000000000000000"))
+    val request: Request = Request(("foo", "9000000000000000"))
     val futureResult: Future[Long] = param("foo").as[Long].apply(request)
     Await.result(futureResult) shouldBe 9000000000000000L
   }
 
   it should "produce an error if the param is not a long" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Long] = param("foo").as[Long].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
   "A RequiredFloatParam" should "be parsed as a float" in {
-    val request: HttpRequest = Request(("foo", "5.123"))
+    val request: Request = Request(("foo", "5.123"))
     val futureResult: Future[Float] = param("foo").as[Float].apply(request)
     Await.result(futureResult) shouldBe 5.123f
   }
 
   it should "produce an error if the param is not a float" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Float] = param("foo").as[Float].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredDoubleParam" should "be parsed as a double" in {
-    val request: HttpRequest = Request(("foo", "100.0"))
+    val request: Request = Request(("foo", "100.0"))
     val futureResult: Future[Double] = param("foo").as[Double].apply(request)
     Await.result(futureResult) shouldBe 100.0
   }
 
   it should "produce an error if the param is not a double" in {
-    val request: HttpRequest = Request(("foo", "non-number"))
+    val request: Request = Request(("foo", "non-number"))
     val futureResult: Future[Double] = param("foo").as[Double].apply(request)
     a [NotParsed] shouldBe thrownBy(Await.result(futureResult))
   }

--- a/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -25,13 +25,12 @@ package io.finch.request
 
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
-import io.finch._
 import org.scalatest.{Matchers, FlatSpec}
 
 class RequiredParamsSpec extends FlatSpec with Matchers {
 
   "A RequiredParams" should "parse all of the url params with the same key" in {
-    val request: HttpRequest = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
+    val request: Request = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = paramsNonEmpty("foo")(request)
     val result: Seq[String] = Await.result(futureResult)
     result should have length 2
@@ -40,7 +39,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "return only params that are not the empty string" in {
-    val request: HttpRequest = Request(("foo", ""), ("bar", "6"), ("foo", "25"))
+    val request: Request = Request(("foo", ""), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = paramsNonEmpty("foo")(request)
     val result: Seq[String] = Await.result(futureResult)
     result should have length 1
@@ -48,13 +47,13 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "throw a ParamNotFound Exception if the parameter does not exist at all" in {
-    val request: HttpRequest = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
+    val request: Request = Request(("foo", "5"), ("bar", "6"), ("foo", "25"))
     val futureResult: Future[Seq[String]] = paramsNonEmpty("baz")(request)
     a [NotPresent] shouldBe thrownBy(Await.result(futureResult))
   }
 
   it should "throw a Validation Exception if all of the parameter values are empty" in {
-    val request: HttpRequest = Request(("foo", ""), ("bar", "6"), ("foo", ""))
+    val request: Request = Request(("foo", ""), ("bar", "6"), ("foo", ""))
     val futureResult: Future[Seq[String]] = paramsNonEmpty("foo")(request)
     a [NotValid] shouldBe thrownBy(Await.result(futureResult))
   }
@@ -66,7 +65,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
 
 
   "A RequiredBooleanParams" should "be parsed as a list of booleans" in {
-    val request: HttpRequest = Request(("foo", "true"), ("foo", "false"))
+    val request: Request = Request(("foo", "true"), ("foo", "false"))
     val futureResult: Future[Seq[Boolean]] = paramsNonEmpty("foo").as[Boolean].apply(request)
     val result: Seq[Boolean] = Await.result(futureResult)
     result should have length 2
@@ -75,14 +74,14 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a boolean" in {
-    val request: HttpRequest = Request(("foo", "true"), ("foo", "5"))
+    val request: Request = Request(("foo", "true"), ("foo", "5"))
     val futureResult: Future[Seq[Boolean]] = paramsNonEmpty("foo").as[Boolean].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredIntParams" should "be parsed as a list of integers" in {
-    val request: HttpRequest = Request(("foo", "5"), ("foo", "255"))
+    val request: Request = Request(("foo", "5"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = paramsNonEmpty("foo").as[Int].apply(request)
     val result: Seq[Int] = Await.result(futureResult)
     result should have length 2
@@ -91,14 +90,14 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not an integer" in {
-    val request: HttpRequest = Request(("foo", "non-number"), ("foo", "255"))
+    val request: Request = Request(("foo", "non-number"), ("foo", "255"))
     val futureResult: Future[Seq[Int]] = paramsNonEmpty("foo").as[Int].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredLongParams" should "be parsed as a list of longs" in {
-    val request: HttpRequest = Request(("foo", "9000000000000000"), ("foo", "7500000000000000"))
+    val request: Request = Request(("foo", "9000000000000000"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = paramsNonEmpty("foo").as[Long].apply(request)
     val result: Seq[Long] = Await.result(futureResult)
     result should have length 2
@@ -107,14 +106,14 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a long" in {
-    val request: HttpRequest = Request(("foo", "false"), ("foo", "7500000000000000"))
+    val request: Request = Request(("foo", "false"), ("foo", "7500000000000000"))
     val futureResult: Future[Seq[Long]] = paramsNonEmpty("foo").as[Long].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredFloatParams" should "be parsed as a list of floats" in {
-    val request: HttpRequest = Request(("foo", "5.123"), ("foo", "536.22345"))
+    val request: Request = Request(("foo", "5.123"), ("foo", "536.22345"))
     val futureResult: Future[Seq[Float]] = paramsNonEmpty("foo").as[Float].apply(request)
     val result: Seq[Float] = Await.result(futureResult)
     result should have length 2
@@ -123,14 +122,14 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a float" in {
-    val request: HttpRequest = Request(("foo", "non-number"), ("foo", "true"))
+    val request: Request = Request(("foo", "non-number"), ("foo", "true"))
     val futureResult: Future[Seq[Float]] = paramsNonEmpty("foo").as[Float].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }
 
 
   "A RequiredDoubleParams" should "be parsed as a list of doubles" in {
-    val request: HttpRequest = Request(("foo", "100.0"), ("foo", "66566.45243"))
+    val request: Request = Request(("foo", "100.0"), ("foo", "66566.45243"))
     val futureResult: Future[Seq[Double]] = paramsNonEmpty("foo").as[Double].apply(request)
     val result: Seq[Double] = Await.result(futureResult)
     result should have length 2
@@ -139,7 +138,7 @@ class RequiredParamsSpec extends FlatSpec with Matchers {
   }
 
   it should "produce an error if one of the params is not a double" in {
-    val request: HttpRequest = Request(("foo", "45543245.435"), ("foo", "non-number"))
+    val request: Request = Request(("foo", "45543245.435"), ("foo", "non-number"))
     val futureResult: Future[Seq[Double]] = paramsNonEmpty("foo").as[Double].apply(request)
     a [RequestErrors] shouldBe thrownBy(Await.result(futureResult))
   }

--- a/demo/src/main/scala/io/finch/demo/Main.scala
+++ b/demo/src/main/scala/io/finch/demo/Main.scala
@@ -22,14 +22,15 @@
 
 package io.finch.demo
 
-import com.twitter.finagle.{Filter, SimpleFilter, Service, Httpx}
-import com.twitter.util.{Future, Await}
-
-import _root_.argonaut._, _root_.argonaut.Argonaut._
+import _root_.argonaut.Argonaut._
+import _root_.argonaut._
+import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.{Filter, Httpx, Service, SimpleFilter}
+import com.twitter.util.{Await, Future}
 import io.finch.{Endpoint => _, _}
 
 // import the pipe `!` operator
-import io.finch.argonaut._             // import finch-json classes such as `Json`
+import io.finch.argonaut._         // import finch-json classes such as `Json`
 import io.finch.request._          // import request readers such as `RequiredParam`
 import io.finch.request.items._    // import request items for error handling
 import io.finch.response._         // import response builders such as `BadRequest`
@@ -83,14 +84,14 @@ object Main extends App {
 
 object Demo {
 
-  import model._
   import endpoint._
+  import model._
 
   val Secret = "open sesame"
 
-  // A Finagle filter that authorizes a request: performs conversion `HttpRequest` => `AuthRequest`.
-  val authorize = new Filter[HttpRequest, HttpResponse, AuthRequest, HttpResponse] {
-    def apply(req: HttpRequest, service: Service[AuthRequest, HttpResponse]): Future[HttpResponse] = for {
+  // A Finagle filter that authorizes a request: performs conversion `Request` => `AuthRequest`.
+  val authorize = new Filter[Request, Response, AuthRequest, Response] {
+    def apply(req: Request, service: Service[AuthRequest, Response]): Future[Response] = for {
       `X-Secret` <- headerOption("X-Secret")(req)
       rep <- `X-Secret` collect {
         case Secret => service(AuthRequest(req))
@@ -98,11 +99,11 @@ object Demo {
     } yield rep
   }
 
-  val handleDomainErrors: PartialFunction[Throwable, HttpResponse] = {
+  val handleDomainErrors: PartialFunction[Throwable, Response] = {
     case UserNotFound(id) => BadRequest(Json("error" := "user_not_found", "id" := id))
   }
 
-  val handleRequestReaderErrors: PartialFunction[Throwable, HttpResponse] = {
+  val handleRequestReaderErrors: PartialFunction[Throwable, Response] = {
     case NotPresent(ParamItem(p)) => BadRequest(
       Json("error" := "param_not_present", "param" := p)
     )
@@ -120,24 +121,24 @@ object Demo {
     )
   }
 
-  val handleRouterErrors: PartialFunction[Throwable, HttpResponse] = {
+  val handleRouterErrors: PartialFunction[Throwable, Response] = {
     case RouteNotFound(route) => NotFound(Json("error" := "route_not_found", "route" := route))
   }
 
   // A simple Finagle filter that handles all the exceptions, which might be thrown by
   // a request reader of one of the REST services.
-  val handleExceptions = new SimpleFilter[HttpRequest, HttpResponse] {
-    def apply(req: HttpRequest, service: Service[HttpRequest, HttpResponse]): Future[HttpResponse] = service(req) handle
+  val handleExceptions = new SimpleFilter[Request, Response] {
+    def apply(req: Request, service: Service[Request, Response]): Future[Response] = service(req) handle
       (handleDomainErrors orElse handleRequestReaderErrors orElse handleRouterErrors orElse {
         case _ => InternalServerError()
       })
   }
 
   // An API endpoint.
-  val api: Service[AuthRequest, HttpResponse] =
+  val api: Service[AuthRequest, Response] =
     (getUser :+: getUsers :+: postUser :+: postTicket).toService
 
   // An HTTP endpoint with exception handler and Auth filter.
-  val backend: Service[HttpRequest, HttpResponse] =
+  val backend: Service[Request, Response] =
     handleExceptions ! authorize ! api
 }

--- a/demo/src/main/scala/io/finch/demo/package.scala
+++ b/demo/src/main/scala/io/finch/demo/package.scala
@@ -44,11 +44,12 @@ import com.twitter.util.Future
  */
 package demo {
 
-  import model._
+import com.twitter.finagle.httpx.Request
+import model._
 
-  // A custom request type that wraps an `HttpRequest`.
+  // A custom request type that wraps an `Request`.
   // We prefer composition over inheritance.
-  case class AuthRequest(http: HttpRequest)
+  case class AuthRequest(http: Request)
 
   object AuthRequest {
     implicit val toRequest: ToRequest[AuthRequest] =

--- a/demo/src/test/scala/io/finch/demo/DemoSpec.scala
+++ b/demo/src/test/scala/io/finch/demo/DemoSpec.scala
@@ -2,10 +2,9 @@ package io.finch.demo
 
 import com.twitter.finagle.Service
 import com.twitter.finagle.httpx.Method.{Get, Post}
-import com.twitter.finagle.httpx.{Method, Request}
+import com.twitter.finagle.httpx.{Response, Method, Request}
 import com.twitter.io.Buf
 import com.twitter.util.Await
-import io.finch._
 import org.scalatest._
 
 class DemoSpec extends FlatSpec with Matchers {
@@ -70,7 +69,7 @@ class DemoSpec extends FlatSpec with Matchers {
     await(req).status shouldBe io.finch.response.BadRequest().status
   }
 
-  def mkAwait(service: Service[HttpRequest, HttpResponse]): Request => HttpResponse =
+  def mkAwait(service: Service[Request, Response]): Request => Response =
     (req) => Await.result(service(req))
 
   def POST(path: String, body: String): Request = POST(path, Option(body))

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -16,7 +16,7 @@ Finch.
 `finch.io.auth.BasicallyAuthorize` filter.
 
 ```scala
-object ProtectedEndpoint extends Endpoint[HttpRequest, HttpResponse] {
+object ProtectedEndpoint extends Endpoint[Request, Response] {
   def route = {
     case Method.Get -> Root / "users" => BasicallyAuthorize("user", "password") ! GetUsers
   }

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -18,13 +18,13 @@ to `Json` (see section [Json](json.md#argonaut)). Since, all the endpoints have 
 or `orElse` operators. The following example shows the discussed example in details:
 
 ```scala
-val auth: Filter[HttpRequest, HttpResponse, OAuth2Request, HttpResponse] = ???
+val auth: Filter[Request, Response, OAuth2Request, Response] = ???
 val users: Endpoint[OAuth2Request, Json] = ???
 val groups: Endpoint[OAuth2Request, Json] = ???
-val endpoint: Endpoint[OAuth2Request, HttpResponse] = (users orElse groups) ! TurnIntoHttp[Json]
+val endpoint: Endpoint[OAuth2Request, Response] = (users orElse groups) ! TurnIntoHttp[Json]
 
 // An HTTP endpoint that may be served with `Httpx`
-val httpEndpoint: Endpoint[HttpRequest, HttpResponse] = auth ! endpoint
+val httpEndpoint: Endpoint[Request, Response] = auth ! endpoint
 ```
 
 The best practices on what to choose for data transformation are following:
@@ -36,7 +36,7 @@ An `Endpoint[Req, Rep]` may be implicitly converted into `Service[Req, Rep]` by 
 the following code is correct.
 
 ```scala
-val e: Endpoint[MyRequest, HttpResponse] = ???
+val e: Endpoint[MyRequest, Response] = ???
 // an endpoint `e` will be converted to service implicitly
 Httpx.serve(new InetSocketAddress(8081), e)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ either `/` (`flatMap`) or `/>` (`map`) operator. There is also `|` (`orElse`) op
 terms of the inclusive or operator.
 
 ```scala
-val router: Endpoint[HttpRequest, HttpResponse] = Get / ("users" | "user") / int /> GetUser
+val router: Endpoint[Request, Response] = Get / ("users" | "user") / int /> GetUser
 ```
 
 #### Step 2: Reading the HTTP requests in a `Service`
@@ -38,7 +38,7 @@ of any type. In fact, `ResponseBuilder` is a function that takes some content an
 depending on a content. There are plenty of predefined builders that might be used directly.
 
 ```scala
- val ok: HttpResponse = Ok("Hello, world!") // text/plain HTTP response with status code 200
+ val ok: Response = Ok("Hello, world!") // text/plain HTTP response with status code 200
 ```
 
 ## Table of Contents

--- a/docs/json.md
+++ b/docs/json.md
@@ -19,7 +19,7 @@ import io.finch.jackson._
 implicit val objectMapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
 case class Foo(id: Int, s: String)
 
-val ok: HttpResponse = Ok(Foo(10, "foo")) // will be encoded as JSON
+val ok: Response = Ok(Foo(10, "foo")) // will be encoded as JSON
 val foo: RequestReader[Foo] = body.as[Foo] // a request reader that reads Foo
 ```
 
@@ -32,7 +32,7 @@ import io.finch.json4s._
 implicit val formats = DefaultFormats ++ JodaTimeSerializers.all
 case class Bar(x: Int, y: Boolean)
 
-val ok: HttpResponse = Ok(Bar(1, true)) // will be encoded as JSON
+val ok: Response = Ok(Bar(1, true)) // will be encoded as JSON
 val foo: RequestReader[Bar] = body.as[Bar] // a request reader that reads Bar
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,11 +25,12 @@ import io.finch.response._
 import io.finch.route._
 ```
 
-In addition to the Finch API we will also need a couple of Finagle basic blocks, such as `Service` and `Httpx`.
+In addition to the Finch API we will also need a couple of Finagle basic blocks, such as `Service`, `Httpx`,
+`Request` and `Response`.
 
 ```scala
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.Httpx
+import com.twitter.finagle.httpx.{Httpx, Request, Response}
 ```
 
 Using the [route combinators](route.md), we may define a _route_ for our `hello` service. In the code bellow `endpoint`
@@ -51,8 +52,8 @@ Finally, we define a service `hello` that actually greets users. The HTTP respon
 [response builder](response.md) `Ok` that takes a string and returns a `text/plain` HTTP response.  
 
 ```scala
-def hello(name: String) = new Service[HttpRequest, HttpResponse] {
-  def apply(req: HttpRequest) = for {
+def hello(name: String) = new Service[Request, Response] {
+  def apply(req: Request) = for {
     t <- title(req)
   } yield Ok(s"Hello, $t $name!")
 }

--- a/docs/response.md
+++ b/docs/response.md
@@ -33,9 +33,10 @@ and start typing.
 import io.finch._
 import io.finch.request._
 import io.finch.response._
+import com.twitter.finagle.httpx.{Request, Response}
 
-object Hello extends Service[HttpRequest, HttpResponse] {
-  def apply(req: HttpRequest) = for {
+object Hello extends Service[Request, Response] {
+  def apply(req: Request) = for {
     name <- param("name")(req)
   } yield Ok(s"Hello, $name!")
 }
@@ -73,7 +74,7 @@ implicit def encodeMsgPack[A](implicit encode: EncodeMsgPack[A]): EncodeResponse
 The charset may be overridden by `withCharset(charset: Option[String])` method on `ResponseBuilder`.
 
 ```scala
-val ok: HttpResponse = Ok.withCharset(None)
+val ok: Response = Ok.withCharset(None)
 ```
 
 #### Content Type
@@ -82,7 +83,7 @@ While the `content-type` is implicitly defined by the `EncodeResponse` instance 
 with `withContentType(contentType: Option[String])` method:
 
 ```scala
-val ok: HttpResponse = Ok.withContentType("application/octet-stream")("byte string")
+val ok: Response = Ok.withContentType("application/octet-stream")("byte string")
 ```
 
 #### HTTP Headers
@@ -91,7 +92,7 @@ HTTP headers may be added to respond instance with `withHeaders` method:
 
 ```scala
 val seeOther: ResponseBuilder = SeeOther.withHeaders("Some-Header-A" -> "a", "Some-Header-B" -> "b")
-val rep: HttpResponse = seeOther(Json.obj("a" -> 10))
+val rep: Response = seeOther(Json.obj("a" -> 10))
 ```
 
 ### Redirects
@@ -100,7 +101,7 @@ There is a tiny factory object `io.finch.response.Redirect` that may be used for
 the example:
 
 ```scala
-val e = new Endpoint[HttpRequest, HttpResponse] = {
+val e = new Endpoint[Request, Response] = {
   def route = {
     case Method.Get -> Root / "users" / name => GetUser(name)
     case Method.Get -> Root / "Bob" => Redirect("/users/Bob") // or with path object


### PR DESCRIPTION
I just replaced all usages of ```HttpRequest``` and ```HttpResponse``` aliases with ```com.twitter.finagle.httpx.Response``` and ```com.twitter.finagle.httpx.Request``` respectively.

Also, I optimized some imports.

A review would be great, because it's my first PR to this project! :)

Resolves #341