### PR TITLE
Introduce the Mapper type class

### DIFF
--- a/core/src/main/scala/io/finch/route/Mapper.scala
+++ b/core/src/main/scala/io/finch/route/Mapper.scala
@@ -1,0 +1,46 @@
+package io.finch.route
+
+import com.twitter.util.Future
+import shapeless.ops.function.FnToProduct
+
+/**
+ * A type class that allows the [[Router]] to be mapped to either `A => B` or `A => Future[B]`.
+ */
+trait Mapper[A] {
+  type Out
+
+  def apply(r: Router[A]): Router[Out]
+}
+
+trait LowPriorityMapperConversions {
+  type Aux[A, B] = Mapper[A] { type Out = B }
+
+  implicit def mapperFromFunction[A, B](f: A => B): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Router[A]): Router[Out] = r.map(f)
+  }
+
+  implicit def mapperFromFutureFunction[A, B](f: A => Future[B]): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Router[A]): Router[Out] = r.embedFlatMap(f)
+  }
+}
+
+trait MidPriorityMapperConversions extends LowPriorityMapperConversions {
+  implicit def mapperFromHFunction[A, B, F](f: F)(implicit
+    ftp: FnToProduct.Aux[F, A => B]
+  ): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Router[A]): Router[Out] = r.map(ftp(f))
+  }
+}
+
+object Mapper extends MidPriorityMapperConversions {
+  implicit def mapperFromFutureHFunction[A, B, F, FB](f: F)(implicit
+    ftp: FnToProduct.Aux[F, A => FB],
+    ev: FB <:< Future[B]
+  ): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Router[A]): Router[Out] = r.embedFlatMap(value => ev(ftp(f)(value)))
+  }
+}

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -309,6 +309,23 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     runRouter(router, route) shouldBe Some((route.drop(3), 310))
   }
 
+  it should "maps with Mapper" in {
+    val r1: Router[Int] = Router.value(100)
+    val r2: Router[String] = r1 { i: Int => i.toString }
+    val r3: Router[String] = r1 { i: Int => Future.value(i.toString) }
+    val r4: Router2[Int, Int] = Router.value(10) / Router.value(100)
+    val r5: Router[Int] = r4 { (a: Int, b: Int) => a + b }
+    val r6: Router[Int] = r4 { (a: Int, b: Int) => Future.value(a + b) }
+
+    val route = Input(Request())
+    runRouter(r1, route) shouldBe Some((route, 100))
+    runRouter(r2, route) shouldBe Some((route, "100"))
+    runRouter(r3, route) shouldBe Some((route, "100"))
+    runRouter(r4, route) shouldBe Some((route, 10 :: 100 :: HNil))
+    runRouter(r5, route) shouldBe Some((route, 110))
+    runRouter(r6, route) shouldBe Some((route, 110))
+  }
+
   "A string matcher" should "have the correct string representation" in {
     check { (s: String) =>
       val matcher: Router[HNil] = s


### PR DESCRIPTION
The type class `Mapper` is a variation of "magnet pattern" in Scala that allows us to workaround JVM's type-erasure. This PR introduces an `apply` method on `Router` that accepts a `Mapper` instaince. The compiler will substitute given `Mapper` with either `A => B` or `A => Future[B]`.

The motivation behind this change is to be able to write this:

Before:
```scala
val getUser: Router[User] = get("users" / string) /> { name: String =>
  User(name)
}

val patchUser: Router[User] = 
  patch("users" / string ? body.as[User]) />> { (name: Stirng, user: User) =>
     Future.value(user)
  }
```

After:
```scala
val getUser: Router[User] = get("users" / string) { name: String =>
  User(name)
}

val patchUser: Router[User] = 
  patch("users" / string ? body.as[User]) { (name: Stirng, user: User) =>
     Future.value(user)
  }
```