### PR TITLE
Allow the Router to be mapped to value/future value

### DIFF
--- a/core/src/main/scala/io/finch/route/Mapper.scala
+++ b/core/src/main/scala/io/finch/route/Mapper.scala
@@ -1,6 +1,7 @@
 package io.finch.route
 
 import com.twitter.util.Future
+import shapeless.HNil
 import shapeless.ops.function.FnToProduct
 
 /**
@@ -42,5 +43,15 @@ object Mapper extends MidPriorityMapperConversions {
   ): Mapper.Aux[A, B] = new Mapper[A] {
     type Out = B
     def apply(r: Router[A]): Router[Out] = r.embedFlatMap(value => ev(ftp(f)(value)))
+  }
+
+  implicit def mapperFromValue[A](v: A): Mapper.Aux[HNil, A] = new Mapper[HNil] {
+    type Out = A
+    def apply(r: Router[HNil]): Router[Out] = r.map(_ => v)
+  }
+
+  implicit def mapperFromFutureValue[A](f: Future[A]): Mapper.Aux[HNil, A] = new Mapper[HNil] {
+    type Out = A
+    def apply(r: Router[HNil]): Router[Out] = r.embedFlatMap(_ => f)
   }
 }

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -348,6 +348,10 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     val r4: Router2[Int, Int] = Router.value(10) / Router.value(100)
     val r5: Router[Int] = r4 { (a: Int, b: Int) => a + b }
     val r6: Router[Int] = r4 { (a: Int, b: Int) => Future.value(a + b) }
+    val r7: Router0 = /
+    val r8: Router[String] = r7 { "foo" }
+    val r9: Router[String] = r7 { Future.value("foo") }
+
 
     val route = Input(Request())
     runRouter(r1, route) shouldBe Some((route, 100))
@@ -356,6 +360,9 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     runRouter(r4, route) shouldBe Some((route, 10 :: 100 :: HNil))
     runRouter(r5, route) shouldBe Some((route, 110))
     runRouter(r6, route) shouldBe Some((route, 110))
+    runRouter(r7, route) shouldBe Some((route, HNil))
+    runRouter(r8, route) shouldBe Some((route, "foo"))
+    runRouter(r9, route) shouldBe Some((route, "foo"))
   }
 
   "A string matcher" should "have the correct string representation" in {


### PR DESCRIPTION
A missing bit for #370:

```scala
val hello = get("hello") {
  Future.value("Hello, world!")
}
```