### PR TITLE
Remove explicit exception handling from ToService

### DIFF
--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -62,10 +62,7 @@ trait LowPriorityToServiceInstances {
 
       def apply(req: Request): Future[Response] = safeEndpoint(Input(req)) match {
         case Some((remainder, output)) if remainder.isEmpty =>
-          output.map(f => f.map(o => o.toResponse(req.version))).value.handle {
-            // TODO: Remove after Finagle 6.31
-            case _ => Response(req.version, Status.InternalServerError)
-          }
+          output.map(f => f.map(o => o.toResponse(req.version))).value
         case _ => Future.value(Response(req.version, Status.NotFound))
       }
     }


### PR DESCRIPTION
Given that we're already on Finagle 6.31, we don't need that explicit conversion from unhandled exceptions to basic 500s responses.