### PR TITLE
Fix #408: exhaustive match in basicAuth

### DIFF
--- a/core/src/main/scala/io/finch/Endpoints.scala
+++ b/core/src/main/scala/io/finch/Endpoints.scala
@@ -244,6 +244,7 @@ trait Endpoints {
       def apply(input: Input): Option[(Input, () => Future[Output[A]])] =
         input.request.authorization.flatMap {
           case `expected` => r(input)
+          case _ => None
         }
 
       override def toString: String = s"BasicAuth($r)"

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -436,7 +436,7 @@ class EndpointSpec extends FlatSpec with Matchers with Checkers {
 
   "A basicAuth combinator" should "auth the endpoint" in {
     def encode(user: String, password: String) = "Basic " + Base64StringEncoder.encode(s"$user:$password".getBytes)
-    val r: Endpoint[String] = get(/) /> "foo"
+    val r: Endpoint[String] = get(/) { "foo" }
 
     check { (u: String, p: String) =>
       val req = Request()
@@ -446,6 +446,8 @@ class EndpointSpec extends FlatSpec with Matchers with Checkers {
       val input = Input(req)
 
       rr.toString === s"BasicAuth($r)"
+      runAndAwaitValue(rr, input) === None
+      req.headerMap.update("Authorization", encode(u, p))
       runAndAwaitValue(rr, input) === Some((input, "foo"))
     }
   }


### PR DESCRIPTION
I also moved encoding over to `java.util.Base64` which is now available in Java8.