### PR TITLE
Simplify TooFastString

### DIFF
--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -10,16 +10,11 @@ package object internal {
   @inline private[this] final val someTrue: Option[Boolean] = Some(true)
   @inline private[this] final val someFalse: Option[Boolean] = Some(false)
 
-  // copy-pasted from
-  // https://github.com/sirthias/parboiled2/blob/master/parboiled-core/src/main/scala/org/parboiled2/CharUtils.scala
-  @inline private[this] def hexValue(c: Char): Int = (c & 0x1f) + ((c >> 6) * 0x19) - 0x10
-
   // adopted from Java's Long.parseLong
   // scalastyle:off return
   private[this] def parseLong(s: String, min: Long, max: Long): Option[Long] = {
     var negative = false
     var limit = -max
-    var mulMin = limit / 10L
     var result = 0L
 
     var i = 0
@@ -29,7 +24,6 @@ package object internal {
         if (firstChar == '-') {
           negative = true
           limit = min
-          mulMin = min / 10L
         } else if (firstChar != '+') return None
 
         if (s.length == 1) return None
@@ -37,12 +31,17 @@ package object internal {
         i += 1
       }
 
+      // skip zeros
+      while (i < s.length && s.charAt(i) == '0') i += 1
+
+      val mulMin = limit / 10L
+
       while (i < s.length) {
         val c = s.charAt(i)
         if ('0' <= c && c <= '9') {
           if (result < mulMin) return None
           result = result * 10L
-          val digit = hexValue(c)
+          val digit = c - '0'
           if (result < limit + digit) return None
           result = result - digit
         } else return None
@@ -70,15 +69,15 @@ package object internal {
     }
 
     /**
-     * Converts this string to the optional integer value.
+     * Converts this string to the optional integer value. The maximum allowed length for a number string is 32.
      */
     def tooInt: Option[Int] =
-      if (s.length > 11) None else parseLong(s, Int.MinValue, Int.MaxValue).map(_.toInt)
+      if (s.length == 0 || s.length > 32) None else parseLong(s, Int.MinValue, Int.MaxValue).map(_.toInt)
 
     /**
-     * Converts this string to the optional integer value.
+     * Converts this string to the optional integer value. The maximum allowed length for a number string is 32.
      */
     def tooLong: Option[Long] =
-      if (s.length > 20) None else parseLong(s, Long.MinValue, Long.MaxValue)
+      if (s.length == 0 || s.length > 32) None else parseLong(s, Long.MinValue, Long.MaxValue)
   }
 }


### PR DESCRIPTION
Just a couple of simplifications for `TooFastString` to make it work with `00000x` num strings (leading zeros).