### PR TITLE
finch-oauth2 should be lazy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ScoverageSbtPlugin._
 
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
-  version := "0.10.0",
+  version := "0.11.0-SNAPSHOT",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.6", "2.11.7")
 )

--- a/oauth2/src/main/scala/io/finch/oauth2/package.scala
+++ b/oauth2/src/main/scala/io/finch/oauth2/package.scala
@@ -22,7 +22,7 @@ package object oauth2 {
    */
   def authorize[U](dataHandler: DataHandler[U]): Endpoint[AuthInfo[U]] =
     Endpoint.embed(items.MultipleItems)(i =>
-      Some((i, Eval.now(OAuth2.authorize(i.request, dataHandler).map(Output.payload(_)))))
+      Some((i, Eval.later(OAuth2.authorize(i.request, dataHandler).map(Output.payload(_)))))
     ).handle(handleOAuthError)
 
   /**
@@ -31,6 +31,6 @@ package object oauth2 {
    */
   def issueAccessToken[U](dataHandler: DataHandler[U]): Endpoint[GrantHandlerResult] =
     Endpoint.embed(items.MultipleItems)(i =>
-      Some((i, Eval.now(OAuth2.issueAccessToken(i.request, dataHandler).map(Output.payload(_)))))
+      Some((i, Eval.later(OAuth2.issueAccessToken(i.request, dataHandler).map(Output.payload(_)))))
     ).handle(handleOAuthError)
 }


### PR DESCRIPTION
Noticed that oauth2 support should be lazy (evaluating endpoints).