### PR TITLE
Add 0.9.1-backward compatible API for failures

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
@@ -8,8 +8,7 @@ class FinchUserService(implicit
   userDecoder: DecodeRequest[User],
   newUserInfoDecoder: DecodeRequest[NewUserInfo],
   userEncoder: EncodeResponse[User],
-  usersEncoder: EncodeResponse[List[User]],
-  encodeErr: EncodeResponse[Map[String, String]]
+  usersEncoder: EncodeResponse[List[User]]
 ) extends UserService {
 
   val getUser: Endpoint[User] = get("users" / long) { id: Long =>

--- a/core/src/main/scala/io/finch/EncodeResponse.scala
+++ b/core/src/main/scala/io/finch/EncodeResponse.scala
@@ -44,6 +44,11 @@ object EncodeResponse extends LowPriorityEncodeResponseInstances {
       def contentType: String = e.contentType
     }
 
+  implicit val encodeMap: EncodeResponse[Map[String, String]] =
+    EncodeResponse("text/plain")(map =>
+      Buf.Utf8(map.toSeq.map(kv => kv._1 + ":" + kv._2).mkString("\n"))
+    )
+
   implicit val encodeString: EncodeResponse[String] =
     fromString[String]("text/plain")(identity)
 

--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -57,4 +57,13 @@ object Error {
       s"${item.description} cannot be converted to ${targetType.runtimeClass.getSimpleName}: ${cause.getMessage}."
     override def getCause: Throwable = cause
   }
+
+  /**
+   * An exception that wrap an immutable map, which encodes an exception message.
+   *
+   * Warning: This class is only used to provide a 0.9.1-compatible API in 0.9.2. Will be removed in 0.9.3.
+   */
+  private[finch] final case class MapException(map: Map[String, String]) extends Error {
+    override def getMessage: String = map.toSeq.map(kv => kv._1 + ":" + kv._2).mkString("\n")
+  }
 }

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -3,6 +3,7 @@ package io.finch
 import cats.Eval
 import com.twitter.finagle.http.{Cookie, Response, Status, Version}
 import com.twitter.util.{Await, Future}
+import io.finch.Error.MapException
 import io.finch.internal.ToResponse
 
 /**
@@ -35,10 +36,12 @@ sealed trait Output[+A] { self =>
 
   def toResponse(version: Version = Version.Http11)(implicit
     payloadToResponse: ToResponse[A],
-    failureToResponse: ToResponse[Exception]
+    failureToResponse: ToResponse[Exception],
+    mapToResponse: ToResponse[Map[String, String]]
   ): Response = {
     val rep = this match {
       case Output.Payload(v, _, _, _, _, _) => payloadToResponse(v)
+      case Output.Failure(MapException(map), _, _, _, _, _) => mapToResponse(map)
       case Output.Failure(x, _, _, _, _, _) => failureToResponse(x)
     }
     rep.version = version

--- a/core/src/main/scala/io/finch/Outputs.scala
+++ b/core/src/main/scala/io/finch/Outputs.scala
@@ -1,6 +1,7 @@
 package io.finch
 
 import com.twitter.finagle.http.Status
+import io.finch.Error.MapException
 
 trait Outputs {
 
@@ -38,7 +39,7 @@ trait Outputs {
       cause, Status.RequestedRangeNotSatisfiable)                                                                  //416
   def EnhanceYourCalm(cause: Exception): Output.Failure = Output.Failure(cause, Status.EnhanceYourCalm)            //420
   def UnprocessableEntity(cause: Exception): Output.Failure = Output.Failure(cause, Status.UnprocessableEntity)    //422
-  def ToManyRequests(cause: Exception): Output.Failure = Output.Failure(cause, Status.TooManyRequests)             //429
+  def TooManyRequests(cause: Exception): Output.Failure = Output.Failure(cause, Status.TooManyRequests)            //429
 
   // 5xx
   def InternalServerError(cause: Exception): Output.Failure = Output.Failure(cause, Status.InternalServerError)    //500
@@ -47,4 +48,75 @@ trait Outputs {
   def ServiceUnavailable(cause: Exception): Output.Failure = Output.Failure(cause, Status.ServiceUnavailable)      //503
   def GatewayTimeout(cause: Exception): Output.Failure = Output.Failure(cause, Status.GatewayTimeout)              //504
   def InsufficientStorage(cause: Exception): Output.Failure = Output.Failure(cause, Status.InsufficientStorage)    //507
+
+  // ------ 0.9.1-compatible API (will be removed in 0.9.3) ------
+
+  // 3xx
+  @deprecated("Use MovedPermanently(Exception) instead", "0.9.2")
+  def MovedPermanently(messages: (String, String)*): Output.Failure = MovedPermanently(MapException(messages.toMap))
+  @deprecated("Use Found(Exception) instead", "0.9.2")
+  def Found(messages: (String, String)*): Output.Failure = Found(MapException(messages.toMap))
+  @deprecated("Use SeeOther(Exception) instead", "0.9.2")
+  def SeeOther(messages: (String, String)*): Output.Failure = SeeOther(MapException(messages.toMap))
+  @deprecated("Use NotModified(Exception) instead", "0.9.2")
+  def NotModified(messages: (String, String)*): Output.Failure = NotModified(MapException(messages.toMap))
+  @deprecated("Use TemporaryRedirect(Exception) instead", "0.9.2")
+  def TemporaryRedirect(messages: (String, String)*): Output.Failure = TemporaryRedirect(MapException(messages.toMap))
+  @deprecated("Use PermanentRedirect(Exception) instead", "0.9.2")
+  def PermanentRedirect(messages: (String, String)*): Output.Failure = PermanentRedirect(MapException(messages.toMap))
+
+  // 4xx
+  @deprecated("Use BadRequest(Exception) instead", "0.9.2")
+  def BadRequest(messages: (String, String)*): Output.Failure = BadRequest(MapException(messages.toMap))
+  @deprecated("Use Unauthorized(Exception) instead", "0.9.2")
+  def Unauthorized(messages: (String, String)*): Output.Failure = Unauthorized(MapException(messages.toMap))
+  @deprecated("Use PaymentRequired(Exception) instead", "0.9.2")
+  def PaymentRequired(messages: (String, String)*): Output.Failure = PaymentRequired(MapException(messages.toMap))
+  @deprecated("Use Forbidden(Exception) instead", "0.9.2")
+  def Forbidden(messages: (String, String)*): Output.Failure = Forbidden(MapException(messages.toMap))
+  @deprecated("Use NotFound(Exception) instead", "0.9.2")
+  def NotFound(messages: (String, String)*): Output.Failure = NotFound(MapException(messages.toMap))
+  @deprecated("Use MethodNotAllowed(Exception) instead", "0.9.2")
+  def MethodNotAllowed(messages: (String, String)*): Output.Failure = MethodNotAllowed(MapException(messages.toMap))
+  @deprecated("Use NotAcceptable(Exception) instead", "0.9.2")
+  def NotAcceptable(messages: (String, String)*): Output.Failure = NotAcceptable(MapException(messages.toMap))
+  @deprecated("Use RequestTimeout(Exception) instead", "0.9.2")
+  def RequestTimeout(messages: (String, String)*): Output.Failure = RequestTimeout(MapException(messages.toMap))
+  @deprecated("Use Conflict(Exception) instead", "0.9.2")
+  def Conflict(messages: (String, String)*): Output.Failure = Conflict(MapException(messages.toMap))
+  @deprecated("Use Gone(Exception) instead", "0.9.2")
+  def Gone(messages: (String, String)*): Output.Failure = Gone(MapException(messages.toMap))
+  @deprecated("Use LengthRequired(Exception) instead", "0.9.2")
+  def LengthRequired(messages: (String, String)*): Output.Failure = LengthRequired(MapException(messages.toMap))
+  @deprecated("Use PreconditionFailed(Exception) instead", "0.9.2")
+  def PreconditionFailed(messages: (String, String)*): Output.Failure = PreconditionFailed(MapException(messages.toMap))
+  @deprecated("Use RequestEntityTooLarge(Exception) instead", "0.9.2")
+  def RequestEntityTooLarge(messages: (String, String)*): Output.Failure =
+    RequestEntityTooLarge(MapException(messages.toMap))
+  @deprecated("Use RequestedRangeNotSatisfiable(Exception) instead", "0.9.2")
+  def RequestedRangeNotSatisfiable(messages: (String, String)*): Output.Failure =
+    RequestedRangeNotSatisfiable(MapException(messages.toMap))
+  @deprecated("Use EnhanceYourCalm(Exception) instead", "0.9.2")
+  def EnhanceYourCalm(messages: (String, String)*): Output.Failure = EnhanceYourCalm(MapException(messages.toMap))
+  @deprecated("Use UnprocessableEntity(Exception) instead", "0.9.2")
+  def UnprocessableEntity(messages: (String, String)*): Output.Failure =
+    UnprocessableEntity(MapException(messages.toMap))
+  @deprecated("Use TooManyRequests(Exception) instead", "0.9.2")
+  def TooManyRequests(messages: (String, String)*): Output.Failure = TooManyRequests(MapException(messages.toMap))
+
+  // 5xx
+  @deprecated("Use InternalServerError(Exception) instead", "0.9.2")
+  def InternalServerError(messages: (String, String)*): Output.Failure =
+    InternalServerError(MapException(messages.toMap))
+  @deprecated("Use NotImplemented(Exception) instead", "0.9.2")
+  def NotImplemented(messages: (String, String)*): Output.Failure = NotImplemented(MapException(messages.toMap))
+  @deprecated("Use BadGateway(Exception) instead", "0.9.2")
+  def BadGateway(messages: (String, String)*): Output.Failure = BadGateway(MapException(messages.toMap))
+  @deprecated("Use ServiceUnavailable(Exception) instead", "0.9.2")
+  def ServiceUnavailable(messages: (String, String)*): Output.Failure = ServiceUnavailable(MapException(messages.toMap))
+  @deprecated("Use GatewayTimeout(Exception) instead", "0.9.2")
+  def GatewayTimeout(messages: (String, String)*): Output.Failure = GatewayTimeout(MapException(messages.toMap))
+  @deprecated("Use InsufficientStorage(Exception) instead", "0.9.2")
+  def InsufficientStorage(messages: (String, String)*): Output.Failure =
+    InsufficientStorage(MapException(messages.toMap))
 }

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -51,7 +51,8 @@ trait LowPriorityToServiceInstances {
    */
   implicit def valueRouterToService[A](implicit
     polyCase: EncodeAll.Case.Aux[A, Response],
-    tre: ToResponse[Exception]
+    tre: ToResponse[Exception],
+    trm: ToResponse[Map[String, String]]
   ): ToService[A] = instance(e => endpointToService(e.map(polyCase(_))))
 
   protected def endpointToService(e: Endpoint[Response])(implicit
@@ -89,6 +90,7 @@ object ToService extends LowPriorityToServiceInstances {
    */
   implicit def coproductRouterToService[C <: Coproduct](implicit
     folder: Folder.Aux[EncodeAll.type, C, Response],
-    tre: ToResponse[Exception]
+    tre: ToResponse[Exception],
+    trm: ToResponse[Map[String, String]]
   ): ToService[C] = instance(e => endpointToService(e.map(folder(_))))
 }


### PR DESCRIPTION
This PR allows users to continue using the 0.9.1-style API for failures:

```scala
val error = BadRequest("err" -> "error message")
```

Although, this API is deprecated in favour of `Failure(cause: Exception)`.