### PR TITLE
Introduce Endpoint.Output

### DIFF
--- a/core/src/main/scala/io/finch/Endpoints.scala
+++ b/core/src/main/scala/io/finch/Endpoints.scala
@@ -8,7 +8,6 @@ import shapeless._
  * A collection of [[Endpoint]] combinators.
  */
 trait Endpoints {
-
   type Endpoint0 = Endpoint[HNil]
   type Endpoint2[A, B] = Endpoint[A :: B :: HNil]
   type Endpoint3[A, B, C] = Endpoint[A :: B :: C :: HNil]
@@ -18,8 +17,10 @@ trait Endpoints {
    */
   private[finch] class Matcher(s: String) extends Endpoint[HNil] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[HNil])] =
-      input.headOption.collect({ case `s` => () => Future.value(HNil: HNil) }).map((input.drop(1), _))
+    def apply(input: Input): Option[(Input, () => Future[Output[HNil]])] =
+      input.headOption.collect(
+        { case `s` => () => Future.value(Output.HNil) }
+      ).map((input.drop(1), _))
 
     override def toString: String = s
   }
@@ -33,8 +34,8 @@ trait Endpoints {
    */
   private[finch] class MethodMatcher(m: Method) extends Endpoint[HNil] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[HNil])] =
-      if (input.request.method == m) Some((input, () => Future.value(HNil)))
+    def apply(input: Input): Option[(Input, () => Future[Output[HNil]])] =
+      if (input.request.method == m) Some((input, () => Future.value(Output.HNil)))
       else None
 
     override def toString: String = s"${m.toString.toUpperCase}"
@@ -43,23 +44,23 @@ trait Endpoints {
   //
   // A group of routers that matches HTTP methods.
   //
-  @deprecated("Use method get: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method get: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Get extends MethodMatcher(Method.Get)
-  @deprecated("Use method post: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method post: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Post extends MethodMatcher(Method.Post)
-  @deprecated("Use method patch: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method patch: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Patch extends MethodMatcher(Method.Patch)
-  @deprecated("Use method delete: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method delete: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Delete extends MethodMatcher(Method.Delete)
-  @deprecated("Use method head: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method head: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Head extends MethodMatcher(Method.Head)
-  @deprecated("Use method options: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method options: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Options extends MethodMatcher(Method.Options)
-  @deprecated("Use method put: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method put: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Put extends MethodMatcher(Method.Put)
-  @deprecated("Use method connect: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method connect: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Connect extends MethodMatcher(Method.Connect)
-  @deprecated("Use method trace: Endpoint[A] => Endpoint[A] instead", "0.9.9")
+  @deprecated("Use method trace: Endpoint[A] => Endpoint[A] instead", "0.9.0")
   object Trace extends MethodMatcher(Method.Trace)
 
   /**
@@ -67,11 +68,11 @@ trait Endpoints {
    */
   case class Extractor[A](name: String, f: String => A) extends Endpoint[A] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[A])] =
+    def apply(input: Input): Option[(Input, () => Future[Output[A]])] =
       for {
         ss <- input.headOption
         aa <- Try(f(ss)).toOption
-      } yield (input.drop(1), () => Future.value(aa))
+      } yield (input.drop(1), () => Future.value(Output(aa)))
 
     def apply(n: String): Endpoint[A] = copy[A](name = n)
 
@@ -83,11 +84,11 @@ trait Endpoints {
    */
   case class TailExtractor[A](name: String, f: String => A) extends Endpoint[Seq[A]] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[Seq[A]])] =
-      Some((input.copy(path = Nil), () => Future.value(for {
+    def apply(input: Input): Option[(Input, () => Future[Output[Seq[A]]])] =
+      Some((input.copy(path = Nil), () => Future.value(Output(for {
         s <- input.path
         a <- Try(f(s)).toOption
-      } yield a)))
+      } yield a))))
 
     def apply(n: String): Endpoint[Seq[A]] = copy[A](name = n)
 
@@ -139,8 +140,8 @@ trait Endpoints {
    */
   object * extends Endpoint[HNil] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[HNil])] =
-      Some((input.copy(path = Nil), () => Future.value(HNil)))
+    def apply(input: Input): Option[(Input, () => Future[Output[HNil]])] =
+      Some((input.copy(path = Nil), () => Future.value(Output.HNil)))
 
     override def toString: String = "*"
   }
@@ -150,15 +151,15 @@ trait Endpoints {
    */
   object / extends Endpoint[HNil] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[HNil])] =
-      Some((input, () => Future.value(HNil)))
+    def apply(input: Input): Option[(Input, () => Future[Output[HNil]])] =
+      Some((input, () => Future.value(Output.HNil)))
 
     override def toString: String = ""
   }
 
   private[this] def method[A](m: Method)(r: Endpoint[A]): Endpoint[A] = new Endpoint[A] {
     import Endpoint._
-    def apply(input: Input): Option[(Input, () => Future[A])] =
+    def apply(input: Input): Option[(Input, () => Future[Output[A]])] =
       if (input.request.method == m) r(input)
       else None
 
@@ -229,7 +230,7 @@ trait Endpoints {
 
     new Endpoint[A] {
       import Endpoint._
-      def apply(input: Input): Option[(Input, () => Future[A])] =
+      def apply(input: Input): Option[(Input, () => Future[Output[A]])] =
         input.request.authorization.flatMap {
           case `expected` => r(input)
         }

--- a/core/src/main/scala/io/finch/Mapper.scala
+++ b/core/src/main/scala/io/finch/Mapper.scala
@@ -4,6 +4,8 @@ import com.twitter.util.Future
 import shapeless.HNil
 import shapeless.ops.function.FnToProduct
 
+import io.finch.Endpoint._
+
 /**
  * A type class that allows the [[Endpoint]] to be mapped to either `A => B` or `A => Future[B]`.
  */
@@ -16,18 +18,38 @@ trait Mapper[A] {
 trait LowPriorityMapperConversions {
   type Aux[A, B] = Mapper[A] { type Out = B }
 
+  @deprecated("Use an explicit output (i.e., Ok()) instead.", "0.9.0")
   implicit def mapperFromFunction[A, B](f: A => B): Mapper.Aux[A, B] = new Mapper[A] {
     type Out = B
     def apply(r: Endpoint[A]): Endpoint[Out] = r.map(f)
   }
 
+  @deprecated("Use an explicit output (i.e., Ok()) instead.", "0.9.0")
   implicit def mapperFromFutureFunction[A, B](f: A => Future[B]): Mapper.Aux[A, B] = new Mapper[A] {
     type Out = B
-    def apply(r: Endpoint[A]): Endpoint[Out] = r.embedFlatMap(f)
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.fmap(f)
   }
+
+  implicit def mapperFromOutputFunction[A, B](f: A => Output[B]): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.emap(f)
+  }
+
+  implicit def mapperFromOutputFutureFunction[A, B](f: A => Output[Future[B]]): Mapper.Aux[A, B] =
+    new Mapper[A] {
+      type Out = B
+      def apply(r: Endpoint[A]): Endpoint[Out] = r.efmap(f)
+    }
+
+  implicit def mapperFromFutureOutputFunction[A, B](f: A => Future[Output[B]]): Mapper.Aux[A, B] =
+    new Mapper[A] {
+      type Out = B
+      def apply(r: Endpoint[A]): Endpoint[Out] = r.femap(f)
+    }
 }
 
 trait MidPriorityMapperConversions extends LowPriorityMapperConversions {
+  @deprecated("Use an explicit output (i.e., Ok()) instead.", "0.9.0")
   implicit def mapperFromHFunction[A, B, F](f: F)(implicit
     ftp: FnToProduct.Aux[F, A => B]
   ): Mapper.Aux[A, B] = new Mapper[A] {
@@ -36,22 +58,69 @@ trait MidPriorityMapperConversions extends LowPriorityMapperConversions {
   }
 }
 
-object Mapper extends MidPriorityMapperConversions {
+trait HighPriorityMapperConversions extends MidPriorityMapperConversions {
+  implicit def mapperFromOutputHFunction[A, B, F, OB](f: F)(implicit
+    ftp: FnToProduct.Aux[F, A => OB],
+    ev: OB <:< Output[B]
+  ): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.emap(value => ev(ftp(f)(value)))
+  }
+
+  @deprecated("Use an explicit output (i.e., Ok()) instead.", "0.9.0")
   implicit def mapperFromFutureHFunction[A, B, F, FB](f: F)(implicit
     ftp: FnToProduct.Aux[F, A => FB],
     ev: FB <:< Future[B]
   ): Mapper.Aux[A, B] = new Mapper[A] {
     type Out = B
-    def apply(r: Endpoint[A]): Endpoint[Out] = r.embedFlatMap(value => ev(ftp(f)(value)))
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.fmap(value => ev(ftp(f)(value)))
   }
 
+  @deprecated("Use an explicit output (i.e., Ok()) instead.", "0.9.0")
   implicit def mapperFromValue[A](v: => A): Mapper.Aux[HNil, A] = new Mapper[HNil] {
     type Out = A
     def apply(r: Endpoint[HNil]): Endpoint[Out] = r.map(_ => v)
   }
 
+  @deprecated("Use an explicit output (i.e., Ok()) instead.", "0.9.0")
   implicit def mapperFromFutureValue[A](f: => Future[A]): Mapper.Aux[HNil, A] = new Mapper[HNil] {
     type Out = A
-    def apply(r: Endpoint[HNil]): Endpoint[Out] = r.embedFlatMap(_ => f)
+    def apply(r: Endpoint[HNil]): Endpoint[Out] = r.fmap(_ => f)
+  }
+
+  implicit def mapperFromOutputValue[A](o: => Output[A]): Mapper.Aux[HNil, A] = new Mapper[HNil] {
+    type Out = A
+    def apply(r: Endpoint[HNil]): Endpoint[Out] = r.emap(_ => o)
+  }
+
+  implicit def mapperFromOutputFutureValue[A](o: => Output[Future[A]]): Mapper.Aux[HNil, A] =
+    new Mapper[HNil] {
+      type Out = A
+      def apply(r: Endpoint[HNil]): Endpoint[Out] = r.efmap(_ => o)
+    }
+
+  implicit def mapperFromFutureOutputValue[A](o: => Future[Output[A]]): Mapper.Aux[HNil, A] =
+    new Mapper[HNil] {
+      type Out = A
+      def apply(r: Endpoint[HNil]): Endpoint[Out] = r.femap(_ => o)
+    }
+}
+
+object Mapper extends HighPriorityMapperConversions {
+
+  implicit def mapperFromOutputFutureHFunction[A, B, F, OFB](f: F)(implicit
+     ftp: FnToProduct.Aux[F, A => OFB],
+     ev: OFB <:< Output[Future[B]]
+  ): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.efmap(value => ev(ftp(f)(value)))
+  }
+
+  implicit def mapperFromFutureOutputHFunction[A, B, F, FOB](f: F)(implicit
+    ftp: FnToProduct.Aux[F, A => FOB],
+    ev: FOB <:< Future[Output[B]]
+  ): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.femap(value => ev(ftp(f)(value)))
   }
 }

--- a/core/src/main/scala/io/finch/Outputs.scala
+++ b/core/src/main/scala/io/finch/Outputs.scala
@@ -1,0 +1,79 @@
+package io.finch
+
+import com.twitter.finagle.httpx.Status
+
+trait Outputs {
+  import Endpoint.Output
+
+  trait OutputBuilder { self: Output[Unit] =>
+    def apply[A](a: A): Output[A] = Output(a, self.status)
+  }
+
+  // 1xx
+  object Continue extends Output((), Status.Continue) with OutputBuilder                       // 100
+  object Processing extends Output((), Status.Processing) with OutputBuilder                   // 102
+
+  // 2xx
+  object Ok extends Output((), Status.Ok) with OutputBuilder                                   // 200
+  object Created extends Output((), Status.Created) with OutputBuilder                         // 201
+  object Accepted extends Output((), Status.Accepted) with OutputBuilder                       // 202
+  object NonAuthoritativeInformation
+    extends Output((), Status.NonAuthoritativeInformation) with OutputBuilder                  // 203
+  object NoContent extends Output((), Status.NoContent) with OutputBuilder                     // 204
+  object ResetContent extends Output((), Status.ResetContent) with OutputBuilder               // 205
+  object PartialContent extends Output((), Status.PartialContent) with OutputBuilder           // 206
+  object MultiStatus extends Output((), Status.MultiStatus) with OutputBuilder                 // 208
+
+  // 3xx
+  object MultipleChoices extends Output((), Status.MultipleChoices) with OutputBuilder         // 300
+  object MovedPermanently extends Output((), Status.MovedPermanently) with OutputBuilder       // 301
+  object Found extends Output((), Status.Found) with OutputBuilder                             // 302
+  object SeeOther extends Output((), Status.SeeOther) with OutputBuilder                       // 303
+  object NotModified extends Output((), Status.NotModified) with OutputBuilder                 // 304
+  object UseProxy extends Output((), Status.UseProxy) with OutputBuilder                       // 305
+  object TemporaryRedirect extends Output((), Status.TemporaryRedirect) with OutputBuilder     // 307
+
+  // 4xx
+  object BadRequest extends Output((), Status.BadRequest) with OutputBuilder                   // 400
+  object Unauthorized extends Output((), Status.Unauthorized) with OutputBuilder               // 401
+  object PaymentRequired extends Output((), Status.PaymentRequired) with OutputBuilder         // 402
+  object Forbidden extends Output((), Status.Forbidden) with OutputBuilder                     // 403
+  object NotFound extends Output((), Status.NotFound) with OutputBuilder                       // 404
+  object MethodNotAllowed extends Output((), Status.MethodNotAllowed) with OutputBuilder       // 405
+  object NotAcceptable extends Output((), Status.NotAcceptable) with OutputBuilder             // 406
+  object ProxyAuthenticationRequired
+    extends Output((), Status.ProxyAuthenticationRequired) with OutputBuilder                  // 407
+  object RequestTimeOut extends Output((), Status.RequestTimeout) with OutputBuilder           // 408
+  object Conflict extends Output((), Status.Conflict) with OutputBuilder                       // 409
+  object Gone extends Output((), Status.Gone) with OutputBuilder                               // 410
+  object LengthRequired extends Output((), Status.LengthRequired) with OutputBuilder           // 411
+  object PreconditionFailed extends Output((), Status.PreconditionFailed) with OutputBuilder   // 412
+  object RequestEntityTooLarge
+    extends Output((), Status.RequestEntityTooLarge) with OutputBuilder                        // 413
+  object RequestUriTooLong extends Output((), Status.RequestURITooLong) with OutputBuilder     // 414
+  object UnsupportedMediaType
+    extends Output((), Status.UnsupportedMediaType) with OutputBuilder                         // 415
+  object RequestedRangeNotSatisfiable
+    extends Output((), Status.RequestedRangeNotSatisfiable) with OutputBuilder                 // 416
+  object ExpectationFailed extends Output((), Status.ExpectationFailed) with OutputBuilder     // 417
+  object UnprocessableEntity extends Output((), Status.UnprocessableEntity) with OutputBuilder // 422
+  object Locked extends Output((), Status.Locked) with OutputBuilder                           // 423
+  object FailedDependency extends Output((), Status.FailedDependency) with OutputBuilder       // 424
+  object UnorderedCollection extends Output((), Status.UnorderedCollection) with OutputBuilder // 425
+  object UpgradeRequired extends Output((), Status.UpgradeRequired) with OutputBuilder         // 426
+  object PreconditionRequired extends Output((), Status(428)) with OutputBuilder               // 428
+  object TooManyRequests extends Output((), Status(429)) with OutputBuilder                    // 429
+
+  // 5xx
+  object InternalServerError extends Output((), Status.InternalServerError) with OutputBuilder // 500
+  object NotImplemented extends Output((), Status.NotImplemented) with OutputBuilder           // 501
+  object BadGateway extends Output((), Status.BadGateway) with OutputBuilder                   // 502
+  object ServiceUnavailable extends Output((), Status.ServiceUnavailable) with OutputBuilder   // 503
+  object GatewayTimeout extends Output((), Status.GatewayTimeout) with OutputBuilder           // 504
+  object HttpVersionNotSupported
+    extends Output((), Status.HttpVersionNotSupported) with OutputBuilder                      // 505
+  object VariantAlsoNegotiates
+    extends Output((), Status.VariantAlsoNegotiates) with OutputBuilder                        // 506
+  object InsufficientStorage extends Output((), Status.InsufficientStorage) with OutputBuilder // 507
+  object NotExtended extends Output((), Status.NotExtended) with OutputBuilder                 // 510
+}

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -7,7 +7,9 @@ import com.twitter.util.Future
  * for writing lightweight HTTP services. It roughly contains three packages: [[io.finch.route]], [[io.finch.request]],
  * [[io.finch.response]].
  */
-package object finch extends Endpoints {
+package object finch
+  extends Endpoints
+  with Outputs {
 
   /**
    * Alters any object within a `toFuture` method.

--- a/core/src/main/scala/io/finch/response/EncodeResponse.scala
+++ b/core/src/main/scala/io/finch/response/EncodeResponse.scala
@@ -17,6 +17,7 @@ trait EncodeResponse[-A] {
 }
 
 object EncodeResponse {
+
   /**
    * Convenience method for creating new [[io.finch.response.EncodeResponse EncodeResponse]] instances.
    */
@@ -47,7 +48,12 @@ object EncodeResponse {
   /**
    * Allows to pass raw strings to a [[ResponseBuilder]].
    */
-  implicit val encodeString: EncodeResponse[String] = EncodeResponse.fromString[String]("text/plain")(identity)
+  implicit val encodeString: EncodeResponse[String] =
+    EncodeResponse.fromString[String]("text/plain")(identity)
+
+  // TODO: Make it JSON-agnostic
+  implicit val encodeUnit: EncodeResponse[Unit] =
+    EncodeResponse("application/json")(_ => Buf.Empty)
 
   /**
    * Allows to pass `Buf` to a [[ResponseBuilder]].
@@ -62,16 +68,4 @@ object EncodeResponse {
 trait EncodeAnyResponse {
   def apply[A](rep: A): Buf
   def contentType: String
-}
-
-class TurnIntoHttp[A](val e: EncodeResponse[A]) extends Service[A, Response] {
-  def apply(req: A): Future[Response] = Ok(req)(e).toFuture
-}
-
-/**
- * A service that converts an encoded object into HTTP response with status ''OK'' using an implicit
- * [[io.finch.response.EncodeResponse EncodeResponse]].
- */
-object TurnIntoHttp {
-  def apply[A](implicit e: EncodeResponse[A]): Service[A, Response] = new TurnIntoHttp[A](e)
 }

--- a/petstore/src/main/scala/io/finch/petstore/endpoint.scala
+++ b/petstore/src/main/scala/io/finch/petstore/endpoint.scala
@@ -6,7 +6,6 @@ import com.twitter.util.{Future}
 import io.finch._
 import io.finch.argonaut._
 import io.finch.request._
-import io.finch.response._
 
 /**
  * Provides the paths and endpoints for all the API's public service methods.
@@ -64,7 +63,7 @@ object endpoint extends ErrorHandling {
    * @return A Router that contains the Pet fetched.
    */
   def getPet(db: PetstoreDb): Endpoint[Pet] =
-    get("pet" / long) { id: Long => db.getPet(id) }
+    get("pet" / long) { id: Long => Ok(db.getPet(id)) }
 
   /**
    * The pet to be added must be passed in the body.
@@ -72,7 +71,7 @@ object endpoint extends ErrorHandling {
    */
   def addPet(db: PetstoreDb): Endpoint[Long] =
     post("pet" ? body.as[Pet]) { p: Pet =>
-      db.addPet(p)
+      Ok(db.addPet(p))
     }
 
   /**
@@ -86,7 +85,7 @@ object endpoint extends ErrorHandling {
         case None => throw MissingIdentifier("The updated pet must have a valid id.")
       }
 
-      db.updatePet(pet.copy(id = Some(identifier)))
+      Ok(db.updatePet(pet.copy(id = Some(identifier))))
     }
 
   /**
@@ -95,7 +94,7 @@ object endpoint extends ErrorHandling {
    */
   def getPetsByStatus(db: PetstoreDb): Endpoint[Seq[Pet]] =
     get("pet" / "findByStatus" ? reader.findByStatusReader) { s: Seq[String] =>
-      db.getPetsByStatus(s)
+      Ok(db.getPetsByStatus(s))
     }
 
   /**
@@ -104,16 +103,16 @@ object endpoint extends ErrorHandling {
    */
   def findPetsByTag(db: PetstoreDb): Endpoint[Seq[Pet]] =
     get("pet" / "findByTags" ? reader.tagReader) { s: Seq[String] =>
-      db.findPetsByTag(s)
+      Ok(db.findPetsByTag(s))
     }
 
   /**
    * The ID of the pet to delete is passed in the path.
    * @return A Router that contains a RequestReader of the deletePet result (true for success, false otherwise).
    */
-  def deletePet(db: PetstoreDb): Endpoint[Response] =
+  def deletePet(db: PetstoreDb): Endpoint[Unit] =
     delete("pet" / long) { petId: Long =>
-      db.deletePet(petId).map(_ => NoContent())
+      NoContent(db.deletePet(petId))
     }
 
   /**
@@ -125,7 +124,7 @@ object endpoint extends ErrorHandling {
       for {
         pet <- db.getPet(petId)
         newPet <- db.updatePetNameStatus(petId, Some(n), Some(s))
-      } yield newPet
+      } yield Ok(newPet)
     }
 
   /**
@@ -135,14 +134,14 @@ object endpoint extends ErrorHandling {
    */
   def uploadImage(db: PetstoreDb): Endpoint[String] =
     post("pet" / long / "uploadImage" ? fileUpload("file")) { (id: Long, upload: FileUpload) =>
-      db.addImage(id, upload.get())
+      Ok(db.addImage(id, upload.get()))
     }
 
   /**
    * @return A Router that contains a RequestReader of a Map reflecting the inventory.
    */
   def getInventory(db: PetstoreDb): Endpoint[Inventory] =
-    get("store" / "inventory") { db.getInventory }
+    get("store" / "inventory") { Ok(db.getInventory) }
 
   /**
    * The order to be added is passed in the body.
@@ -150,7 +149,7 @@ object endpoint extends ErrorHandling {
    */
   def addOrder(db: PetstoreDb): Endpoint[Long] =
     post("store" / "order" ? body.as[Order]) { o: Order =>
-      db.addOrder(o)
+      Ok(db.addOrder(o))
     }
 
   /**
@@ -159,7 +158,7 @@ object endpoint extends ErrorHandling {
    */
   def deleteOrder(db: PetstoreDb): Endpoint[Boolean] =
     delete("store" / "order" / long) { id: Long =>
-      db.deleteOrder(id)
+      Ok(db.deleteOrder(id))
     }
 
   /**
@@ -168,7 +167,7 @@ object endpoint extends ErrorHandling {
    */
   def findOrder(db: PetstoreDb): Endpoint[Order] =
     get("store" / "order" / long) { id: Long =>
-      db.findOrder(id)
+      Ok(db.findOrder(id))
     }
 
   /**
@@ -177,7 +176,7 @@ object endpoint extends ErrorHandling {
    */
   def addUser(db: PetstoreDb): Endpoint[String] =
     post("user" ? body.as[User]) { u: User =>
-      db.addUser(u)
+      Ok(db.addUser(u))
     }
 
   /**
@@ -186,7 +185,7 @@ object endpoint extends ErrorHandling {
    */
   def addUsersViaList(db: PetstoreDb): Endpoint[Seq[String]] =
     post("user" / "createWithList" ? body.as[Seq[User]]) { s: Seq[User] =>
-      Future.collect(s.map(db.addUser))
+      Ok(Future.collect(s.map(db.addUser)))
     }
 
   /**
@@ -195,7 +194,7 @@ object endpoint extends ErrorHandling {
    */
   def addUsersViaArray(db: PetstoreDb): Endpoint[Seq[String]] =
     post("user" / "createWithArray" ? body.as[Seq[User]]) { s: Seq[User] =>
-      Future.collect(s.map(db.addUser))
+      Ok(Future.collect(s.map(db.addUser)))
     }
 
   /**
@@ -204,7 +203,7 @@ object endpoint extends ErrorHandling {
    */
   def deleteUser(db: PetstoreDb): Endpoint[Unit] =
     delete("user" / string) { n: String =>
-      db.deleteUser(n)
+      Ok(db.deleteUser(n))
     }
 
   /**
@@ -213,7 +212,7 @@ object endpoint extends ErrorHandling {
    */
   def getUser(db: PetstoreDb): Endpoint[User] =
     get("user" / string) { n: String =>
-      db.getUser(n)
+      Ok(db.getUser(n))
     }
 
   /**
@@ -222,7 +221,7 @@ object endpoint extends ErrorHandling {
    */
   def updateUser(db: PetstoreDb): Endpoint[User] =
     put("user" / string ? body.as[User]) { (n: String, u: User) =>
-      db.updateUser(u)
+      Ok(db.updateUser(u))
     }
 }
 


### PR DESCRIPTION
The idea is to allow users to capture the output context while keeping the type information. Previously, this has been done by dropping down to the `Response` type. Now it's possible to use `Output` in order to supply an additional context that will be used while converting an encodeable into a `Response`.

```scala
val postUser: Endpoint[User] = post("users" ? body.as[User]) { u: User =>
  Created(u).withHeader("Location" -> u.id)
} 
```

The API of the `Output` completely repeats `ResponseBuilder`, which eventually should be replaced by `Output`.