### PR TITLE
Update sbt-jmh and unify benchmarks

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/request/reader.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/request/reader.scala
@@ -15,11 +15,14 @@ case class Foo(s: String, d: Double, i: Int, l: Long, b: Boolean)
  * The following command will run the request reader benchmarks with reasonable
  * settings:
  *
- * > sbt "benchmarks/run -i 10 -wi 10 -f 2 -t 1 io.finch.benchmarks.request.*"
+ * > sbt 'project benchmarks' 'run -prof gc io.finch.benchmarks.request.*Benchmark.*'
  */
 @State(Scope.Thread)
-@BenchmarkMode(Array(Mode.Throughput))
+@BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
 class SuccessfulRequestReaderBenchmark extends FooReadersAndRequests {
   @Benchmark
   def monadicReader: Foo = Await.result(monadicFooReader(goodFooRequest))
@@ -42,8 +45,11 @@ class SuccessfulRequestReaderBenchmark extends FooReadersAndRequests {
  * readers for invalid inputs, since it fails on the first error.
  */
 @State(Scope.Thread)
-@BenchmarkMode(Array(Mode.Throughput))
+@BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
 class FailingRequestReaderBenchmark extends FooReadersAndRequests {
   @Benchmark
   def monadicReader: Try[Foo] = Await.result(monadicFooReader(badFooRequest).liftToTry)

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
@@ -13,10 +13,14 @@ import org.openjdk.jmh.annotations._
  * The following command will run all user service benchmarks with reasonable
  * settings:
  *
- * > sbt "benchmarks/run -i 10 -wi 10 -f 2 -t 1 io.finch.benchmarks.service.*"
+ * > sbt 'project benchmarks' 'run -prof gc io.finch.benchmarks.service.*Benchmark.*'
  */
 @State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
 abstract class UserServiceBenchmark(service: () => UserService)
   extends UserServiceApp(service)(8123, 2000, 10) {
   @Setup(Level.Invocation)
@@ -26,22 +30,17 @@ abstract class UserServiceBenchmark(service: () => UserService)
   def tearDown(): Unit = tearDownService()
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.SingleShotTime))
   def createUsers(): Seq[Response] = Await.result(runCreateUsers)
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.AverageTime))
   def getUsers(): Seq[Response] = Await.result(runGetUsers)
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.SingleShotTime))
   def updateUsers(): Seq[Response] = Await.result(runUpdateUsers)
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.AverageTime))
   def getAllUsers(): Response = Await.result(runGetAllUsers)
 
   @Benchmark
-  @BenchmarkMode(Array(Mode.AverageTime))
   def deleteAllUsers(): Response = Await.result(runDeleteAllUsers)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,6 @@ lazy val petstore = project
     .settings(Defaults.itSettings)
     .settings(parallelExecution in IntegrationTest := false)
     .settings(coverageExcludedPackages := "io\\.finch\\.petstore\\.PetstoreApp.*")
-    .disablePlugins(JmhPlugin)
     .dependsOn(core, argonaut, test % "test,it")
 
 lazy val argonaut = project
@@ -182,6 +181,7 @@ lazy val circe = project
 
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")
+  .enablePlugins(JmhPlugin)
   .settings(allSettings)
   .configs(IntegrationTest)
   .settings(Defaults.itSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,6 @@ resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
@@ -12,4 +11,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
 addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.15")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.4")


### PR DESCRIPTION
This PR updates `sbt-jmh` to 0.2.2 as well as well as unifies settings for all the benchmakrs we have.