### PR TITLE
Add streaming request/response

### DIFF
--- a/core/src/main/scala/io/finch/RequestReaders.scala
+++ b/core/src/main/scala/io/finch/RequestReaders.scala
@@ -1,9 +1,10 @@
 package io.finch
 
+import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.http.{Cookie, Request}
 import com.twitter.finagle.http.exp.Multipart.FileUpload
 import com.twitter.finagle.netty3.ChannelBufferBuf
-import com.twitter.io.{Buf, Charsets}
+import com.twitter.io.{Buf, Charsets, Reader}
 import com.twitter.util.{Future, Try}
 
 trait RequestReaders {
@@ -133,6 +134,18 @@ trait RequestReaders {
    * [[Error.NotPresent]] exception.
    */
   val binaryBody: RequestReader[Array[Byte]] = binaryBodyOption.failIfNone
+
+  /**
+   * A [[RequestReader]] that reads a required chunked streaming binary body, interpreted as a `AsyncStream[Buf]`.
+   */
+  val asyncBody: RequestReader[AsyncStream[Buf]] = {
+    def read(chunkSize: Int, reader: Reader): AsyncStream[Buf] =
+      AsyncStream.fromFuture(reader.read(chunkSize)).flatMap {
+        case Some(buf) => buf +:: read(chunkSize, reader)
+        case None => AsyncStream.empty
+      }
+    RequestReader(request => read(Int.MaxValue, request.reader))
+  }
 
   /**
    * A [[RequestReader]] that reads an optional request body, interpreted as a `String`, into an `Option`.

--- a/core/src/test/scala/io/finch/OutputSpec.scala
+++ b/core/src/test/scala/io/finch/OutputSpec.scala
@@ -1,7 +1,7 @@
 package io.finch
 
 import com.twitter.io.Buf
-import com.twitter.finagle.http.Status
+import com.twitter.finagle.http.{Response, Status}
 
 class OutputSpec extends FinchSpec {
 
@@ -72,13 +72,13 @@ class OutputSpec extends FinchSpec {
 
   "Failure" should "propagate cause to response" in {
     check { of: Output.Failure =>
-      of.toResponse().content === EncodeResponse.encodeException(of.cause)
+      (of: Output[Unit]).toResponse().content === EncodeResponse.encodeException(of.cause)
     }
   }
 
   "Empty" should "propagate empytiness to response" in {
     check { of: Output.Empty =>
-      of.toResponse().content === Buf.Empty
+      (of: Output[Unit]).toResponse().content === Buf.Empty
     }
   }
 


### PR DESCRIPTION
As I asked in finagle's Gitter, S3 API needs to support up to 5GB in a single PUT but unfortunately the max chunk size is limited to 2GB by netty so we need streaming to support larger objects. Aside the PUT issue, streaming is required for GETting large objects (that could be uploaded by multipart upload where each transfer is small but could be huge as a result) from the server.

This work is based on @ImLiar 's PoC. https://github.com/finagle/finch/pull/498
Thanks @ImLiar 


