### PR TITLE
Fix #484: Catch exceptions thrown during multipart parsing

### DIFF
--- a/core/src/main/scala/io/finch/RequestReaders.scala
+++ b/core/src/main/scala/io/finch/RequestReaders.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.http.{Cookie, Request}
 import com.twitter.finagle.http.exp.Multipart.FileUpload
 import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.io.{Buf, Charsets}
-import com.twitter.util.Future
+import com.twitter.util.{Future, Try}
 
 trait RequestReaders {
 
@@ -43,7 +43,7 @@ trait RequestReaders {
     req.cookies.get(cookie)
 
   private[finch] def requestUpload(upload: String)(req: Request): Option[FileUpload] =
-    req.multipart.flatMap(m => m.files.get(upload).flatMap(fs => fs.headOption))
+    Try(req.multipart).getOrElse(None).flatMap(m => m.files.get(upload).flatMap(fs => fs.headOption))
 
   // A convenient method for internal needs.
   private[finch] def rr[A](i: RequestItem)(f: Request => A): RequestReader[A] =

--- a/core/src/test/scala/io/finch/MultipartParamSpec.scala
+++ b/core/src/test/scala/io/finch/MultipartParamSpec.scala
@@ -44,6 +44,12 @@ class MultipartParamSpec extends FlatSpec with Matchers {
     buf.length should be > 0
   }
 
+  it should "produce an error if the request body is not parsable as multipart" in {
+    val request = RequestBuilder().url("http://example.com").buildPost(Buf.Utf8("&"))
+    val futureResult = fileUpload("notmultipart")(request)
+    an [Error.NotPresent] shouldBe thrownBy(Await.result(futureResult))
+  }
+
   "An OptionalMultipartFile" should "have a filename if it exists" in {
     val request = requestFromBinaryFile("/upload.bytes")
     val futureResult: Future[Option[Multipart.FileUpload]] = fileUploadOption("groups")(request)
@@ -53,6 +59,12 @@ class MultipartParamSpec extends FlatSpec with Matchers {
   it should "be empty when the upload name exists but is not an upload" in {
     val request = RequestBuilder().url("http://localhost/").addFormElement("groups" -> "foo").buildFormPost()
     val futureResult: Future[Option[Multipart.FileUpload]] = fileUploadOption("groups")(request)
+    Await.result(futureResult) shouldBe None
+  }
+
+  it should "produce an error if the request body is not parsable as multipart" in {
+    val request = RequestBuilder().url("http://example.com").buildPost(Buf.Utf8("&"))
+    val futureResult = fileUploadOption("notmultipart")(request)
     Await.result(futureResult) shouldBe None
   }
 


### PR DESCRIPTION
This is a simple patch that will produce the desired behavior as described in #484. However, the updated code replaces the exception with a `None` value, losing all information about the cause of the error. This seemed reasonable given that Finch is currently using `None` to indicate missing request components; in the future using `Try`, `Either`, or similar may be more useful. Of course, if `com.twitter.finagle.http.Request.multipart` were updated to handle the exceptions directly, this change would no longer be needed.