### PR TITLE
fix class name which leads user compile error in quickstart.md.

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,10 +35,10 @@ val api: Router[String] =
   }
 ```
 
-The following code serves the given API endpoint with Finagle's Http codec.
+The following code serves the given API endpoint with Finagle's Httpx codec.
 
 ```scala
-Await.ready(Http.serve(":8081", api.toService))
+Await.ready(Httpx.serve(":8081", api.toService))
 ```
 
 So, we can now query the backend with `curl`.


### PR DESCRIPTION
* Change the document quickstart.md
  * In original document it says server can start via `Http#serve`
  * But `Http` object or class in `com.twitter.finagle.httpx` does not have `serve` method.
  * After grepping codes, I found it should be `com.twitter.finagle.Httpx`.