### PR TITLE
Add support for circe in a subproject

### DIFF
--- a/benchmarks/src/it/scala/io/finch/benchmarks/service/UserServiceAppTest.scala
+++ b/benchmarks/src/it/scala/io/finch/benchmarks/service/UserServiceAppTest.scala
@@ -7,6 +7,7 @@ class ArgonautUserServiceAppTest extends UserServiceAppTest(() => argonaut.userS
 class FinagleUserServiceAppTest extends UserServiceAppTest(() => finagle.userService)
 class JacksonUserServiceAppTest extends UserServiceAppTest(() => jackson.userService)
 class Json4sUserServiceAppTest extends UserServiceAppTest(() => json4s.userService)
+class CirceUserServiceAppTest extends UserServiceAppTest(() => circe.userService)
 
 class UserServiceAppTest(
   service: () => UserService

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/circe/benchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/circe/benchmark.scala
@@ -1,0 +1,4 @@
+package io.finch.benchmarks.service
+package circe
+
+class CirceBenchmark extends UserServiceBenchmark(() => userService)

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/circe/package.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/circe/package.scala
@@ -1,0 +1,8 @@
+package io.finch.benchmarks.service
+
+import io.finch.circe._
+import io.circe.generic.auto._
+
+package object circe {
+  def userService: UserService = new FinchUserService
+}

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val root = project.in(file("."))
         |import io.finch.route._
       """.stripMargin
   )
-  .aggregate(core, argonaut, jackson, json4s, benchmarks, petstore)
+  .aggregate(core, argonaut, jackson, json4s, circe, benchmarks, petstore)
   .dependsOn(core, argonaut)
 
 lazy val core = project
@@ -159,6 +159,18 @@ lazy val json4s = project
   )
   .dependsOn(core, test % "test")
 
+lazy val circe = project
+  .settings(moduleName := "finch-circe")
+  .settings(allSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core" % "0.1.1",
+      "io.circe" %% "circe-jawn" % "0.1.1",
+      "io.circe" %% "circe-generic" % "0.1.1" % "test"
+    )
+  )
+  .dependsOn(core, test % "test")
+
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")
   .settings(allSettings)
@@ -166,6 +178,7 @@ lazy val benchmarks = project
   .settings(Defaults.itSettings)
   .settings(parallelExecution in IntegrationTest := false)
   .settings(coverageExcludedPackages := "io\\.finch\\.benchmarks\\.service\\.UserServiceBenchmark")
+  .settings(libraryDependencies += "io.circe" %% "circe-generic" % "0.1.1")
   .settings(
     javaOptions in run ++= Seq(
       "-Djava.net.preferIPv4Stack=true",
@@ -186,4 +199,11 @@ lazy val benchmarks = project
       "-server"
     )
   )
-  .dependsOn(core, argonaut, jackson, json4s, test % "it")
+  .dependsOn(
+    core,
+    argonaut,
+    jackson,
+    json4s,
+    circe,
+    test % "it"
+  )

--- a/circe/README.md
+++ b/circe/README.md
@@ -1,0 +1,12 @@
+The `finch-jfc` module provides the Finch library a support for the [jfc](https://github.com/travisbrown/jfc) JSON library. 
+
+Installation
+------------
+Use the following _sbt_ snippet (not currently working as 0.8.0 hasn't been published):
+
+```scala
+libraryDependencies ++= Seq(
+  "com.github.finagle" %% "finch-jfc" % "0.8.0"
+)
+```
+

--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -1,0 +1,33 @@
+package io.finch
+
+import io.finch.request.DecodeRequest
+import io.finch.request.RequestError
+import io.finch.response.EncodeResponse
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.jawn.decode
+import com.twitter.util.{Try, Throw, Return}
+
+package object circe {
+
+  /**
+   * @param d The [[io.circe.Decoder]] to use for decoding
+   * @tparam A The type of data that the [[io.circe.Decoder]] will decode into
+   * @return Create a Finch ''DecodeRequest'' from a [[io.circe.Decoder]]
+   */
+  implicit def decodeCirce[A](implicit d: Decoder[A]): DecodeRequest[A] =
+    DecodeRequest(
+      decode[A](_).fold[Try[A]](
+        error => Throw[A](new RequestError(error.getMessage)),
+        Return(_)
+      )
+    )
+
+  /**
+   * @param e The [[io.circe.Encoder]] to use for decoding
+   * @tparam A The type of data that the [[io.circe.Encoder]] will use to create the JSON string
+   * @return Create a Finch ''EncodeJson'' from an [[io.circe.Encoder]]
+   */
+  implicit def encodeCirce[A](implicit e: Encoder[A]): EncodeResponse[A] =
+    EncodeResponse.fromString[A]("application/json")(e(_).noSpaces)
+}
+

--- a/circe/src/test/scala/io/finch/circe/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/CirceSpec.scala
@@ -1,0 +1,15 @@
+package io.finch.circe
+
+import io.finch.test.json._
+import io.circe.generic.auto._
+import org.scalatest.prop.Checkers
+import org.scalatest.{FlatSpec, Matchers}
+
+class CirceSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
+  "The circe codec provider" should "encode a case class as JSON" in encodeNestedCaseClass
+  it should "decode a case class from JSON" in decodeNestedCaseClass
+  it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson
+  it should "encode a list of case class instances as JSON" in encodeCaseClassList
+  it should "decode a list of case class instances from JSON" in decodeCaseClassList
+  it should "provide encoders with the correct content type" in checkContentType
+}


### PR DESCRIPTION
As discussed in #368, I put together a subproject for [jfc](https://github.com/travisbrown/jfc) this weekend, and adding a benchmark ended up taking just a few lines of code.

I don't think we should merge this until we have an 0.1 release for jfc on Maven Central.

At a glance the benchmark looks good but not amazing:

```
[info] Benchmark                                          Mode  Cnt    Score    Error  Units
[info] i.f.b.s.argonaut.ArgonautBenchmark.deleteAllUsers  avgt   20    0.229 ±  0.007  ms/op
[info] i.f.b.s.argonaut.ArgonautBenchmark.getAllUsers     avgt   20   25.448 ±  4.454  ms/op
[info] i.f.b.s.argonaut.ArgonautBenchmark.getUsers        avgt   20  172.193 ±  3.978  ms/op
[info] i.f.b.s.finagle.FinagleBenchmark.deleteAllUsers    avgt   20    0.264 ±  0.017  ms/op
[info] i.f.b.s.finagle.FinagleBenchmark.getAllUsers       avgt   20   17.212 ±  1.205  ms/op
[info] i.f.b.s.finagle.FinagleBenchmark.getUsers          avgt   20  187.409 ± 15.131  ms/op
[info] i.f.b.s.jackson.JacksonBenchmark.deleteAllUsers    avgt   20    0.244 ±  0.024  ms/op
[info] i.f.b.s.jackson.JacksonBenchmark.getAllUsers       avgt   20   16.019 ±  2.528  ms/op
[info] i.f.b.s.jackson.JacksonBenchmark.getUsers          avgt   20  171.037 ±  6.197  ms/op
[info] i.f.b.s.jfc.JfcBenchmark.deleteAllUsers            avgt   20    0.256 ±  0.075  ms/op
[info] i.f.b.s.jfc.JfcBenchmark.getAllUsers               avgt   20   23.959 ±  1.784  ms/op
[info] i.f.b.s.jfc.JfcBenchmark.getUsers                  avgt   20  171.827 ±  7.647  ms/op
[info] i.f.b.s.json4s.Json4sBenchmark.deleteAllUsers      avgt   20    0.236 ±  0.016  ms/op
[info] i.f.b.s.json4s.Json4sBenchmark.getAllUsers         avgt   20   20.209 ±  2.610  ms/op
[info] i.f.b.s.json4s.Json4sBenchmark.getUsers            avgt   20  173.999 ±  8.577  ms/op
[info] i.f.b.s.argonaut.ArgonautBenchmark.createUsers       ss   20  161.038 ± 18.435  ms/op
[info] i.f.b.s.argonaut.ArgonautBenchmark.updateUsers       ss   20  206.705 ± 19.754  ms/op
[info] i.f.b.s.finagle.FinagleBenchmark.createUsers         ss   20  153.534 ±  6.609  ms/op
[info] i.f.b.s.finagle.FinagleBenchmark.updateUsers         ss   20  194.612 ± 13.582  ms/op
[info] i.f.b.s.jackson.JacksonBenchmark.createUsers         ss   20  154.407 ± 14.713  ms/op
[info] i.f.b.s.jackson.JacksonBenchmark.updateUsers         ss   20  203.795 ± 16.317  ms/op
[info] i.f.b.s.jfc.JfcBenchmark.createUsers                 ss   20  153.800 ± 12.577  ms/op
[info] i.f.b.s.jfc.JfcBenchmark.updateUsers                 ss   20  219.608 ± 21.056  ms/op
[info] i.f.b.s.json4s.Json4sBenchmark.createUsers           ss   20  160.398 ±  9.972  ms/op
[info] i.f.b.s.json4s.Json4sBenchmark.updateUsers           ss   20  212.948 ± 30.642  ms/op
