### PR TITLE
Fix 406: Allow to override pretty printer for Circe and Argonaut

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
@@ -1,0 +1,23 @@
+package io.finch.argonaut
+
+import scala.util.{Failure, Success}
+
+import argonaut.{CursorHistory, DecodeJson, Json}
+import com.twitter.util.{Return, Throw, Try}
+import io.finch.{DecodeRequest, Error}
+import jawn.Parser
+import jawn.support.argonaut.Parser._
+
+trait Decoders {
+
+  /**
+   * Maps Argonaut's [[DecodeJson]] to Finch's [[DecodeRequest]].
+   */
+  implicit def decodeArgonaut[A](implicit d: DecodeJson[A]): DecodeRequest[A] = DecodeRequest.instance[A] { s =>
+    val err: (String, CursorHistory) => Try[A] = { (str, hist) => Throw[A](Error(str)) }
+    Parser.parseFromString[Json](s)(facade) match {
+      case Success(value) => d.decodeJson(value).fold[Try[A]](err, Return(_))
+      case Failure(error) => Throw[A](Error(error.getMessage))
+    }
+  }
+}

--- a/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
@@ -1,0 +1,15 @@
+package io.finch.argonaut
+
+import argonaut.{EncodeJson, PrettyParams}
+import io.finch.EncodeResponse
+
+trait Encoders {
+
+  protected def printer: PrettyParams
+
+  /**
+   * Maps Argonaut's [[EncodeJson]] to Finch's [[EncodeResponse]].
+   */
+  implicit def encodeArgonaut[A](implicit e: EncodeJson[A]): EncodeResponse[A] =
+    EncodeResponse.fromString[A]("application/json")(a => printer.pretty(e.encode(a)))
+}

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -1,0 +1,19 @@
+package io.finch.circe
+
+import com.twitter.util.{Return, Throw, Try}
+import io.circe.Decoder
+import io.circe.jawn.decode
+import io.finch.{DecodeRequest, Error}
+
+trait Decoders {
+
+  /**
+   * Maps a Circe's [[Decoder]] to Finch's [[DecodeRequest]].
+   */
+  implicit def decodeCirce[A](implicit d: Decoder[A]): DecodeRequest[A] = DecodeRequest.instance(s =>
+    decode[A](s).fold[Try[A]](
+      error => Throw[A](Error(error.getMessage)),
+      value => Return(value)
+    )
+  )
+}

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -1,0 +1,15 @@
+package io.finch.circe
+
+import io.circe.{Encoder, Printer}
+import io.finch.EncodeResponse
+
+trait Encoders {
+
+  protected def printer: Printer
+
+  /**
+   * Maps Circe's [[Encoder]] to Finch's [[EncodeResponse]].
+   */
+  implicit def encodeCirce[A](implicit e: Encoder[A]): EncodeResponse[A] =
+    EncodeResponse.fromString[A]("application/json")(a => printer.pretty(e(a)))
+}

--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -1,29 +1,16 @@
 package io.finch
 
-import com.twitter.util.{Return, Throw, Try}
-import io.circe.{Decoder, Encoder}
-import io.circe.jawn.decode
+import io.circe.Printer
 
-package object circe {
+package object circe extends Encoders with Decoders {
 
-  /**
-   * @param d The [[io.circe.Decoder]] to use for decoding
-   * @tparam A The type of data that the [[io.circe.Decoder]] will decode into
-   * @return Create a Finch ''DecodeRequest'' from a [[io.circe.Decoder]]
-   */
-  implicit def decodeCirce[A](implicit d: Decoder[A]): DecodeRequest[A] = DecodeRequest.instance(s =>
-    decode[A](s).fold[Try[A]](
-      error => Throw[A](Error(error.getMessage)),
-      Return(_)
-    )
-  )
+  override protected val printer: Printer = Printer.noSpaces
 
   /**
-   * @param e The [[io.circe.Encoder]] to use for decoding
-   * @tparam A The type of data that the [[io.circe.Encoder]] will use to create the JSON string
-   * @return Create a Finch ''EncodeJson'' from an [[io.circe.Encoder]]
+   * Provides an implicit [[Printer]] that drops null keys.
    */
-  implicit def encodeCirce[A](implicit e: Encoder[A]): EncodeResponse[A] =
-    EncodeResponse.fromString[A]("application/json")(e(_).noSpaces)
+  object dropNullKeys extends Encoders with Decoders {
+    override protected val printer: Printer = Printer.noSpaces.copy(dropNullKeys = true)
+  }
 }
 


### PR DESCRIPTION
This PR allows users to override the default pretty printer for Circe and Argonaut.

Circe:

```scala
import io.finch.circe._
import io.finch.circe.dropNullKeys._
```

Argonaut:

```scala
import io.finch.argonaut._
import io.finch.argonaut.preserveOrder._
```