### PR TITLE
Support tracking underlying functions for mapped endpoints

### DIFF
--- a/test/src/main/scala/io/finch/test/package.scala
+++ b/test/src/main/scala/io/finch/test/package.scala
@@ -1,0 +1,12 @@
+package io.finch
+
+import com.twitter.util.Await
+
+package object test {
+  /**
+   * Syntax for testing an [[Endpoint.Mapped]].
+   */
+  implicit class MappedEndpointOps[In, A](endpoint: Endpoint.Mapped[In, A]) {
+    def lift(in: In): A = Await.result(endpoint.underlying(in)).value
+  }
+}


### PR DESCRIPTION
This change introduces a new subtype of `Endpoint` that keeps track of the fact that the endpoint is the result of mapping a function over another endpoint. This supports a testing idiom similar to the proposal in #390:

``` scala
import io.finch._, io.finch.test._

case class User(name: String)

val getUser: Endpoint.Mapped[Long, User] = get("users" / long) { id: Long =>
  User(id.toString)
}

assert(getUser.lift(100L) == User("100"))
```

`lift` is an enrichment method provided by `io.finch.test` that uses an `underlying` method on `Endpoint.Mapped`. Because some mappings may be into combinations of `Future` and `Option`, the return type of `underlying` is `Future[Option[A]]`, which isn't terribly convenient for testing, so `lift` awaits and unwraps this result.

Note that this change doesn't provide the exact syntax proposed in #390, since the input type must be statically tracked.

One other note: it would conceivably be possible to put an input type member on `Endpoint` itself, and have it default to `Nothing` or `Request`, but I think the approach I'm using here is a little cleaner.
