### PR TITLE
Add streaming example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,7 +198,8 @@ lazy val examples = project
   .settings(allSettings)
   .settings(noPublish)
   .settings(resolvers += "TM" at "http://maven.twttr.com")
-  .settings(coverageExcludedPackages := "io\\.finch\\.div\\..*;io\\.finch\\.todo\\..*;io\\.finch\\.eval\\..*")
+  .settings(coverageExcludedPackages :=
+    "io\\.finch\\.div\\..*;io\\.finch\\.todo\\..*;io\\.finch\\.eval\\..*;io\\.finch\\.streaming\\..*")
   .settings(
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-generic" % circeVersion,

--- a/core/src/main/scala/io/finch/internal/ToResponse.scala
+++ b/core/src/main/scala/io/finch/internal/ToResponse.scala
@@ -42,13 +42,12 @@ object ToResponse {
    * Provides implicit ToResponse for `AsyncStream[Buf]`.
    * If it reaches the end of the stream it closes the connection.
    *
-   * Http server should be initialized with `.withStreaming(enabled=true)`
+   * Http server should be initialized with `.withStreaming(enabled = true)`
    */
-  implicit def asyncToResponse: ToResponse[AsyncStream[Buf]] = new ToResponse[AsyncStream[Buf]] {
-    override def apply(a: AsyncStream[Buf]): Response = {
+  implicit val asyncToResponse: ToResponse[AsyncStream[Buf]] =
+    instance { a =>
       val writable = Reader.writable()
       a.foreachF(writable.write).ensure(writable.close())
       Response(Version.Http11, Status.Ok, writable)
     }
-  }
 }

--- a/examples/src/main/scala/io/finch/streaming/Main.scala
+++ b/examples/src/main/scala/io/finch/streaming/Main.scala
@@ -1,0 +1,69 @@
+package io.finch.streaming
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.Http
+import com.twitter.io.Buf
+import com.twitter.util.{Await, Try}
+import io.finch._
+
+/**
+ * A simple Finch application featuring very basic, `Buf`-based streaming support.
+ *
+ * There are three endpoints in this example:
+ *
+ *  1. `totalSum` - streaming request
+ *  2. `sumTo` - streaming response
+ *  3. `sumSoFar` - end-to-end (request - response) streaming
+ *
+ * Use the following sbt command to run the application.
+ *
+ * {{{
+ *   $ sbt 'examples/runMain io.finch.streaming.Main'
+ * }}}
+ */
+object Main extends App {
+
+  val sum: AtomicLong = new AtomicLong(0)
+
+  // we decode a long value from a Buf
+  private[this] def bufToLong(buf: Buf): Long =
+    Buf.Utf8.unapply(buf).flatMap(s => Try(s.toLong).toOption).getOrElse(0L)
+
+  // This endpoint takes a streaming request (a stream of numbers), sums them up, and
+  // returns a simple response with a total sum.
+  //
+  // For example, if input stream is `1, 2, 3` then output response would be `6`.
+  val totalSum: Endpoint[String] = post("totalSum" ? asyncBody) { as: AsyncStream[Buf] =>
+    as.foldLeft(0L)((acc, b) => acc + bufToLong(b)).map(s => Ok(s.toString))
+  }
+
+  // This endpoint takes a simple request with an integer number N and returns a
+  // stream of sums so far up to this number.
+  //
+  // For example, if an input value is `3` then output stream would be
+  // `1 (1), 3 (1 + 2), 5 (1 + 2 + 3)`.
+  val sumTo: Endpoint[AsyncStream[Buf]] = post("sumTo" / int) { to: Int =>
+    def loop(n: Int, s: Int): AsyncStream[Int] =
+      if (n > to) AsyncStream.empty[Int]
+      else (n + s) +:: loop(n + 1, n + s)
+
+    Ok(loop(1, 0).map(i => Buf.Utf8(i.toString)))
+  }
+
+  // This endpoint takes a streaming request (a stream of numbers) and responds
+  // to each number (chunk) a sum that has been collected so far.
+  //
+  // For example, if input stream is `1, 2, 3` then output stream would be `1, 3, 6`.
+  val sumSoFar: Endpoint[AsyncStream[Buf]] = post("sumSoFar" ? asyncBody) { as: AsyncStream[Buf] =>
+    Ok(as.map(b =>
+      Buf.Utf8(sum.addAndGet(bufToLong(b)).toString)
+    ))
+  }
+
+  Await.result(Http.server
+    .withStreaming(enabled = true)
+    .serve(":8081", (sumSoFar :+: sumTo :+: totalSum).toService)
+  )
+}


### PR DESCRIPTION
The initial version of streaming example for three types of endpoints:

1. Streaming request
2. Streaming response
3. End-to-end streaming
