### PR TITLE
Cleanup type-classes

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/package.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/package.scala
@@ -10,13 +10,12 @@ package object argonaut {
    * @tparam A The type of data that the ''DecodeJson'' will decode into
    * @return Create a Finch ''DecodeRequest'' from an argonaut ''DecodeJson''
    */
-  implicit def decodeArgonaut[A](implicit decode: DecodeJson[A]): DecodeRequest[A] =
-    DecodeRequest(
-      Parse.decodeEither(_).fold[Try[A]](
-        error => Throw[A](Error(error)),
-        Return(_)
-      )
+  implicit def decodeArgonaut[A](implicit decode: DecodeJson[A]): DecodeRequest[A] = DecodeRequest.instance(s =>
+    Parse.decodeEither(s).fold[Try[A]](
+      error => Throw[A](Error(error)),
+      Return(_)
     )
+  )
 
   /**
    * @param encode The argonaut ''EncodeJson'' to use for decoding

--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -11,13 +11,12 @@ package object circe {
    * @tparam A The type of data that the [[io.circe.Decoder]] will decode into
    * @return Create a Finch ''DecodeRequest'' from a [[io.circe.Decoder]]
    */
-  implicit def decodeCirce[A](implicit d: Decoder[A]): DecodeRequest[A] =
-    DecodeRequest(
-      decode[A](_).fold[Try[A]](
-        error => Throw[A](Error(error.getMessage)),
-        Return(_)
-      )
+  implicit def decodeCirce[A](implicit d: Decoder[A]): DecodeRequest[A] = DecodeRequest.instance(s =>
+    decode[A](s).fold[Try[A]](
+      error => Throw[A](Error(error.getMessage)),
+      Return(_)
     )
+  )
 
   /**
    * @param e The [[io.circe.Encoder]] to use for decoding

--- a/core/src/test/scala/io/finch/ApplicativeRequestReaderSpec.scala
+++ b/core/src/test/scala/io/finch/ApplicativeRequestReaderSpec.scala
@@ -61,14 +61,14 @@ class ApplicativeRequestReaderSpec extends FlatSpec with Matchers {
   it should "compiles with both implicits Generic and DecodeRequest in the scope" in {
     case class MyString(s: String)
     implicit val decodeMyString: DecodeRequest[MyString] =
-      DecodeRequest { s => Try(MyString(s)) }
+      DecodeRequest.instance(s => Try(MyString(s)))
 
     val foo: RequestReader[MyString] = param("a").as[MyString]
     Await.result(foo(Request("a" -> "foo"))) shouldBe MyString("foo")
 
     case class MyInt(i: Int)
     implicit val decodeMyInt: DecodeRequest[MyInt] =
-      DecodeRequest { s => Try(MyInt(s.toInt)) }
+      DecodeRequest.instance(s => Try(MyInt(s.toInt)))
 
     val bar: RequestReader[MyInt] = param("a").as[MyInt]
     Await.result(bar(Request("a" -> "100"))) shouldBe MyInt(100)

--- a/core/src/test/scala/io/finch/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/DecodeSpec.scala
@@ -11,8 +11,6 @@ class DecodeSpec extends FlatSpec with Matchers {
 
   private def decode[A](json: String)(implicit d: DecodeRequest[A]): Try[A] = d(json)
   
-  implicit val decodeInt = DecodeRequest { s => Try(s.toInt) }
-  
   "A DecodeJson" should "be accepted as implicit instance of superclass" in {
     implicit object BigDecimalJson extends DecodeRequest[BigDecimal] {
       def apply(s: String): Try[BigDecimal] = Try(BigDecimal(s))
@@ -99,5 +97,4 @@ class DecodeSpec extends FlatSpec with Matchers {
     val result = reader(request)
     Await.result(result) shouldBe ((Foo("foo"), Bar("bar")))
   }
-  
 }

--- a/core/src/test/scala/io/finch/EndToEndSpec.scala
+++ b/core/src/test/scala/io/finch/EndToEndSpec.scala
@@ -13,7 +13,7 @@ class EndToEndSpec extends FinchSpec {
       EncodeResponse.fromString("text/plain")(_.s)
 
     implicit val decodeFoo: DecodeRequest[Foo] =
-      DecodeRequest(s => Return(Foo(s)))
+      DecodeRequest.instance(s => Return(Foo(s)))
 
     implicit val encodeException: EncodeResponse[Exception] =
       EncodeResponse.fromString("text/plain")(_ => "ERR!")

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -12,9 +12,8 @@ package object json4s {
    * @tparam A the type of data to decode into
    */
   //@TODO get rid of Manifest as soon as json4s migrates to new reflection API
-  implicit def decodeJson[A : Manifest](implicit formats: Formats): DecodeRequest[A] = DecodeRequest(
-    input => Try(JsonMethods.parse(input).extract[A])
-  )
+  implicit def decodeJson[A : Manifest](implicit formats: Formats): DecodeRequest[A] =
+    DecodeRequest.instance(input => Try(JsonMethods.parse(input).extract[A]))
 
   /**
    * @param formats json4s `Formats` to use for decoding


### PR DESCRIPTION
This PR cleans up most of the Finch type classe to use Circe-style patterns (`apply` and `instance`), which I personally really like.