### PR TITLE
Move FromParams to internal

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -246,7 +246,7 @@ object Endpoint {
     def as[A](implicit gen: Generic.Aux[A, B :: HNil]): Endpoint[A] = self.map(value => gen.from(value :: HNil))
   }
 
-  final implicit class HListEndpointOps[L <: HList](val self: Endpoint[L]) {
+  final implicit class HListEndpointOps[L <: HList](val self: Endpoint[L]) extends AnyVal {
     /**
      * Converts this endpoint to one that returns any type with this [[shapeless.HList]] as its representation.
      */

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -1,0 +1,32 @@
+package io.finch.internal
+
+import scala.reflect.ClassTag
+
+import io.finch._
+import shapeless.{::, HList, HNil, Witness}
+import shapeless.labelled._
+
+/**
+ * A type class empowering a generic derivation of [[RequestReader]]s from query string params.
+ */
+trait FromParams[L <: HList] {
+  def reader: RequestReader[L]
+}
+
+object FromParams {
+
+  implicit val hnilFromParams: FromParams[HNil] = new FromParams[HNil] {
+    def reader: RequestReader[HNil] = RequestReader.value(HNil)
+  }
+
+  implicit def hconsFromParams[HK <: Symbol, HV, T <: HList](implicit
+    dh: DecodeRequest[HV],
+    ct: ClassTag[HV],
+    key: Witness.Aux[HK],
+    fpt: FromParams[T]
+  ): FromParams[FieldType[HK, HV] :: T] = new FromParams[FieldType[HK, HV] :: T] {
+    def reader: RequestReader[FieldType[HK, HV] :: T] =
+      param(key.value.name).as(dh, ct).map(field[HK](_)) :: fpt.reader
+  }
+}
+


### PR DESCRIPTION
Moving `FromParams` under the `io.finch.internal` pacakge.