### PR TITLE
Fix #398: Support UUIDs

### DIFF
--- a/core/src/main/scala/io/finch/request/DecodeRequest.scala
+++ b/core/src/main/scala/io/finch/request/DecodeRequest.scala
@@ -1,6 +1,8 @@
 package io.finch.request
 
-import com.twitter.util.Try
+import java.util.UUID
+
+import com.twitter.util.{Throw, Try}
 import scala.reflect.ClassTag
 
 /**
@@ -19,22 +21,22 @@ object DecodeRequest {
   }
 
   /**
-   * A [[io.finch.request.DecodeRequest DecodeRequest]] instance for `String`.
+   * A [[DecodeRequest]] instance for `String`.
    */
   implicit val decodeString: DecodeRequest[String] = DecodeRequest { s => Try(s) }
 
   /**
-   * A [[io.finch.request.DecodeRequest DecodeRequest]] instance for `Int`.
+   * A [[DecodeRequest]] instance for `Int`.
    */
   implicit val decodeInt: DecodeRequest[Int] = DecodeRequest { s => Try(s.toInt) }
 
   /**
-   * A [[io.finch.request.DecodeRequest DecodeRequest]] instance for `Long`.
+   * A [[DecodeRequest]] instance for `Long`.
    */
   implicit val decodeLong: DecodeRequest[Long] = DecodeRequest { s => Try(s.toLong) }
 
   /**
-   * A [[io.finch.request.DecodeRequest DecodeRequest]] instance for `Float`.
+   * A [[DecodeRequest]] instance for `Float`.
    */
   implicit val decodeFloat: DecodeRequest[Float] = DecodeRequest { s => Try(s.toFloat) }
 
@@ -44,9 +46,17 @@ object DecodeRequest {
   implicit val decodeDouble: DecodeRequest[Double] = DecodeRequest { s => Try(s.toDouble) }
 
   /**
-   * A [[io.finch.request.DecodeRequest DecodeRequest]] instance for `Boolean`.
+   * A [[DecodeRequest]] instance for `Boolean`.
    */
   implicit val decodeBoolean: DecodeRequest[Boolean] = DecodeRequest { s => Try(s.toBoolean) }
+
+  /**
+   * A [[DecodeRequest]] instance for `UUID`.
+   */
+  implicit val decodeUUID: DecodeRequest[UUID] = DecodeRequest { s =>
+    if (s.length != 36) Throw(new IllegalArgumentException(s"Too long for UUID: ${s.length}"))
+    else Try(UUID.fromString(s))
+  }
 
   /**
    * Creates a [[DecodeRequest]] from [[DecodeAnyRequest ]].

--- a/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
@@ -1,5 +1,7 @@
 package io.finch.request
 
+import java.util.UUID
+
 import com.twitter.finagle.httpx.Request
 import com.twitter.util.{Await, Future}
 import org.scalatest.{Matchers, FlatSpec}
@@ -55,6 +57,16 @@ class RequiredParamSpec extends FlatSpec with Matchers {
       Future.value(foo * 4)
     }
     Await.result(reader(request)) shouldBe "5555"
+  }
+
+  it should "be parsed as UUID" in {
+    val uuid = UUID.randomUUID()
+    val request: Request = Request(("foo", uuid.toString))
+    val badRequest: Request = Request(("foo", "00000000" + uuid.toString))
+
+    val p = param("foo").as[UUID]
+    Await.result(p(request)) shouldBe uuid
+    a [NotParsed] shouldBe thrownBy(Await.result(p(badRequest)))
   }
 
   "A RequiredBooleanParam" should "be parsed as a boolean" in {


### PR DESCRIPTION
This PR enables UUIDs support in both ways:

* Via `Endpoint` instance `uuid` and `uuids` (tail extractor)
* Via `DecodeRequest` instance for `UUID` type

So the following works as expected.

```scala
val a: Endpoint[UUID] = get("users" / uuid) { id: UUID =>
  Ok(id)
}

val b: RequestReader[UUID] = param("id").as[UUID]
```