### PR TITLE
Use Cats' Eval

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val buildSettings = Seq(
 lazy val finagleVersion = "6.30.0"
 lazy val circeVersion = "0.3.0-SNAPSHOT"
 lazy val shapelessVersion = "2.3.0-SNAPSHOT"
+lazy val catsVersion = "0.4.0-SNAPSHOT"
 
 lazy val compilerOptions = Seq(
   "-deprecation",
@@ -35,6 +36,7 @@ val testDependencies = Seq(
 val baseSettings = Seq(
   libraryDependencies ++= Seq(
     "com.chuusai" %% "shapeless" % shapelessVersion,
+    "org.spire-math" %% "cats-core" % catsVersion,
     "com.twitter" %% "finagle-http" % finagleVersion,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -2,7 +2,6 @@ package io.finch
 
 import com.twitter.finagle.http.{Cookie, Response, Status, Version}
 import com.twitter.util.Future
-import shapeless.HNil
 
 /**
  * An output of [[Endpoint]].
@@ -55,6 +54,16 @@ sealed trait Output[+A] { self =>
 object Output {
 
   /**
+   * Creates a new [[Output.Payload]] of type `Output[A]`.
+   */
+  def payload[A](a: A, s: Status = Status.Ok): Output[A] = Payload(a, s)
+
+  /**
+   * Creates a new [[Output.Failure]] of type `Output[A]`.
+   */
+  def failure[A](cause: Exception, s: Status = Status.BadRequest): Output[A] = Failure(cause, s)
+
+  /**
    * A successful [[Output]] that captures a payload `value`.
    */
   final case class Payload[A](
@@ -94,7 +103,7 @@ object Output {
    */
   final case class Failure(
     cause: Exception,
-    status: Status,
+    status: Status = Status.BadRequest,
     headers: Map[String, String] = Map.empty[String, String],
     cookies: Seq[Cookie] = Seq.empty[Cookie],
     contentType: Option[String] = None,
@@ -117,6 +126,4 @@ object Output {
       headers = headers, cookies = cookies, contentType = contentType, charset = charset
     )
   }
-
-  private[finch] val HNil: Payload[HNil] = Output.Payload(shapeless.HNil)
 }

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -71,7 +71,7 @@ trait LowPriorityToServiceInstances {
 
       def apply(req: Request): Future[Response] = safeEndpoint(Input(req)) match {
         case Some((remainder, output)) if remainder.isEmpty =>
-          output().map(o => o.toResponse(req.version)).handle {
+          output.map(f => f.map(o => o.toResponse(req.version))).value.handle {
             // TODO: Remove after Finagle 6.31
             case _ => Response(req.version, Status.InternalServerError)
           }

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -2,6 +2,7 @@ package io.finch
 
 import java.util.UUID
 
+import cats.Eval
 import com.twitter.finagle.http._
 import com.twitter.util.{Await, Future}
 import org.scalacheck.{Arbitrary, Gen}
@@ -15,8 +16,8 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers {
 
   case class OptionalNonEmptyString(o: Option[String])
 
-  implicit class OptionOutputOps[A](o: Option[(Input, () => Future[Output[A]])]) {
-    def output: Option[Output[A]] = o.map({ case (_, oa) => Await.result(oa()) })
+  implicit class OptionOutputOps[A](o: Option[(Input, Eval[Future[Output[A]]])]) {
+    def output: Option[Output[A]] = o.map({ case (_, oa) => Await.result(oa.value) })
     def value: Option[A] = output.map(oa => oa.value)
     def remainder: Option[Input] = o.map(_._1)
   }

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -1,5 +1,6 @@
 package io.finch.oauth2
 
+import cats.Eval
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.oauth2._
 import com.twitter.util.{Await, Future}
@@ -11,10 +12,12 @@ import io.finch._
 
 class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar {
 
-  def runAndAwaitOutput[A](e: Endpoint[A], input: Input): Option[(Input, Output[A])] =
-    e(input).map {
-      case (remainder, output) => (remainder, Await.result(output()))
-    }
+  // TODO: Reuse this one from FinchSpec
+  implicit class OptionOutputOps[A](o: Option[(Input, Eval[Future[Output[A]]])]) {
+    def output: Option[Output[A]] = o.map({ case (_, oa) => Await.result(oa.value) })
+    def value: Option[A] = output.map(oa => oa.value)
+    def remainder: Option[Input] = o.map(_._1)
+  }
 
   "The OAuth2 provider" should "authorize the requests" in {
     val at: AccessToken = mock[AccessToken]
@@ -34,8 +37,8 @@ class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar 
     val i1 = Input(Request("/user", "access_token" -> "bar"))
     val i2 = Input(Request("/user"))
 
-    runAndAwaitOutput(e, i1) shouldBe Some((i1.drop(1), Ok(42)))
-    an [OAuthError] shouldBe thrownBy(runAndAwaitOutput(e, i2))
+    e(i1).output shouldBe Some(Ok(42))
+    an [OAuthError] shouldBe thrownBy(e(i2).output)
   }
 
   it should "issue the access token" in {
@@ -58,7 +61,7 @@ class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar 
     )
     val i2 = Input(Request("/token"))
 
-    runAndAwaitOutput(e, i1) shouldBe Some((i1.drop(1), Ok("foobar")))
-    an [OAuthError] shouldBe thrownBy(runAndAwaitOutput(e, i2))
+    e(i1).output shouldBe Some(Ok("foobar"))
+    an [OAuthError] shouldBe thrownBy(e(i2).output)
   }
 }


### PR DESCRIPTION
This is just a first step towards Cats in Finch! But I think it's a good start!

This PR uses Cats' `Eval[A]` instead of `() => A`. The end-user API wasn't affected. I'm going to check the benchmarks later tonight and would appriciate any thoughts on this.