### PR TITLE
Make Mapper lazier

### DIFF
--- a/core/src/main/scala/io/finch/route/Mapper.scala
+++ b/core/src/main/scala/io/finch/route/Mapper.scala
@@ -45,12 +45,12 @@ object Mapper extends MidPriorityMapperConversions {
     def apply(r: Router[A]): Router[Out] = r.embedFlatMap(value => ev(ftp(f)(value)))
   }
 
-  implicit def mapperFromValue[A](v: A): Mapper.Aux[HNil, A] = new Mapper[HNil] {
+  implicit def mapperFromValue[A](v: => A): Mapper.Aux[HNil, A] = new Mapper[HNil] {
     type Out = A
     def apply(r: Router[HNil]): Router[Out] = r.map(_ => v)
   }
 
-  implicit def mapperFromFutureValue[A](f: Future[A]): Mapper.Aux[HNil, A] = new Mapper[HNil] {
+  implicit def mapperFromFutureValue[A](f: => Future[A]): Mapper.Aux[HNil, A] = new Mapper[HNil] {
     type Out = A
     def apply(r: Router[HNil]): Router[Out] = r.embedFlatMap(_ => f)
   }

--- a/core/src/test/scala/io/finch/route/RouterSpec.scala
+++ b/core/src/test/scala/io/finch/route/RouterSpec.scala
@@ -365,6 +365,20 @@ class RouterSpec extends FlatSpec with Matchers with Checkers {
     runRouter(r9, route) shouldBe Some((route, "foo"))
   }
 
+  it should "maps lazily to values" in {
+    var i: Int = 0
+    val r1: Router[Int] = get(/) { i = i + 1; i }
+    val r2: Router[Int] = get(/) { i = i + 1; Future.value(i) }
+
+    val route = Input(Request())
+    runRouter(r1, route) shouldBe Some((route, 1))
+    runRouter(r1, route) shouldBe Some((route, 2))
+    runRouter(r1, route) shouldBe Some((route, 3))
+    runRouter(r2, route) shouldBe Some((route, 4))
+    runRouter(r2, route) shouldBe Some((route, 5))
+    runRouter(r2, route) shouldBe Some((route, 6))
+  }
+
   "A string matcher" should "have the correct string representation" in {
     check { (s: String) =>
       val matcher: Router[HNil] = s


### PR DESCRIPTION
I was doing my workshop examples and tried to write a simple web-service that returns the current time. It looks like this:

```scala
def currentTime(): String = Calendar.getInstance().getTime.toString
val time: Router[String] = get(/) { currentTime() }
```

So in order to make it work I made the value argument lazy for `Mapper` (pass by name).