### PR TITLE
Fix flakey test in OutputSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,8 +104,7 @@ lazy val root = project.in(file("."))
       """
         |import io.finch._
         |import io.finch.circe._
-        |import io.finch.request._
-        |import io.finch.request.items._
+        |import io.finch.items._
         |import com.twitter.util.{Future, Await}
         |import com.twitter.finagle.Service
         |import com.twitter.finagle.http.{Request, Response, Status}

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -28,7 +28,9 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers {
     value <- genNonEmptyString
   } yield (key, value)
 
-  def genHeaders: Gen[Headers] = Gen.mapOf(genNonEmptyTuple).map(Headers.apply)
+  def genHeaders: Gen[Headers] = Gen.mapOf(genNonEmptyTuple).map(m =>
+    Headers(m.map(kv => kv._1.toLowerCase -> kv._2.toLowerCase))
+  )
 
   def genCookies: Gen[Cookies] = Gen.listOf(genNonEmptyTuple.map(t => new Cookie(t._1, t._2))).map(Cookies.apply)
 


### PR DESCRIPTION
Hope that's not a surprise by Netty doesn't distinct `x` and `X` headers:

```scala
scala> val rep = Response()
rep: com.twitter.finagle.http.Response = Response("HTTP/1.1 Status(200)")

scala> rep.headerMap.set("X", "y")
res0: com.twitter.finagle.http.HeaderMap = Map(X -> y)

scala> rep.headerMap.set("x", "y")
res1: com.twitter.finagle.http.HeaderMap = Map(x -> y)

scala> rep.headerMap.toMap
res2: scala.collection.immutable.Map[String,String] = Map(x -> y)

scala> rep.headerMap.set("X", "y")
res3: com.twitter.finagle.http.HeaderMap = Map(X -> y)
```