### PR TITLE
Custom Decoder doc update

### DIFF
--- a/docs/request.md
+++ b/docs/request.md
@@ -410,7 +410,7 @@ for a Joda `DateTime` from a `Long` representing the number of milliseconds sinc
 
 ```scala
 implicit val dateTimeDecoder: DecodeRequest[DateTime] =
-  DecodeRequest(s => Try(new DateTime(s.toLong)))
+  DecodeRequest.instance(s => Try(new DateTime(s.toLong)))
 ```
 
 The example shows the most concise way of creating a new decoder: using the factory method on the companion object of


### PR DESCRIPTION
I ran into an issue trying to follow the doc for creating a custom decoder for use in a request reader, and updated the doc to show the appropriate function call.  The paragraph following my change may also need an update to be strictly correct, but for now I believe this is an improvement (the old example does not compile under finch-0.9.3 (scala 2.11.7)