### PR TITLE
Update Finagle to 6.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ This "Hello World!" example is built with the `0.9.0-SNAPSHOT` version of `finch
 
 ```scala
 import io.finch._
-import com.twitter.finagle.Httpx
+import com.twitter.finagle.Http
 
 val api: Endpoint[String] = get("hello") { Ok("Hello, World!") }
 
-Httpx.serve(":8080", api.toService)
+Http.serve(":8080", api.toService)
 ```
 
 Performance

--- a/benchmarks/src/main/scala/io/finch/benchmarks/request/reader.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/request/reader.scala
@@ -1,6 +1,6 @@
 package io.finch.benchmarks.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Try}
 import io.finch.request._
 import java.util.concurrent.TimeUnit

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
@@ -1,6 +1,6 @@
 package io.finch.benchmarks.service
 
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.Service
 import io.finch._
 import io.finch.request._

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/UserService.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/UserService.scala
@@ -1,7 +1,7 @@
 package io.finch.benchmarks.service
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Response, Request}
+import com.twitter.finagle.http.{Response, Request}
 
 abstract class UserService {
   val db: UserDb = new UserDb

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceApp.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceApp.scala
@@ -2,8 +2,8 @@ package io.finch.benchmarks.service
 
 import java.net.{InetSocketAddress, URL}
 
-import com.twitter.finagle.httpx.{Request, RequestBuilder, Response}
-import com.twitter.finagle.{Httpx, Service}
+import com.twitter.finagle.http.{Request, RequestBuilder, Response}
+import com.twitter.finagle.{Http, Service}
 import com.twitter.io.Buf
 import com.twitter.util.{Await, Closable, Future}
 
@@ -16,8 +16,8 @@ class UserServiceApp(service: () => UserService)(
   var client: Service[Request, Response] = _
 
   def setUpService(): Unit = {
-    server = Httpx.serve(new InetSocketAddress(port), service().backend)
-    client = Httpx.newService(s"127.0.0.1:$port")
+    server = Http.serve(new InetSocketAddress(port), service().backend)
+    client = Http.newService(s"127.0.0.1:$port")
     Await.result(batchCalls(Seq.tabulate(count)(createUserRequest)))
   }
 

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
@@ -1,6 +1,6 @@
 package io.finch.benchmarks.service
 
-import com.twitter.finagle.httpx.Response
+import com.twitter.finagle.http.Response
 import com.twitter.util.Await
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._

--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/finagle/benchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/finagle/benchmark.scala
@@ -4,10 +4,10 @@ package finagle
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.{Service, SimpleFilter}
-import com.twitter.finagle.httpx._
-import com.twitter.finagle.httpx.Method._
-import com.twitter.finagle.httpx.path._
-import com.twitter.finagle.httpx.service.RoutingService
+import com.twitter.finagle.http._
+import com.twitter.finagle.http.Method._
+import com.twitter.finagle.http.path._
+import com.twitter.finagle.http.service.RoutingService
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util.Future
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val testDependencies = Seq(
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
     "com.chuusai" %% "shapeless" % "2.2.5",
-    "com.twitter" %% "finagle-httpx" % "6.29.0",
+    "com.twitter" %% "finagle-http" % "6.30.0",
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ) ++ testDependencies.map(_ % "test"),
@@ -108,7 +108,7 @@ lazy val root = project.in(file("."))
         |import io.finch.request.items._
         |import com.twitter.util.Future
         |import com.twitter.finagle.Service
-        |import com.twitter.finagle.httpx.{Request, Response, Status}
+        |import com.twitter.finagle.http.{Request, Response, Status}
       """.stripMargin
   )
   .aggregate(core, argonaut, jackson, json4s, circe, benchmarks, petstore, test, jsonTest, oauth2)
@@ -184,7 +184,7 @@ lazy val oauth2 = project
   .settings(moduleName := "finch-oauth2")
   .settings(allSettings)
   .settings(libraryDependencies ++= Seq(
-    "com.github.finagle" %% "finagle-oauth2" % "0.1.4",
+    "com.github.finagle" %% "finagle-oauth2" % "0.1.5",
     "org.mockito" % "mockito-all" % "1.10.19" % "test"
   ))
   .dependsOn(core)

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -1,7 +1,7 @@
 package io.finch
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Cookie, Request, Response}
+import com.twitter.finagle.http.{Cookie, Request, Response}
 import com.twitter.util.Future
 import io.finch.request._
 import shapeless._

--- a/core/src/main/scala/io/finch/Endpoints.scala
+++ b/core/src/main/scala/io/finch/Endpoints.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import com.twitter.finagle.httpx.Method
+import com.twitter.finagle.http.Method
 import com.twitter.util.{Try, Base64StringEncoder, Future}
 import shapeless._
 

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 
 /**
  * An input for [[Endpoint]].

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import com.twitter.finagle.httpx.{Status, Cookie}
+import com.twitter.finagle.http.{Status, Cookie}
 import com.twitter.util.Future
 import shapeless.HNil
 

--- a/core/src/main/scala/io/finch/Outputs.scala
+++ b/core/src/main/scala/io/finch/Outputs.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import com.twitter.finagle.httpx.Status
+import com.twitter.finagle.http.Status
 
 trait Outputs {
   private[this] val emptyErr: Map[String, String] = Map.empty[String, String]

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -1,7 +1,7 @@
 package io.finch
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Cookie, Request, Response, Status}
+import com.twitter.finagle.http.{Cookie, Request, Response, Status}
 import com.twitter.util.Future
 import io.finch.response.EncodeResponse
 import shapeless.ops.coproduct.Folder

--- a/core/src/main/scala/io/finch/request/RequestReader.scala
+++ b/core/src/main/scala/io/finch/request/RequestReader.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Return, Throw, Try, Future}
 import io.finch._
 import io.finch.request.items._

--- a/core/src/main/scala/io/finch/request/package.scala
+++ b/core/src/main/scala/io/finch/request/package.scala
@@ -1,8 +1,8 @@
 package io.finch
 
-import com.twitter.finagle.httpx.{Cookie, Request}
-import com.twitter.finagle.httpx.exp.Multipart
-import com.twitter.finagle.httpx.exp.Multipart.FileUpload
+import com.twitter.finagle.http.{Cookie, Request}
+import com.twitter.finagle.http.exp.Multipart
+import com.twitter.finagle.http.exp.Multipart.FileUpload
 import com.twitter.io.Buf
 
 /**

--- a/core/src/main/scala/io/finch/response/Redirect.scala
+++ b/core/src/main/scala/io/finch/response/Redirect.scala
@@ -1,8 +1,8 @@
 package io.finch.response
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Response, Request}
-import com.twitter.finagle.httpx.path.Path
+import com.twitter.finagle.http.{Response, Request}
+import com.twitter.finagle.http.path.Path
 import io.finch._
 
 /**

--- a/core/src/main/scala/io/finch/response/ResponseBuilder.scala
+++ b/core/src/main/scala/io/finch/response/ResponseBuilder.scala
@@ -1,6 +1,6 @@
 package io.finch.response
 
-import com.twitter.finagle.httpx.{Cookie, Response, Status}
+import com.twitter.finagle.http.{Cookie, Response, Status}
 
 /**
  * An abstraction that is responsible for building HTTP responses.
@@ -28,7 +28,7 @@ case class ResponseBuilder(
   /**
    * Creates a new response builder with the given `cookies`.
    *
-   * @param cookies the [[com.twitter.finagle.httpx.Cookie Cookie]]'s to add to the response
+   * @param cookies the [[com.twitter.finagle.http.Cookie Cookie]]'s to add to the response
    */
   def withCookies(cookies: Cookie*): ResponseBuilder = copy(cookies = this.cookies ++ cookies)
 

--- a/core/src/main/scala/io/finch/response/package.scala
+++ b/core/src/main/scala/io/finch/response/package.scala
@@ -3,7 +3,7 @@ package io.finch
 /**
  * This package enables a reasonable approach of building HTTP responses using the
  * [[io.finch.response.ResponseBuilder ResponseBuilder]] abstraction. The `ResponseBuilder` provides an immutable way
- * of building concrete [[com.twitter.finagle.httpx.Response Response]] instances by specifying their ''status'',
+ * of building concrete [[com.twitter.finagle.http.Response Response]] instances by specifying their ''status'',
  * ''headers'' and ''cookies''. There are plenty of predefined builders named by HTTP statuses, i.e., `Ok`, `Created`,
  * `NotFound`. Thus, the typical use case of the `ResponseBuilder` abstraction involves usage of concrete builder
  * instead of abstract `ResponseBuilder` itself.

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -3,7 +3,7 @@ package io.finch
 import java.util.UUID
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Request, Response, Status}
+import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.io.Buf
 import com.twitter.util.{Await, Base64StringEncoder, Future, Return}
 import io.finch.request.{DecodeRequest, RequestReader, param}

--- a/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/ApplicativeRequestReaderSpec.scala
@@ -2,7 +2,7 @@ package io.finch.request
 
 import org.scalatest.{FlatSpec, Matchers}
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Throw, Try}
 import items._
 

--- a/core/src/test/scala/io/finch/request/BodySpec.scala
+++ b/core/src/test/scala/io/finch/request/BodySpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.io.Buf.ByteArray
 import com.twitter.util.{Await, Future, Try}
 import org.scalatest.{FlatSpec, Matchers}

--- a/core/src/test/scala/io/finch/request/CookieSpec.scala
+++ b/core/src/test/scala/io/finch/request/CookieSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.{Request, Cookie}
+import com.twitter.finagle.http.{Request, Cookie}
 import com.twitter.util.{Await, Future}
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/request/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/request/DecodeSpec.scala
@@ -2,7 +2,7 @@ package io.finch.request
 
 import org.scalatest.{Matchers, FlatSpec}
 import com.twitter.util.{Try, Return, Await}
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import scala.math._
 import scala.reflect.ClassTag
 

--- a/core/src/test/scala/io/finch/request/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/request/HeaderSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.Await
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/request/MultipartParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/MultipartParamSpec.scala
@@ -1,7 +1,7 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.{Request, RequestBuilder}
-import com.twitter.finagle.httpx.exp.Multipart.FileUpload
+import com.twitter.finagle.http.{Request, RequestBuilder}
+import com.twitter.finagle.http.exp.Multipart.FileUpload
 import com.twitter.util.{Await, Future}
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Future}
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/OptionalParamsSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Future}
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderCompanionSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Future}
 import io.finch._
 import org.scalatest.{Matchers, FlatSpec}

--- a/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequestReaderValidationSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Future, Return, Throw}
 import org.scalacheck.Prop.BooleanOperators
 import org.scalatest.{Matchers, FlatSpec}

--- a/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamSpec.scala
@@ -2,7 +2,7 @@ package io.finch.request
 
 import java.util.UUID
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Future}
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
+++ b/core/src/test/scala/io/finch/request/RequiredParamsSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.request
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.util.{Await, Future}
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/response/RedirectSpec.scala
+++ b/core/src/test/scala/io/finch/response/RedirectSpec.scala
@@ -1,7 +1,7 @@
 package io.finch.response
 
-import com.twitter.finagle.httpx.{Request, Status}
-import com.twitter.finagle.httpx.path.Root
+import com.twitter.finagle.http.{Request, Status}
+import com.twitter.finagle.http.path.Root
 import com.twitter.util.Await
 import org.scalatest.{Matchers, FlatSpec}
 

--- a/core/src/test/scala/io/finch/response/ResponseBuilderSpec.scala
+++ b/core/src/test/scala/io/finch/response/ResponseBuilderSpec.scala
@@ -1,6 +1,6 @@
 package io.finch.response
 
-import com.twitter.finagle.httpx.{Status, Cookie}
+import com.twitter.finagle.http.{Status, Cookie}
 import com.twitter.io.Buf
 import com.twitter.io.Buf.{Utf8, ByteBuffer}
 import org.scalatest.{Matchers, FlatSpec}

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -23,7 +23,7 @@ val users: Endpoint[OAuth2Request, Json] = ???
 val groups: Endpoint[OAuth2Request, Json] = ???
 val endpoint: Endpoint[OAuth2Request, Response] = (users orElse groups) ! TurnIntoHttp[Json]
 
-// An HTTP endpoint that may be served with `Httpx`
+// An HTTP endpoint that may be served with `Http`
 val httpEndpoint: Endpoint[Request, Response] = auth ! endpoint
 ```
 
@@ -38,7 +38,7 @@ the following code is correct.
 ```scala
 val e: Endpoint[MyRequest, Response] = ???
 // an endpoint `e` will be converted to service implicitly
-Httpx.serve(new InetSocketAddress(8081), e)
+Http.serve(new InetSocketAddress(8081), e)
 ```
 
 --

--- a/docs/micro.md
+++ b/docs/micro.md
@@ -90,7 +90,7 @@ value of type `EncodeResponse[String]` provided by the `io.finch.request` packag
 
 ```scala
 val e: Endpoint = Get / "a" /> Micro.value("foo")
-Httpx.serve(":8081", e)
+Http.serve(":8081", e)
 ```
 
 ### Custom Request Type

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,10 +35,10 @@ val api: Router[String] =
   }
 ```
 
-The following code serves the given API endpoint with Finagle's Httpx codec.
+The following code serves the given API endpoint with Finagle's Http codec.
 
 ```scala
-Await.ready(Httpx.serve(":8081", api.toService))
+Await.ready(Http.serve(":8081", api.toService))
 ```
 
 So, we can now query the backend with `curl`.

--- a/docs/request.md
+++ b/docs/request.md
@@ -35,7 +35,7 @@ request in a Finagle application:
 
 ```scala
 import io.finch._
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.{Request, Response}
 
 def param(req: Request)(key: String): Option[String] =
   req.params.get(key) orElse {

--- a/docs/response.md
+++ b/docs/response.md
@@ -33,7 +33,7 @@ and start typing.
 import io.finch._
 import io.finch.request._
 import io.finch.response._
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.{Request, Response}
 
 object Hello extends Service[Request, Response] {
   def apply(req: Request) = for {

--- a/docs/route.md
+++ b/docs/route.md
@@ -143,11 +143,11 @@ val users: Endpoint[Request, Response] =
 ```
 
 Endpoints are implicitly convertible to Finagle `Service`s if there is an implicit view `Req => Request` available
-in the scope. This means, that you can usually pass an endpoint into a `Httpx.serve` method call.
+in the scope. This means, that you can usually pass an endpoint into a `Http.serve` method call.
 
 ```scala
 val endpoint: Endpoint[Request, Response] = users | tickets
-Httpx.serve(":8081", endpoint)
+Http.serve(":8081", endpoint)
 ```
 
 `Service` with underlying endpoint tries to match the _full_ route and throws a `RouteNotFound` exception in case if

--- a/oauth2/src/main/scala/io/finch/oauth2/package.scala
+++ b/oauth2/src/main/scala/io/finch/oauth2/package.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.finagle.OAuth2
 import com.twitter.finagle.oauth2.{GrantHandlerResult, AuthInfo, DataHandler}
 import com.twitter.util.Future

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -1,6 +1,6 @@
 package io.finch.oauth2
 
-import com.twitter.finagle.httpx.Request
+import com.twitter.finagle.http.Request
 import com.twitter.finagle.oauth2._
 import com.twitter.util.{Await, Future}
 import io.finch.request.RequestReader

--- a/petstore/src/main/scala/io/finch/petstore/endpoint.scala
+++ b/petstore/src/main/scala/io/finch/petstore/endpoint.scala
@@ -1,8 +1,8 @@
 package io.finch.petstore
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.exp.Multipart.FileUpload
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.exp.Multipart.FileUpload
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.Future
 import io.finch._
 import io.finch.argonaut._

--- a/petstore/src/main/scala/io/finch/petstore/service.scala
+++ b/petstore/src/main/scala/io/finch/petstore/service.scala
@@ -1,6 +1,6 @@
 package io.finch.petstore
 
-import com.twitter.finagle.Httpx
+import com.twitter.finagle.Http
 import com.twitter.util.{Future, Await}
 
 /**
@@ -18,7 +18,7 @@ class PetstoreApp {
 
   val service = endpoint.makeService(db)
 
-  val server = Httpx.serve(":8080", service) //creates service
+  val server = Http.serve(":8080", service) //creates service
 
   Await.ready(server)
 

--- a/petstore/src/test/scala/io/finch/petstore/PetstorePetServiceSpec.scala
+++ b/petstore/src/test/scala/io/finch/petstore/PetstorePetServiceSpec.scala
@@ -1,7 +1,7 @@
 package io.finch.petstore
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{FileElement, Request, RequestBuilder, Response}
+import com.twitter.finagle.http.{FileElement, Request, RequestBuilder, Response}
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util.{Duration, Await}
 import io.finch.test.ServiceSuite

--- a/petstore/src/test/scala/io/finch/petstore/PetstoreStoreServiceSpec.scala
+++ b/petstore/src/test/scala/io/finch/petstore/PetstoreStoreServiceSpec.scala
@@ -1,7 +1,7 @@
 package io.finch.petstore
 
 import com.twitter.finagle.{Service}
-import com.twitter.finagle.httpx.{FileElement, Request, RequestBuilder, Response}
+import com.twitter.finagle.http.{FileElement, Request, RequestBuilder, Response}
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util.{Await}
 import io.finch.test.ServiceSuite

--- a/petstore/src/test/scala/io/finch/petstore/PetstoreUserServiceSpec.scala
+++ b/petstore/src/test/scala/io/finch/petstore/PetstoreUserServiceSpec.scala
@@ -1,7 +1,7 @@
 package io.finch.petstore
 
 import com.twitter.finagle.{Service}
-import com.twitter.finagle.httpx.{FileElement, Request, RequestBuilder, Response}
+import com.twitter.finagle.http.{FileElement, Request, RequestBuilder, Response}
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util.{Await}
 import io.finch.test.ServiceSuite

--- a/test/src/main/scala/io/finch/test/ServiceIntegrationSuite.scala
+++ b/test/src/main/scala/io/finch/test/ServiceIntegrationSuite.scala
@@ -1,7 +1,7 @@
 package io.finch.test
 
-import com.twitter.finagle.{Httpx, ListeningServer, Service}
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.{Http, ListeningServer, Service}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.Await
 import org.scalatest.Outcome
 import org.scalatest.fixture.FlatSpec
@@ -23,8 +23,8 @@ trait ServiceIntegrationSuite extends ServiceSuite { self: FlatSpec =>
    */
   override def withFixture(test: OneArgTest): Outcome = {
     val service: Service[Request, Response] = createService()
-    var server: ListeningServer = Httpx.serve(s":$port", service)
-    var client: Service[Request, Response] = Httpx.newService(s"127.0.0.1:$port")
+    var server: ListeningServer = Http.serve(s":$port", service)
+    var client: Service[Request, Response] = Http.newService(s"127.0.0.1:$port")
 
     try {
       self.withFixture(test.toNoArgTest(FixtureParam(client)))

--- a/test/src/main/scala/io/finch/test/ServiceSuite.scala
+++ b/test/src/main/scala/io/finch/test/ServiceSuite.scala
@@ -1,7 +1,7 @@
 package io.finch.test
 
 import com.twitter.finagle.Service
-import com.twitter.finagle.httpx.{Request, Response}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.{Await, Duration}
 import org.scalatest.Outcome
 import org.scalatest.fixture.FlatSpec


### PR DESCRIPTION
This PR bumps Finagle to 6.30 and [renames `finagle.httpx` to `finagle.http`](https://gist.github.com/vkostyukov/130dd016dd25389275c9).