### PR TITLE
Fix weird 2.10 compile error

### DIFF
--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -10,55 +10,55 @@ package object internal {
   @inline private[this] final val someTrue: Option[Boolean] = Some(true)
   @inline private[this] final val someFalse: Option[Boolean] = Some(false)
 
+  // copy-pasted from
+  // https://github.com/sirthias/parboiled2/blob/master/parboiled-core/src/main/scala/org/parboiled2/CharUtils.scala
+  @inline private[this] def hexValue(c: Char): Int = (c & 0x1f) + ((c >> 6) * 0x19) - 0x10
+
+  // adopted from Java's Long.parseLong
+  // scalastyle:off return
+  private[this] def parseLong(s: String, min: Long, max: Long): Option[Long] = {
+    var negative = false
+    var limit = -max
+    var mulMin = limit / 10L
+    var result = 0L
+
+    var i = 0
+    if (s.length > 0) {
+      val firstChar = s.charAt(0)
+      if (firstChar < '0') {
+        if (firstChar == '-') {
+          negative = true
+          limit = min
+          mulMin = min / 10L
+        } else if (firstChar != '+') return None
+
+        if (s.length == 1) return None
+
+        i += 1
+      }
+
+      while (i < s.length) {
+        val c = s.charAt(i)
+        if ('0' <= c && c <= '9') {
+          if (result < mulMin) return None
+          result = result * 10L
+          val digit = hexValue(c)
+          if (result < limit + digit) return None
+          result = result - digit
+        } else return None
+
+        i += 1
+      }
+    } else return None
+
+    Some(if (negative) result else -result)
+  }
+  // scalastyle:on return
+
   /**
    * Enriches any string with fast `tooX` conversions.
    */
   implicit class TooFastString(val s: String) extends AnyVal {
-
-    // copy-pasted from
-    // https://github.com/sirthias/parboiled2/blob/master/parboiled-core/src/main/scala/org/parboiled2/CharUtils.scala
-    private[this] def hexValue(c: Char): Int = (c & 0x1f) + ((c >> 6) * 0x19) - 0x10
-
-    // adopted from Java's Long.parseLong
-    // scalastyle:off return
-    private[this] def parseLong(min: Long, max: Long): Option[Long] = {
-      var negative = false
-      var limit = -max
-      var mulMin = limit / 10L
-      var result = 0L
-
-      var i = 0
-      if (s.length > 0) {
-        val firstChar = s.charAt(0)
-        if (firstChar < '0') {
-          if (firstChar == '-') {
-            negative = true
-            limit = min
-            mulMin = min / 10L
-          } else if (firstChar != '+') return None
-
-          if (s.length == 1) return None
-
-          i += 1
-        }
-
-        while (i < s.length) {
-          val c = s.charAt(i)
-          if ('0' <= c && c <= '9') {
-            if (result < mulMin) return None
-            result = result * 10L
-            val digit = hexValue(c)
-            if (result < limit + digit) return None
-            result = result - digit
-          } else return None
-
-          i += 1
-        }
-      } else return None
-
-      Some(if (negative) result else -result)
-    }
-    // scalastyle:on return
 
     /**
      * Converts this string to the optional boolean value.
@@ -73,12 +73,12 @@ package object internal {
      * Converts this string to the optional integer value.
      */
     def tooInt: Option[Int] =
-      if (s.length > 11) None else parseLong(Int.MinValue, Int.MaxValue).map(_.toInt)
+      if (s.length > 11) None else parseLong(s, Int.MinValue, Int.MaxValue).map(_.toInt)
 
     /**
      * Converts this string to the optional integer value.
      */
     def tooLong: Option[Long] =
-      if (s.length > 20) None else parseLong(Long.MinValue, Long.MaxValue)
+      if (s.length > 20) None else parseLong(s, Long.MinValue, Long.MaxValue)
   }
 }


### PR DESCRIPTION
Somehow the new `TooFastString` breaks 2.10 compiler:

```
[error] uncaught exception during compilation: scala.reflect.internal.Types$TypeError
scala.reflect.internal.Types$TypeError: method hexValue$extension in object TooFastString cannot be accessed in object io.finch.internal.package.TooFastString

```