### PR TITLE
[F-375] Error handler for endpoint

### DIFF
--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -450,4 +450,16 @@ class EndpointSpec extends FlatSpec with Matchers with Checkers {
     val r: Endpoint0 = basicAuth("foo", "bar")(/)
     runAndAwaitValue(r, Input(Request())) shouldBe None
   }
+
+  it should "handle exceptions occurred at the endpoint" in {
+    val stopWord = "Stop, u're destroying our universe!"
+
+    val input = Input(Request())
+
+    val r1 = get(/) { 1/0 } handle {
+      case e: ArithmeticException => InternalServerError(stopWord)
+    }
+
+    runAndAwaitValue(r1, input).map(_._2) shouldBe Some(stopWord)
+  }
 }


### PR DESCRIPTION
This PR is about issue #375. But yet there is a question. 

Due to current `Endpoint` implementation it's type parameter `A` is a type for `Output[A]`. And when you're trying to return different from router applied function's result (look for specs i.e.), you'll get `Endpoint[Any]` at the end, since your handler might return `InternalServerError` just in case:

```scala
val r1: Endpoint[Any] = get(/) { 1/0 } handle {
      case e: ArithmeticException => InternalServerError("oh noes")
}
```

I think, there should be better solution. Any ideas?