### PR TITLE
Introduce an empty output

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/service/FinchUserService.scala
@@ -1,5 +1,6 @@
 package io.finch.benchmarks.service
 
+import com.twitter.finagle.http
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.Service
 import io.finch._
@@ -23,7 +24,8 @@ class FinchUserService(implicit
   }
 
   val postUser: Endpoint[Unit] = post("users" ? body.as[NewUserInfo]) { u: NewUserInfo =>
-    db.add(u.name, u.age).map(id => Created(()).withHeader("Location" -> s"/users/$id"))
+      db.add(u.name, u.age)
+        .map(id => Output.unit(http.Status.Created).withHeader("Location" -> s"/users/$id"))
   }
 
   val deleteUser: Endpoint[String] = delete("users") {
@@ -31,7 +33,7 @@ class FinchUserService(implicit
   }
 
   val putUser: Endpoint[Unit] = put("users" ? body.as[User]) { u: User =>
-    db.update(u).map(NoContent)
+    db.update(u).map(_ => NoContent[Unit])
   }
 
   val backend: Service[Request, Response] = (

--- a/core/src/main/scala/io/finch/DecodeRequest.scala
+++ b/core/src/main/scala/io/finch/DecodeRequest.scala
@@ -1,7 +1,6 @@
 package io.finch
 
 import java.util.UUID
-import scala.reflect.ClassTag
 
 import com.twitter.util.{Return, Throw, Try}
 import shapeless.{::, Generic, HNil}

--- a/core/src/main/scala/io/finch/Outputs.scala
+++ b/core/src/main/scala/io/finch/Outputs.scala
@@ -4,47 +4,58 @@ import com.twitter.finagle.http.Status
 
 trait Outputs {
 
-  // See https://gist.github.com/vkostyukov/32c84c0c01789425c29a to understand how this list is assembled.
+  // See https://gist.github.com/vkostyukov/32c84c0c01789425c29a to understand how this list
+  // is assembled.
 
   // 2xx
-  def Ok[A](a: A): Output.Payload[A] = Output.Payload(a, Status.Ok)                                               // 200
-  def Created[A](a: A): Output.Payload[A] = Output.Payload(a, Status.Created)                                     // 201
-  def Accepted[A](a: A): Output.Payload[A] = Output.Payload(a, Status.Accepted)                                   // 202
-  def NoContent[A](a: A): Output.Payload[A] = Output.Payload(a, Status.NoContent)                                 // 204
-
-  // 3xx
-  def MovedPermanently(cause: Exception): Output.Failure = Output.Failure(cause, Status.MovedPermanently)          //301
-  def Found(cause: Exception): Output.Failure = Output.Failure(cause, Status.Found)                                //302
-  def SeeOther(cause: Exception): Output.Failure = Output.Failure(cause, Status.SeeOther)                          //303
-  def NotModified(cause: Exception): Output.Failure = Output.Failure(cause, Status.NotModified)                    //304
-  def TemporaryRedirect(cause: Exception): Output.Failure = Output.Failure(cause, Status.TemporaryRedirect)        //307
-  def PermanentRedirect(cause: Exception): Output.Failure = Output.Failure(cause, Status(308))                     //308
+  def Ok[A](a: A): Output[A] = Output.payload(a, Status.Ok)                                   // 200
+  def Created[A](a: A): Output[A] = Output.payload(a, Status.Created)                         // 201
+  def Accepted[A]: Output[A] = Output.empty(Status.Accepted)                                  // 202
+  def NoContent[A]: Output[A] = Output.empty(Status.NoContent)                                // 204
 
   // 4xx
-  def BadRequest(cause: Exception): Output.Failure = Output.Failure(cause, Status.BadRequest)                      //400
-  def Unauthorized(cause: Exception): Output.Failure = Output.Failure(cause, Status.Unauthorized)                  //401
-  def PaymentRequired(cause: Exception): Output.Failure = Output.Failure(cause, Status.PaymentRequired)            //402
-  def Forbidden(cause: Exception): Output.Failure = Output.Failure(cause, Status.Forbidden)                        //403
-  def NotFound(cause: Exception): Output.Failure = Output.Failure(cause, Status.NotFound)                          //404
-  def MethodNotAllowed(cause: Exception): Output.Failure = Output.Failure(cause, Status.MethodNotAllowed)          //405
-  def NotAcceptable(cause: Exception): Output.Failure = Output.Failure(cause, Status.NotAcceptable)                //406
-  def RequestTimeout(cause: Exception): Output.Failure = Output.Failure(cause, Status.RequestTimeout)              //408
-  def Conflict(cause: Exception): Output.Failure = Output.Failure(cause, Status.Conflict)                          //409
-  def Gone(cause: Exception): Output.Failure = Output.Failure(cause, Status.Gone)                                  //410
-  def LengthRequired(cause: Exception): Output.Failure = Output.Failure(cause, Status.LengthRequired)              //411
-  def PreconditionFailed(cause: Exception): Output.Failure = Output.Failure(cause, Status.PreconditionFailed)      //412
-  def RequestEntityTooLarge(cause: Exception): Output.Failure = Output.Failure(cause, Status.RequestEntityTooLarge)//413
-  def RequestedRangeNotSatisfiable(cause: Exception): Output.Failure = Output.Failure(
-      cause, Status.RequestedRangeNotSatisfiable)                                                                  //416
-  def EnhanceYourCalm(cause: Exception): Output.Failure = Output.Failure(cause, Status.EnhanceYourCalm)            //420
-  def UnprocessableEntity(cause: Exception): Output.Failure = Output.Failure(cause, Status.UnprocessableEntity)    //422
-  def TooManyRequests(cause: Exception): Output.Failure = Output.Failure(cause, Status.TooManyRequests)            //429
+  def BadRequest(cause: Exception): Output[Nothing] = Output.failure(cause, Status.BadRequest) //400
+  def Unauthorized(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.Unauthorized)                                                 //401
+  def PaymentRequired(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.PaymentRequired)                                              //402
+
+  def Forbidden(cause: Exception): Output[Nothing] = Output.failure(cause, Status.Forbidden)   //403
+  def NotFound(cause: Exception): Output[Nothing] = Output.failure(cause, Status.NotFound)     //404
+  def MethodNotAllowed(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.MethodNotAllowed)                                             //405
+  def NotAcceptable(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.NotAcceptable)                                                //406
+  def RequestTimeout(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.RequestTimeout)                                               //408
+  def Conflict(cause: Exception): Output[Nothing] = Output.failure(cause, Status.Conflict)     //409
+  def Gone(cause: Exception): Output[Nothing] = Output.failure(cause, Status.Gone)             //410
+  def LengthRequired(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.LengthRequired)                                               //411
+  def PreconditionFailed(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.PreconditionFailed)                                           //412
+  def RequestEntityTooLarge(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.RequestEntityTooLarge)                                        //413
+  def RequestedRangeNotSatisfiable(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.RequestedRangeNotSatisfiable)                                 //416
+  def EnhanceYourCalm(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.EnhanceYourCalm)                                              //420
+  def UnprocessableEntity(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.UnprocessableEntity)                                          //422
+  def TooManyRequests(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.TooManyRequests)                                              //429
 
   // 5xx
-  def InternalServerError(cause: Exception): Output.Failure = Output.Failure(cause, Status.InternalServerError)    //500
-  def NotImplemented(cause: Exception): Output.Failure = Output.Failure(cause, Status.NotImplemented)              //501
-  def BadGateway(cause: Exception): Output.Failure = Output.Failure(cause, Status.BadGateway)                      //502
-  def ServiceUnavailable(cause: Exception): Output.Failure = Output.Failure(cause, Status.ServiceUnavailable)      //503
-  def GatewayTimeout(cause: Exception): Output.Failure = Output.Failure(cause, Status.GatewayTimeout)              //504
-  def InsufficientStorage(cause: Exception): Output.Failure = Output.Failure(cause, Status.InsufficientStorage)    //507
+  def InternalServerError(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.InternalServerError)                                          //500
+  def NotImplemented(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.NotImplemented)                                               //501
+  def BadGateway(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.BadGateway)                                                   //502
+  def ServiceUnavailable(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.ServiceUnavailable)                                           //503
+  def GatewayTimeout(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.GatewayTimeout)                                               //504
+  def InsufficientStorage(cause: Exception): Output[Nothing] =
+    Output.failure(cause, Status.InsufficientStorage)                                          //507
 }

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -42,8 +42,8 @@ trait LowPriorityToServiceInstances {
     def apply(endpoint: Endpoint[A]): Service[Request, Response] = f(endpoint)
   }
 
-  private[finch] val basicEndpointHandler: PartialFunction[Throwable, Output.Failure] = {
-    case e: io.finch.Error => Output.Failure(e, Status.BadRequest)
+  private[finch] val basicEndpointHandler: PartialFunction[Throwable, Output[Nothing]] = {
+    case e: io.finch.Error => Output.failure(e, Status.BadRequest)
   }
 
   /**


### PR DESCRIPTION
This is fixes #503 and introduces the third case for `Output` that represents an empty response (no payload). I slightly reworked the implementation and the API according to the Circe's [11th design principle](https://github.com/travisbrown/circe/blob/master/DESIGN.md).

I will let this PR soak here for a couple of days to make sure I'm 100% happy with this solution. Also, I'm going to amend this with backward compatible API.

```scala
scala> Output.empty(Status.Ok)
res0: io.finch.Output[Nothing] = Empty(Meta(Status(200),Map(),List(),None,None))

scala> Output.unit(Status.Ok)
res1: io.finch.Output[Unit] = Empty(Meta(Status(200),Map(),List(),None,None))

scala> Output.payload(100)
res2: io.finch.Output[Int] = Payload(100,Meta(Status(200),Map(),List(),None,None))

scala> Output.failure(new Exception())
res3: io.finch.Output[Nothing] = Failure(java.lang.Exception,Meta(Status(400),Map(),List(),None,None))
```

Note the `Output.unit` method that produces `Output[Unit]` useful for endpoints that always return nothing (a unit response, i.e., `Endpoint[Unit]`). For example, a redirect endpoint:

```scala
val redirect: Endpoint[Unit] = get("from") {
  MovedPermanently.withHeader("Location" -> "to") // MovedPermanently: Output[Unit]
}
```