### PR TITLE
Play Json Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Finch uses multi-project structure and contains of the following _modules_:
 * [`finch-jackson`](jackson) - the JSON API support for the [Jackson][jackson] library
 * [`finch-json4s`](json4s) - the JSON API support for the [JSON4S][json4s] library
 * [`finch-circe`](circe) - the JSON API support for the [Circe][circe] library
+* [`finch-playjson`](playjson) - The JSON API support for the [PlayJson][playjson] library
 * [`finch-test`](test) - the test support classes/functions
 * [`finch-oauth2`](oauth2) - the OAuth2 support backed by the [finagle-oauth2][finagle-oauth2] library
 
@@ -143,6 +144,7 @@ limitations under the License.
 [argonaut]: http://argonaut.io
 [finagle-oauth2]: https://github.com/finagle/finagle-oauth2
 [json4s]: http://json4s.org
+[playjson]: https://www.playframework.com/documentation/2.4.x/ScalaJson
 [scaladoc]: http://finagle.github.io/finch/docs/#io.finch.package
 [typelevel]: http://typelevel.org/
 [conduct]: http://typelevel.org/conduct.html

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,7 @@ lazy val finch = project.in(file("."))
         |import io.circe._
       """.stripMargin
   )
-  .aggregate(core, argonaut, jackson, json4s, circe, benchmarks, test, jsonTest, oauth2, examples)
+  .aggregate(core, argonaut, jackson, json4s, circe, playjson, benchmarks, test, jsonTest, oauth2, examples)
   .dependsOn(core, circe)
 
 lazy val core = project
@@ -186,6 +186,12 @@ lazy val circe = project
       "io.circe" %% "circe-jackson" % circeVersion
     )
   )
+  .dependsOn(core, jsonTest % "test")
+
+lazy val playjson = project
+  .settings(moduleName :="finch-playJson")
+  .settings(allSettings)
+  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.6")
   .dependsOn(core, jsonTest % "test")
 
 lazy val oauth2 = project

--- a/playjson/src/main/io/finch/playjson/package.scala
+++ b/playjson/src/main/io/finch/playjson/package.scala
@@ -15,5 +15,5 @@ package object playjson {
  * @tparam A the type of the data to encode from
  */
   implicit def encodeJson[A](implicit writes: Writes[A]): EncodeResponse[A] =
-    EncodeResponse.fromString[A]("application/json") {a =>Json.stringify(Json.toJson(a))}
+    EncodeResponse.fromString[A]("application/json")(a =>Json.stringify(Json.toJson(a)))
 }

--- a/playjson/src/main/io/finch/playjson/package.scala
+++ b/playjson/src/main/io/finch/playjson/package.scala
@@ -1,0 +1,19 @@
+package io.finch
+
+import com.twitter.util.Try
+import play.api.libs.json._
+
+package object playjson {
+/**
+ * @param reads Play JSON `Reads` to use for decoding
+ * @tparam A the type of the data to decode into
+ */
+  implicit def decodeJson[A](implicit reads: Reads[A]): DecodeRequest[A] =
+    DecodeRequest.instance(input => Try(Json.parse(input).as[A]))
+/**
+ * @param writes Play JSON `Writes` to use for encoding
+ * @tparam A the type of the data to encode from
+ */
+  implicit def encodeJson[A](implicit writes: Writes[A]): EncodeResponse[A] =
+    EncodeResponse.fromString[A]("application/json") {a =>Json.stringify(Json.toJson(a))}
+}

--- a/playjson/src/test/scala/io/finch/playjson/Bar.scala
+++ b/playjson/src/test/scala/io/finch/playjson/Bar.scala
@@ -1,9 +1,0 @@
-package io.finch.playjson
-
-import play.api.libs.json._
-case class Bar(x: Int, y: Boolean)
-
-object Bar {
-  implicit val barWrites: Writes[Bar] = Json.writes[Bar]
-  implicit val barReads: Reads[Bar] = Json.reads[Bar]
-}

--- a/playjson/src/test/scala/io/finch/playjson/Bar.scala
+++ b/playjson/src/test/scala/io/finch/playjson/Bar.scala
@@ -4,6 +4,6 @@ import play.api.libs.json._
 case class Bar(x: Int, y: Boolean)
 
 object Bar {
-  implicit val barWrites = Json.writes[Bar]
-  implicit val barReads = Json.reads[Bar]
+  implicit val barWrites: Writes[Bar] = Json.writes[Bar]
+  implicit val barReads: Reads[Bar] = Json.reads[Bar]
 }

--- a/playjson/src/test/scala/io/finch/playjson/Bar.scala
+++ b/playjson/src/test/scala/io/finch/playjson/Bar.scala
@@ -1,3 +1,9 @@
 package io.finch.playjson
 
+import play.api.libs.json._
 case class Bar(x: Int, y: Boolean)
+
+object Bar {
+  implicit val barWrites = Json.writes[Bar]
+  implicit val barReads = Json.reads[Bar]
+}

--- a/playjson/src/test/scala/io/finch/playjson/Bar.scala
+++ b/playjson/src/test/scala/io/finch/playjson/Bar.scala
@@ -1,0 +1,3 @@
+package io.finch.playjson
+
+case class Bar(x: Int, y: Boolean)

--- a/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
+++ b/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
@@ -1,12 +1,19 @@
 package io.finch.playjson
 
 import io.finch.test.json.JsonCodecProviderProperties
+import io.finch.test.json.ExampleCaseClass
+import io.finch.test.json.ExampleNestedCaseClass
 import org.scalatest.prop.Checkers
 import org.scalatest.{FlatSpec, Matchers}
+import play.api.libs.json._
 
 class PlayJsonSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
+    implicit val exampleReads:Reads[ExampleCaseClass] = Json.reads[ExampleCaseClass]
+    implicit val exampleWrites:Writes[ExampleCaseClass] = Json.writes[ExampleCaseClass]
 
-  implicit val formats = play.api.libs.json.Format
+    implicit val exampleNestedReads:Reads[ExampleNestedCaseClass] = Json.reads[ExampleNestedCaseClass]
+    implicit val exampleNestedWrites:Writes[ExampleNestedCaseClass] = Json.writes[ExampleNestedCaseClass]
+    
   "The PlayJson codec provider" should "encode a case class as JSON" in encodeNestedCaseClass
   it should "decode a case class from JSON" in decodeNestedCaseClass
   it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson

--- a/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
+++ b/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
@@ -1,0 +1,16 @@
+package io.finch.playjson
+
+import io.finch.test.json.JsonCodecProviderProperties
+import org.scalatest.prop.Checkers
+import org.scalatest.{FlatSpec, Matchers}
+
+class PlayJsonSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
+
+  implicit val formats = play.api.libs.json.Format
+  "The PlayJson codec provider" should "encode a case class as JSON" in encodeNestedCaseClass
+  it should "decode a case class from JSON" in decodeNestedCaseClass
+  it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson
+  it should "encode a list of case class instances as JSON" in encodeCaseClassList
+  it should "decode a list of case class instances from JSON" in decodeCaseClassList
+  it should "provide encoders with the correct content type" in checkContentType
+}


### PR DESCRIPTION
This is my initial attempt to get Play JSON support into Finch. Currently all the tests in ```PlayJsonSpec``` fail  with similar errors (Cannot find implicit values for decoder/encoders for the case classes defined in ```JsonCodecProviderProperties```).  The purpose of opening this PR is to get some feedback on what might be missing/why these tests fail. I understand the error message but I can't figure out comparing to other JSON libs whats different and how they are properly allowing Finch to create appropriate implicits. 