### PR TITLE
Deprecate all endpoints in favor of coproduct routers

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
@@ -6,7 +6,6 @@ import com.twitter.util.Future
 import io.finch.request._
 import io.finch.response._
 import io.finch.route._
-import io.finch.{Endpoint => _}
 
 class FinchUserService(implicit
   userDecoder: DecodeRequest[User],

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -36,6 +36,7 @@ import com.twitter.finagle.httpx.service.NotFoundService
  * @tparam Req the request type
  * @tparam Rep the response type
  */
+@deprecated(message = "Endpoint is deprecated in favor of coproduct routers", since = "0.8.0")
 trait Endpoint[Req, Rep] { self =>
 
   /**
@@ -100,6 +101,7 @@ trait Endpoint[Req, Rep] { self =>
 /**
  * A companion object for ''Endpoint''
  */
+@deprecated(message = "Endpoint is deprecated in favor of coproduct routers", since = "0.8.0")
 object Endpoint {
 
   /**
@@ -147,6 +149,7 @@ object Endpoint {
    *
    * @return a service that delegates the requests to the underlying endpoint
    */
+  @deprecated(message = "Endpoint is deprecated in favor of coproduct routers", since = "0.8.0")
   implicit def endpointToService[Req, Rep](e: Endpoint[Req, Rep])(implicit ev: Req => Request): Service[Req, Rep] =
     new Service[Req, Rep] {
       def apply(req: Req): Future[Rep] = e.route(req.method -> Path(req.path))(req)

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -112,6 +112,7 @@ package object finch {
      *
      * @return an endpoint composed with filter
      */
+    @deprecated(message = "Endpoint is deprecated in favor of coproduct routers", since = "0.8.0")
     def !(next: Endpoint[ReqOut, RepIn]): Endpoint[ReqIn, RepOut] =
       next andThen { service =>
         filter andThen service

--- a/core/src/main/scala/io/finch/route/Router.scala
+++ b/core/src/main/scala/io/finch/route/Router.scala
@@ -150,6 +150,7 @@ object Router {
    * An implicit conversion that turns any endpoint with an output type that can be converted into a response into a
    * service that returns responses.
    */
+  @deprecated(message = "Endpoint is deprecated in favor of coproduct routers", since = "0.8.0")
   implicit def endpointToResponse[A, B](e: Endpoint[A, B])(implicit
     encoder: EncodeResponse[B]
   ): Endpoint[A, Response] = e.map { service =>

--- a/core/src/main/scala/io/finch/route/package.scala
+++ b/core/src/main/scala/io/finch/route/package.scala
@@ -53,6 +53,7 @@ package object route extends RouterCombinators {
   /**
    * An alias for [[io.finch.route.Router Router]] that maps route to a [[com.twitter.finagle.Service Service]].
    */
+  @deprecated(message = "Endpoint is deprecated in favor of coproduct routers", since = "0.8.0")
   type Endpoint[A, B] = Router[Service[A, B]]
 
   type Router0 = Router[HNil]

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -166,8 +166,8 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "be implicitly convertible into service from future" in {
-    val e: Endpoint[Request, Response] =
-      (Get / "foo" /> Ok("bar").toFuture: Endpoint[Request, Response]) |
+    val e: Router[Service[Request, Response]] =
+      (Get / "foo" /> Ok("bar").toFuture: Router[Service[Request, Response]]) |
       (Get / "bar" /> Ok("foo").toFuture)
 
     Await.result(e(httpx.Request("/foo"))).contentString shouldBe "bar"
@@ -192,8 +192,8 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     val service = new Service[Request, Response] {
       def apply(req: Request) = Ok("foo").toFuture
     }
-    val e: Endpoint[Request, Response] =
-      (Get / "bar" /> Ok("bar").toFuture: Endpoint[Request, Response]) |
+    val e: Router[Service[Request, Response]] =
+      (Get / "bar" /> Ok("bar").toFuture: Router[Service[Request, Response]]) |
       (Get / "foo" /> service)
 
     Await.result(e(httpx.Request("/foo"))).contentString shouldBe "foo"
@@ -201,8 +201,8 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
   }
 
   it should "convert Router[Future[_]] to both endpoint and service" in {
-    val s: Service[Request, Response] = Get / "foo" /> Ok("foo").toFuture: Endpoint[Request, Response]
-    val e: Endpoint[Request, Response] = Get / "bar" /> Ok("bar").toFuture
+    val s: Service[Request, Response] = Get / "foo" /> Ok("foo").toFuture: Router[Service[Request, Response]]
+    val e: Router[Service[Request, Response]] = Get / "bar" /> Ok("bar").toFuture
 
     Await.result(s(httpx.Request("/foo"))).contentString shouldBe "foo"
     Await.result(e(httpx.Request("/bar"))).contentString shouldBe "bar"


### PR DESCRIPTION
As discussed in #320, I just deprecated ```Endpoint``` and ```Endpoint => Service```.
I also replaced ```Endpoint``` with ```Router[Service[Req, Rep]]``` in the demo project.
Hope I did everything right and did't forget anything.

@vkostyukov, please take a look. 
Thanks in advance.

Resolves #320