### PR TITLE
Async request reader and response writer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,6 +193,11 @@ lazy val oauth2 = project
   ))
   .dependsOn(core)
 
+lazy val streaming = project
+  .settings(moduleName := "finch-streaming")
+  .settings(allSettings)
+  .dependsOn(core)
+
 lazy val examples = project
   .settings(moduleName := "finch-examples")
   .settings(allSettings)
@@ -205,7 +210,7 @@ lazy val examples = project
       "com.twitter" %% "twitter-server" % "1.16.0"
     )
   )
-  .dependsOn(core, circe)
+  .dependsOn(core, circe, streaming)
 
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")

--- a/examples/src/main/scala/io/finch/streaming/Client.scala
+++ b/examples/src/main/scala/io/finch/streaming/Client.scala
@@ -1,0 +1,19 @@
+package io.finch.streaming
+
+import com.twitter.finagle.Http
+import com.twitter.finagle.http.{Method, Request}
+import com.twitter.util.Await
+
+import scala.util.Random
+
+object Client extends App {
+
+  val client = Http.client.withStreaming(enabled = true).newService("127.0.0.1:8082")
+
+  val randomString = Random.alphanumeric.take(32).mkString
+  val request = Request(Method.Post, "/upload")
+
+  request.setContentString(randomString)
+
+  Await.result(client(request))
+}

--- a/examples/src/main/scala/io/finch/streaming/Server.scala
+++ b/examples/src/main/scala/io/finch/streaming/Server.scala
@@ -1,0 +1,62 @@
+package io.finch.streaming
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.Http
+import com.twitter.io.Buf
+import com.twitter.io.Buf.ByteArray
+import com.twitter.server.TwitterServer
+import com.twitter.util.{JavaTimer, Await, Future}
+import io.finch._
+import com.twitter.conversions.time._
+
+object Server extends TwitterServer {
+
+  implicit val timer = new JavaTimer
+
+  //read from request body with chunk size equal to 8 bytes
+  val requestReader: RequestReader[AsyncStream[Option[Buf]]] = body.async(8)
+
+  //for each connection create stream of defined size
+  def asyncStream(size: Int): AsyncStream[Option[Int]] = {
+    Some(scala.util.Random.nextInt(100)) +::
+      AsyncStream.fromFuture(Future.sleep(500.millis)).flatMap(_ => {
+        if (size > 0) asyncStream(size - 1) else AsyncStream.of(None)
+      })
+  }
+
+  val streaming: Endpoint[AsyncStream[Option[Buf]]] = get("stream" / int) { size: Int =>
+    Ok(asyncStream(size).map { int =>
+      int.map(Buf.Utf8 apply _.toString)
+    })
+  }
+
+  val upload: Endpoint[String] = post("upload" ? requestReader) { stream: AsyncStream[Option[Buf]]  =>
+    stream.foldLeft("") { (data, buf) =>
+      val chunk = buf.flatMap(Buf.Utf8.unapply)
+      log.info(s"Total data: $data")
+      log.info(s"Current buffer: $chunk")
+      data + chunk.getOrElse("")
+    } map { uploaded =>
+      log.info(s"Final data: $uploaded")
+      Ok(uploaded)
+    }
+  }
+
+  //just to prove that simple endpoints could exists with streaming one
+  val helloWorld: Endpoint[String] = get("hello") {
+    Ok("hello world")
+  }
+
+  val service = (streaming :+: helloWorld :+: upload).toService
+
+  def main(): Unit = {
+    log.info("Starting streaming service")
+
+    val server = Http.server.withStreaming(enabled = true).serve(":8082", service)
+    onExit {
+      server.close()
+    }
+    Await.ready(server)
+  }
+
+}

--- a/streaming/src/main/scala/io/finch/streaming/AsyncReaderOps.scala
+++ b/streaming/src/main/scala/io/finch/streaming/AsyncReaderOps.scala
@@ -1,0 +1,31 @@
+package io.finch.streaming
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.io.{Reader, Buf}
+import io.finch.RequestReader
+
+class AsyncReaderOps[A](val rr: RequestReader[A]) extends AnyVal {
+
+  /**
+    * Asynchronously read bytes from the request.
+    * `None` element represents the end of stream.
+    *
+    * @param chunkSize size of chunk to read
+    */
+  def async(chunkSize: Int): RequestReader[AsyncStream[Option[Buf]]] = {
+    RequestReader(request => read(chunkSize, request.reader))
+  }
+
+  /**
+    * Asynchronously read bytes from the request with default chunk size equals to `Int.MaxValue`
+    * `None` element represents the end of stream.
+    */
+  def async(): RequestReader[AsyncStream[Option[Buf]]] = async(Int.MaxValue)
+
+  private def read(chunkSize: Int, reader: Reader): AsyncStream[Option[Buf]] =
+    AsyncStream.fromFuture(reader.read(chunkSize)).flatMap {
+      case Some(buf) => Some(buf) +:: read(chunkSize, reader)
+      case None => AsyncStream.empty
+    }
+
+}

--- a/streaming/src/main/scala/io/finch/streaming/package.scala
+++ b/streaming/src/main/scala/io/finch/streaming/package.scala
@@ -1,0 +1,30 @@
+package io.finch
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.http.{Status, Response}
+import com.twitter.finagle.http.Version.Http11
+import com.twitter.io.{Reader, Buf}
+import io.finch.internal.ToResponse
+
+package object streaming {
+
+  implicit def asyncRequestReader[A](rr: RequestReader[A]): AsyncReaderOps[A] = new AsyncReaderOps[A](rr)
+
+  /**
+    * Provides implicit ToResponse for `AsyncStream[Option[Buf]]` since vanilla [[Endpoint]] is synchronous
+    * by it's nature
+    * If current element of stream is None sends EOF to client and closes connection otherwise sends data to client
+    *
+    * Http server should be initialized with `.withStreaming(enabled=true)`
+    */
+  implicit def asyncToResponse: ToResponse[AsyncStream[Option[Buf]]] = new ToResponse[AsyncStream[Option[Buf]]] {
+    override def apply(a: AsyncStream[Option[Buf]]): Response = {
+      val writable = Reader.writable()
+      a.foreachF {
+        case Some(buf) => writable.write(buf)
+        case None => writable.close()
+      }
+      Response(Http11, Status.Ok, writable)
+    }
+  }
+}


### PR DESCRIPTION
Proof of concept with async reader/response based on finagle AsyncStream.
I think it could be useful while dealing with data streaming and JSON encoding/decoding in future.

AFAIR @travisbrown was digging in this way for Jawn and Spool (#336)

It would be nice to discuss this feature.