### PR TITLE
Fix #423: Introduce Endpoint.as[A] method

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -259,4 +259,18 @@ object Endpoint {
       implicit ftp: FnToProduct.Aux[F, L => FI], ev: FI <:< Future[I]
     ): Endpoint[I] = r.embedFlatMap(value => ev(ftp(fn)(value)))
   }
+
+  final implicit class ValueEndpointOps[B](val self: Endpoint[B]) extends AnyVal {
+    /**
+     * Converts this endpoint to one that returns any type with `B :: HNil` as its representation.
+     */
+    def as[A](implicit gen: Generic.Aux[A, B :: HNil]): Endpoint[A] = self.map(value => gen.from(value :: HNil))
+  }
+
+  final implicit class HListEndpointOps[L <: HList](val self: Endpoint[L]) {
+    /**
+     * Converts this endpoint to one that returns any type with this [[shapeless.HList]] as its representation.
+     */
+    def as[A](implicit gen: Generic.Aux[A, L]): Endpoint[A] = self.map(gen.from)
+  }
 }


### PR DESCRIPTION
This PR introduces the `Endpoint.as[A]` method which does the same trick as `RequestReader.as[A]`:

```scala
scala> import io.finch._
import io.finch._

scala> case class Foo(i: Int, s: String)
defined class Foo

scala> val e: Endpoint[Foo] = get(int / string).as[Foo]
e: io.finch.Endpoint[Foo] = GET /:int/:string

```