### PR TITLE
Add support for finagle-oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Finch uses multi-project structure and contains of the following _modules_:
 * [`finch-core`](core) - the core classes/functions
 * [`finch-argonaut`](argonaut) - the JSON API support for the [Argonaut](argonaut) library
 * [`finch-jackson`](jackson) - the JSON API support for the [Jackson](jackson) library
-* [`finch-json4s`](json4s) - the JSON API support for the [JSON4S](http://json4s.org/) library
+* [`finch-json4s`](json4s) - the JSON API support for the [JSON4S](json4s) library
 * [`finch-circe`](circe) - the JSON API support for the [Circe](circe) library
 * [`finch-test`](test) - the test support classes/functions
+* [`finch-oauth2`](oauth2) - the OAuth2 support backed by the [finagle-oauth2](finagle-oauth2) library
 
 Installation
 ------------
@@ -135,5 +136,7 @@ limitations under the License.
 [service-benchmark]: https://github.com/finagle/finch/blob/master/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
 [finagle]: https://github.com/twitter/finagle
 [circe]: https://github.com/travisbrown/circe
-[jackson]: http://jackson.codehaus.org/
-[argonaut]: http://argonaut.io/
+[jackson]: http://jackson.codehaus.org
+[argonaut]: http://argonaut.io
+[finagle-oauth2]: https://github.com/finagle/finagle-oauth2
+[json4s]: http://json4s.org

--- a/build.sbt
+++ b/build.sbt
@@ -109,13 +109,12 @@ lazy val root = project.in(file("."))
         |import io.finch.response._
       """.stripMargin
   )
-  .aggregate(core, argonaut, jackson, json4s, circe, benchmarks, petstore, test, jsonTest)
+  .aggregate(core, argonaut, jackson, json4s, circe, benchmarks, petstore, test, jsonTest, oauth2)
   .dependsOn(core, circe)
 
 lazy val core = project
   .settings(moduleName := "finch-core")
   .settings(allSettings)
-  .settings(coverageExcludedPackages := "io\\.finch\\.micro\\..*")
 
 lazy val test = project
   .settings(moduleName := "finch-test")
@@ -178,6 +177,15 @@ lazy val circe = project
     )
   )
   .dependsOn(core, jsonTest % "test")
+
+lazy val oauth2 = project
+  .settings(moduleName := "finch-oauth2")
+  .settings(allSettings)
+  .settings(libraryDependencies ++= Seq(
+    "com.github.finagle" %% "finagle-oauth2" % "0.1.4",
+    "org.mockito" % "mockito-all" % "1.10.19" % "test"
+  ))
+  .dependsOn(core)
 
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")

--- a/core/src/main/scala/io/finch/request/package.scala
+++ b/core/src/main/scala/io/finch/request/package.scala
@@ -5,8 +5,6 @@ import com.twitter.finagle.httpx.exp.Multipart
 import com.twitter.finagle.httpx.exp.Multipart.FileUpload
 import com.twitter.io.Buf
 
-import scala.collection.JavaConverters._
-
 /**
  * This package introduces types and functions that enable _request processing_ in Finch. The [[io.finch.request]]
  * primitives allow both to _read_ the various request items (''query string param'', ''header'' and ''cookie'') using

--- a/oauth2/src/main/scala/io/finch/oauth2/package.scala
+++ b/oauth2/src/main/scala/io/finch/oauth2/package.scala
@@ -1,0 +1,25 @@
+package io.finch
+
+import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.OAuth2
+import com.twitter.finagle.oauth2.{GrantHandlerResult, AuthInfo, DataHandler}
+import com.twitter.util.Future
+import io.finch.request.RequestReader
+import io.finch.request.items._
+
+package object oauth2 {
+
+  private[this] object OAuth2 extends OAuth2
+
+  def authorize[U](dataHandler: DataHandler[U]): RequestReader[AuthInfo[U]] =
+    new RequestReader[AuthInfo[U]] {
+      val item: RequestItem = MultipleItems
+      def apply(req: Request): Future[AuthInfo[U]] = OAuth2.authorize(req, dataHandler)
+    }
+
+  def issueAccessToken[U](dataHandler: DataHandler[U]): RequestReader[GrantHandlerResult] =
+    new RequestReader[GrantHandlerResult] {
+      val item: RequestItem = MultipleItems
+      def apply(req: Request): Future[GrantHandlerResult] = OAuth2.issueAccessToken(req, dataHandler)
+    }
+}

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -1,0 +1,66 @@
+package io.finch.oauth2
+
+import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.oauth2._
+import com.twitter.util.{Await, Future}
+import io.finch.Endpoint.{Output, Input}
+import io.finch.request.RequestReader
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.prop.Checkers
+import org.scalatest.{Matchers, FlatSpec}
+import org.mockito.Mockito._
+import io.finch._
+
+class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar {
+
+  def runAndAwaitOutput[A](e: Endpoint[A], input: Input): Option[(Input, Output[A])] =
+    e(input).map {
+      case (remainder, output) => (remainder, Await.result(output()))
+    }
+
+  "The OAuth2 provider" should "authorize the requests" in {
+    val at: AccessToken = mock[AccessToken]
+    val dh: DataHandler[Int] = mock[DataHandler[Int]]
+    val ai: AuthInfo[Int] = mock[AuthInfo[Int]]
+
+    when(dh.findAccessToken("bar")).thenReturn(Future.value(Some(at)))
+    when(dh.isAccessTokenExpired(at)).thenReturn(false)
+    when(dh.findAuthInfoByAccessToken(at)).thenReturn(Future.value(Some(ai)))
+    when(ai.user).thenReturn(42)
+
+    val authInfo: RequestReader[AuthInfo[Int]] = authorize(dh)
+    val e: Endpoint[Int] = get("user" ? authInfo) { ai: AuthInfo[Int] =>
+      Ok(ai.user)
+    }
+
+    val i1 = Input(Request("/user", "access_token" -> "bar"))
+    val i2 = Input(Request("/user"))
+
+    runAndAwaitOutput(e, i1) shouldBe Some((i1.drop(1), Ok(42)))
+    an [OAuthError] shouldBe thrownBy(runAndAwaitOutput(e, i2))
+  }
+
+  it should "issue the access token" in {
+    val dh: DataHandler[Int] = mock[DataHandler[Int]]
+    val at: AccessToken = mock[AccessToken]
+
+    when(at.token).thenReturn("foobar")
+    when(dh.validateClient("id", "", "password")).thenReturn(Future.value(true))
+    when(dh.findUser("u", "p")).thenReturn(Future.value(Some(42)))
+    when(dh.getStoredAccessToken(AuthInfo(42, "id", None, None))).thenReturn(Future.value(Some(at)))
+    when(dh.isAccessTokenExpired(at)).thenReturn(false)
+
+    val grandHandlerResult: RequestReader[GrantHandlerResult] = issueAccessToken(dh)
+    val e: Endpoint[String] = get("token" ? grandHandlerResult) { ghr: GrantHandlerResult =>
+      Ok(ghr.accessToken)
+    }
+
+    val i1 = Input(
+      Request("/token", "grant_type" -> "password", "username" -> "u", "password" -> "p", "client_id" -> "id")
+    )
+    val i2 = Input(Request("/token"))
+
+    runAndAwaitOutput(e, i1) shouldBe Some((i1.drop(1), Ok("foobar")))
+    an [OAuthError] shouldBe thrownBy(runAndAwaitOutput(e, i2))
+  }
+}


### PR DESCRIPTION
This is my first attempt to solve #136.

The API looks as following:

*Authorize*
```scala
val auth: RequestReader[AuthInfo[Int]] = authorize(dataHandler)
val e: Endpoint[Int] = get("user" ? auth) { ai: AuthInfo[Int] =>
  Ok(ai.user)
}
```

*Issue Access Token*
```scala
val token: RequestReader[GrangHandlerResult] = issueAccessToken(dataHandler)
val e: Endpoint[String] = get("token" ? token) { ghr: GrantHandlerResult =>
  Ok(ghr.accessToken)
}
```