### PR TITLE
fix some reference links to point at respective homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Modules
 Finch uses multi-project structure and contains of the following _modules_:
 
 * [`finch-core`](core) - the core classes/functions
-* [`finch-argonaut`](argonaut) - the JSON API support for the [Argonaut](argonaut) library
-* [`finch-jackson`](jackson) - the JSON API support for the [Jackson](jackson) library
-* [`finch-json4s`](json4s) - the JSON API support for the [JSON4S](json4s) library
-* [`finch-circe`](circe) - the JSON API support for the [Circe](circe) library
+* [`finch-argonaut`](argonaut) - the JSON API support for the [Argonaut][argonaut] library
+* [`finch-jackson`](jackson) - the JSON API support for the [Jackson][jackson] library
+* [`finch-json4s`](json4s) - the JSON API support for the [JSON4S][json4s] library
+* [`finch-circe`](circe) - the JSON API support for the [Circe][circe] library
 * [`finch-test`](test) - the test support classes/functions
-* [`finch-oauth2`](oauth2) - the OAuth2 support backed by the [finagle-oauth2](finagle-oauth2) library
+* [`finch-oauth2`](oauth2) - the OAuth2 support backed by the [finagle-oauth2][finagle-oauth2] library
 
 Installation
 ------------
@@ -137,7 +137,7 @@ limitations under the License.
 [service-benchmark]: https://github.com/finagle/finch/blob/master/benchmarks/src/main/scala/io/finch/benchmarks/service/UserServiceBenchmark.scala
 [finagle]: https://github.com/twitter/finagle
 [circe]: https://github.com/travisbrown/circe
-[jackson]: http://jackson.codehaus.org
+[jackson]: http://wiki.fasterxml.com/JacksonHome
 [argonaut]: http://argonaut.io
 [finagle-oauth2]: https://github.com/finagle/finagle-oauth2
 [json4s]: http://json4s.org


### PR DESCRIPTION
This is a simple README fix for reference links since they didn't seem to be pointing to the right place.