### PR TITLE
Imporve performance of body readers

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
@@ -1,0 +1,32 @@
+package io.finch.benchmarks
+
+import com.twitter.finagle.http.Request
+import com.twitter.io.Buf
+import com.twitter.util.Await
+import io.finch._
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+@State(Scope.Benchmark)
+class BodyBenchmark extends FinchBenchmark {
+
+  val req: Request = {
+    val r = Request()
+    val content = Buf.Utf8("foo" * 1024)
+    r.content = content
+    r.contentLength = content.length
+
+    r
+  }
+
+  @Benchmark
+  def stringOption: Option[String] = Await.result(bodyOption(req))
+
+  @Benchmark
+  def string: String = Await.result(body(req))
+
+  @Benchmark
+  def byteArrayOption: Option[Array[Byte]] = Await.result(binaryBodyOption(req))
+
+  @Benchmark
+  def byteArray: Array[Byte] = Await.result(binaryBody(req))
+}


### PR DESCRIPTION
There is still a room for improvements, but this is a good step forward: 30% less allocations and 20% better performance (running time) for string-based readers.

```
Before:

[info] BodyBenchmark.byteArray                           avgt   20   614.957 ±   9.786   ns/op
[info] BodyBenchmark.byteArray:·gc.alloc.rate.norm       avgt   20  3408.000 ±   0.001    B/op
[info] BodyBenchmark.byteArrayOption                     avgt   20   516.548 ±  83.328   ns/op
[info] BodyBenchmark.byteArrayOption:·gc.alloc.rate.norm avgt   20  3232.000 ±   0.001    B/op
[info] BodyBenchmark.string                              avgt   20  2933.702 ± 136.387   ns/op
[info] BodyBenchmark.string:·gc.alloc.rate.norm          avgt   20  9836.002 ±  10.691    B/op
[info] BodyBenchmark.stringOption                        avgt   20  2601.393 ±  52.171   ns/op
[info] BodyBenchmark.stringOption:·gc.alloc.rate.norm    avgt   20  9620.001 ±  10.691    B/op

After:

[info] BodyBenchmark.byteArray                           avgt   20   622.243 ±  18.590   ns/op
[info] BodyBenchmark.byteArray:·gc.alloc.rate.norm       avgt   20  3392.000 ±   0.001    B/op
[info] BodyBenchmark.byteArrayOption                     avgt   20   429.114 ±  10.309   ns/op
[info] BodyBenchmark.byteArrayOption:·gc.alloc.rate.norm avgt   20  3200.000 ±   0.001    B/op
[info] BodyBenchmark.string                              avgt   20  2498.887 ± 176.078   ns/op
[info] BodyBenchmark.string:·gc.alloc.rate.norm          avgt   20  7064.001 ±   0.003    B/op
[info] BodyBenchmark.stringOption                        avgt   20  2271.496 ± 120.459   ns/op
[info] BodyBenchmark.stringOption:·gc.alloc.rate.norm    avgt   20  6888.001 ±   0.003    B/op
```