### PR TITLE
com.twitter.finagle.Http is deprecated Httpx can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ This "Hello World!" example is built with the `0.9.0-SNAPSHOT` version of `finch
 
 ```scala
 import io.finch._
-import com.twitter.finagle.Http
+import com.twitter.finagle.Httpx
 
 val api: Endpoint[String] = get("hello") { Ok("Hello, World!") }
 
-Http.serve(":8080", api.toService)
+Httpx.serve(":8080", api.toService)
 ```
 
 Performance

--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ libraryDependencies ++= Seq(
 
 Hello World!
 ------------
-This "Hello World!" example is built with the `0.9.0-SNAPSHOT` version of `finch-core`.
+This "Hello World!" example is built with the `0.9.1-SNAPSHOT` version of `finch-core`.
 
 ```scala
 import io.finch._
-import com.twitter.finagle.Httpx
+import com.twitter.finagle.Http
 
 val api: Endpoint[String] = get("hello") { Ok("Hello, World!") }
 
-Httpx.serve(":8080", api.toService)
+Http.serve(":8080", api.toService)
 ```
 
 Performance


### PR DESCRIPTION
This is a minor fix for the README sample but it's useful for newcomers.