### PR TITLE
Introduce monadic composition for Endpoint

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Cookie, Request, Response}
-import com.twitter.util.Future
+import com.twitter.util.{Await, Future}
 import shapeless._
 import shapeless.ops.adjoin.Adjoin
 
@@ -127,6 +127,13 @@ trait Endpoint[A] { self =>
       }
 
     override def toString = self.toString
+  }
+
+  def flatMap[B](fn: A => Endpoint[B]): Endpoint[B] = new Endpoint[B] {
+    override def apply(input: Input): Option[(Input, () => Future[Output[B]])] = for {
+      (r1, ao) <- self(input)
+      (r2, bo) <- fn(Await.result(ao()).value)(r1)
+    } yield (r2, bo)
   }
 
   /**

--- a/core/src/main/scala/io/finch/Mapper.scala
+++ b/core/src/main/scala/io/finch/Mapper.scala
@@ -32,6 +32,11 @@ trait LowPriorityMapperConversions {
       type Out = B
       def apply(r: Endpoint[A]): Endpoint[Out] = r.femap(f)
     }
+
+  implicit def mapperFromEndpointFunction[A, B](f: A => Endpoint[B]): Mapper.Aux[A, B] = new Mapper[A] {
+    type Out = B
+    def apply(r: Endpoint[A]): Endpoint[Out] = r.flatMap(f)
+  }
 }
 
 trait HighPriorityMapperConversions extends LowPriorityMapperConversions {


### PR DESCRIPTION
To pass inner endpoint a context from outer endpoint, Endpoint should be monadic. Endpoint being monadic benefits applications that pass some value (e.g. unique ID to the request) generated at the entry point to the exception handler of the inner endpoint.