### PR TITLE
finch-jackson: Clean up *Any* type-classes; Add docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,14 +198,15 @@ lazy val examples = project
   .settings(allSettings)
   .settings(noPublish)
   .settings(resolvers += "TM" at "http://maven.twttr.com")
-  .settings(coverageExcludedPackages := "io\\.finch\\.div\\..*;io\\.finch\\.todo\\..*")
+  .settings(coverageExcludedPackages := "io\\.finch\\.div\\..*;io\\.finch\\.todo\\..*;io\\.finch\\.eval\\..*")
   .settings(
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-generic" % circeVersion,
-      "com.twitter" %% "twitter-server" % "1.16.0"
+      "com.twitter" %% "twitter-server" % "1.16.0",
+      "com.twitter" %% "util-eval" % "6.30.0"
     )
   )
-  .dependsOn(core, circe)
+  .dependsOn(core, circe, jackson)
 
 lazy val benchmarks = project
   .settings(moduleName := "finch-benchmarks")

--- a/core/src/main/scala/io/finch/DecodeRequest.scala
+++ b/core/src/main/scala/io/finch/DecodeRequest.scala
@@ -77,19 +77,4 @@ object DecodeRequest extends LowPriorityDecodeRequestInstances {
     if (s.length != 36) Throw(new IllegalArgumentException(s"Too long for UUID: ${s.length}"))
     else Try(UUID.fromString(s))
   )
-
-  /**
-   * Creates a [[DecodeRequest]] instance from [[DecodeAnyRequest]].
-   */
-  implicit def decodeRequestFromAnyDecode[A](implicit
-    d: DecodeAnyRequest,
-    tag: ClassTag[A]
-  ): DecodeRequest[A] = instance(s => d(s)(tag))
-}
-
-/**
- * An abstraction that is responsible for decoding the request of general type.
- */
-trait DecodeAnyRequest {
-  def apply[A: ClassTag](req: String): Try[A]
 }

--- a/core/src/main/scala/io/finch/EncodeResponse.scala
+++ b/core/src/main/scala/io/finch/EncodeResponse.scala
@@ -35,15 +35,6 @@ trait LowPriorityEncodeResponseInstances {
 
 object EncodeResponse extends LowPriorityEncodeResponseInstances {
 
-  /**
-   * Converts [[EncodeAnyResponse]] into [[EncodeResponse]].
-   */
-  implicit def anyToConcreteEncode[A](implicit e: EncodeAnyResponse): EncodeResponse[A] =
-    new EncodeResponse[A] {
-      def apply(rep: A): Buf = e(rep)
-      def contentType: String = e.contentType
-    }
-
   implicit val encodeMap: EncodeResponse[Map[String, String]] =
     EncodeResponse("text/plain")(map =>
       Buf.Utf8(map.toSeq.map(kv => kv._1 + ":" + kv._2).mkString("\n"))
@@ -57,12 +48,4 @@ object EncodeResponse extends LowPriorityEncodeResponseInstances {
 
   implicit val encodeBuf: EncodeResponse[Buf] =
     apply("application/octet-stream", None)(identity)
-}
-
-/**
- * An abstraction that is responsible for encoding the response of a generic type.
- */
-trait EncodeAnyResponse {
-  def apply[A](rep: A): Buf
-  def contentType: String
 }

--- a/core/src/test/scala/io/finch/DecodeSpec.scala
+++ b/core/src/test/scala/io/finch/DecodeSpec.scala
@@ -74,27 +74,4 @@ class DecodeSpec extends FlatSpec with Matchers {
     val result = reader(request)
     Await.result(result).isEmpty shouldBe true
   }
-  
-  it should "resolve implicits correctly in case DecodeAnyRequest gets used" in {
-    
-    case class Foo(value: String)
-    case class Bar(value: String)
-    
-    implicit val decodeAny = new DecodeAnyRequest {
-      def apply[A: ClassTag](req: String): Try[A] = Return(new Bar(req).asInstanceOf[A])
-    }                                       
-    
-    implicit val decodeFoo = new DecodeRequest[Foo] {
-      def apply(req: String): Try[Foo] = Return(new Foo(req))
-    }   
-    
-    val request: Request = Request(("foo", "foo"), ("bar", "bar"))
-    val reader: RequestReader[(Foo, Bar)] = for {
-      foo <- param("foo").as[Foo]
-      bar <- param("bar").as[Bar]
-    } yield (foo, bar)
-    
-    val result = reader(request)
-    Await.result(result) shouldBe ((Foo("foo"), Bar("bar")))
-  }
 }

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -222,6 +222,10 @@ implicit val encodeException: Encoder[Exception] = Encoder.instance(e =>
 By default, all the exception are converted into `plain/text` HTTP response containing the exception message in their
 bodies.
 
+While this approach works perfectly well with JSON libraries empowering type-classes as decoders/encoders, it doesn't
+really fit well with libraries using runtime-reflection. Thus, when it comes to exception encoding, it involves some
+workaround to enable [Jackson](json.md#jackson) support in Finch. See [eval][eval] for an idiomatic example.
+
 ### Error Handling
 
 By analogy with `com.twitter.util.Future` API it's possible to _handle_ the failed future in the endpoint using the
@@ -250,3 +254,4 @@ Read Next: [RequestReaders](request.md)
 [shapeless]: https://github.com/milessabin/shapeless
 [hlist]: https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#heterogenous-lists
 [coproduct]: https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#coproducts-and-discriminated-unions
+[eval]: https://github.com/finagle/finch/tree/master/examples/src/main/scala/io/finch/eval

--- a/docs/json.md
+++ b/docs/json.md
@@ -36,6 +36,15 @@ import io.finch.circe.dropNullKeys._
 import io.circe.generic.auto._
 ```
 
+Unless it's absolutely necessary to customize Circe's output format (i.e., drop null keys), always prefer [Jackson
+serializer][circe-jackson] for better performance. The following two imports shows how to switch Circe to use Jackson
+while serializing instead of built-in pretty printer.
+
+```scala
+import io.finch.circe.jacksonSerializer._
+import io.circe.generic.auto._
+```
+
 ### Argonaut
 
 * Bring the dependency to the `finch-argonaut` module.
@@ -90,6 +99,7 @@ implicit val formats: Formats = DefaultFormats ++ JodaTimeSerializers.all
 [jackson]: http://wiki.fasterxml.com/JacksonHome
 [json4s]: http://json4s.org/
 [circe]: https://github.com/travisbrown/circe
+[circe-jackson]: https://github.com/travisbrown/circe/pull/111
 
 --
 Read Next: [Best Practices](best-practices.md)

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -1,0 +1,47 @@
+package io.finch.eval
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.twitter.finagle.Http
+import com.twitter.util.{Await, Eval}
+import io.finch._
+import io.finch.jackson._
+
+/**
+ * A simple Finch application evaluating the given Scala expression using
+ * [[https://github.com/twitter/util/blob/master/util-eval/src/main/scala/com/twitter/util/Eval.scala util-eval]].
+ *
+ * Use the following sbt command to run the application.
+ *
+ * {{{
+ *   $ sbt 'examples/runMain io.finch.eval.Main'
+ * }}}
+ *
+ * Use the following HTTPie commands to test endpoints.
+ *
+ * {{{
+ *   $ http POST :8081/eval expression=10+10
+ *   $ http POST :8081/eval expression=\"abc\".toList.headOption
+ * }}}
+ */
+object Main extends App {
+
+  implicit val objectMapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+
+  implicit val ee: EncodeResponse[Exception] = EncodeResponse.fromString("application/json") { e =>
+    objectMapper.writeValueAsString(Map("error" -> e.getMessage))
+  }
+
+  case class Input(expression: String)
+  case class Output(result: String)
+
+  val execute: Eval = new Eval()
+
+  val eval: Endpoint[Output] = post("eval" ? body.as[Input]) { i: Input =>
+    Ok(Output(execute[Any](i.expression).toString))
+  } handle {
+    case e: Exception => BadRequest(e)
+  }
+
+  Await.ready(Http.server.serve(":8081", eval.toService))
+}

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -3,23 +3,16 @@ package io.finch
 import scala.reflect.ClassTag
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.twitter.io.Buf
-import com.twitter.io.Buf.Utf8
 import com.twitter.util.Try
 
 package object jackson {
 
-  implicit def decodeJackson(implicit mapper: ObjectMapper): DecodeAnyRequest =
-    new DecodeAnyRequest {
-      def apply[A: ClassTag](s: String): Try[A] = Try {
-        val clazz = implicitly[ClassTag[A]].runtimeClass.asInstanceOf[Class[A]]
-        mapper.readValue[A](s, clazz)
-      }
-    }
+  implicit def decodeJackson[A](implicit
+    mapper: ObjectMapper, ct: ClassTag[A]
+  ): DecodeRequest[A] = DecodeRequest.instance(s =>
+    Try(mapper.readValue(s, implicitly[ClassTag[A]].runtimeClass.asInstanceOf[Class[A]]))
+  )
 
-  implicit def encodeJackson(implicit mapper: ObjectMapper): EncodeAnyResponse =
-    new EncodeAnyResponse {
-      def apply[A](rep: A): Buf = Utf8(mapper.writeValueAsString(rep))
-      def contentType: String = "application/json"
-    }
+  implicit def encodeJackson[A](implicit mapper: ObjectMapper): EncodeResponse[A] =
+    EncodeResponse.fromString("application/json")(a => mapper.writeValueAsString(a))
 }


### PR DESCRIPTION
Still no success in the reproducing the finch-jackson bug so I tried to build a new example (see `eval`) with finch-jakson (including idomatic error handling) to make sure we don't break it.