### PR TITLE
Hide prioritization trails and arrange scaladoc comments into groups.

### DIFF
--- a/core/src/main/scala/io/finch/DecodeRequest.scala
+++ b/core/src/main/scala/io/finch/DecodeRequest.scala
@@ -7,12 +7,14 @@ import shapeless.{::, Generic, HNil}
 
 /**
  * An abstraction that is responsible for decoding the request of type `A`.
+ * @groupname LowPriorityDecodeRequest Low priority `DecodeRequest` instances
+ * @groupprio LowPriorityDecodeRequest 0
  */
 trait DecodeRequest[A] {
   def apply(s: String): Try[A]
 }
 
-trait LowPriorityDecodeRequestInstances {
+private[finch] trait LowPriorityDecodeRequestInstances {
 
   /**
    * Creates an instance for a given type.
@@ -37,41 +39,49 @@ object DecodeRequest extends LowPriorityDecodeRequestInstances {
 
   /**
    * Returns an instance for a given type.
+   * @group LowPriorityDecodeRequest
    */
   @inline def apply[A](implicit dr: DecodeRequest[A]): DecodeRequest[A] = dr
 
   /**
    * A [[DecodeRequest]] instance for `String`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeString: DecodeRequest[String] = instance(s => Return(s))
 
   /**
    * A [[DecodeRequest]] instance for `Int`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeInt: DecodeRequest[Int] = instance(s => Try(s.toInt))
 
   /**
    * A [[DecodeRequest]] instance for `Long`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeLong: DecodeRequest[Long] = instance(s => Try(s.toLong))
 
   /**
    * A [[DecodeRequest]] instance for `Float`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeFloat: DecodeRequest[Float] = instance(s => Try(s.toFloat))
 
   /**
    * A [[DecodeRequest]] instance for `Double`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeDouble: DecodeRequest[Double] = instance(s => Try(s.toDouble))
 
   /**
    * A [[DecodeRequest]] instance for `Boolean`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeBoolean: DecodeRequest[Boolean] = instance(s => Try(s.toBoolean))
 
   /**
    * A [[DecodeRequest]] instance for `UUID`.
+   * @group LowPriorityDecodeRequest
    */
   implicit val decodeUUID: DecodeRequest[UUID] = instance(s =>
     if (s.length != 36) Throw(new IllegalArgumentException(s"Too long for UUID: ${s.length}"))

--- a/core/src/main/scala/io/finch/EncodeResponse.scala
+++ b/core/src/main/scala/io/finch/EncodeResponse.scala
@@ -4,6 +4,8 @@ import com.twitter.io.Buf
 
 /**
  * An abstraction that is responsible for encoding the response of type `A`.
+ * @groupname LowPriorityEncodeResponse Low priority `EncodeResponse` inatances
+ * @groupprio LowPriorityEncodeResponse 0
  */
 trait EncodeResponse[-A] {
   def apply(rep: A): Buf
@@ -11,10 +13,11 @@ trait EncodeResponse[-A] {
   def charset: Option[String] = Some("utf-8")
 }
 
-trait LowPriorityEncodeResponseInstances {
+private[finch] trait LowPriorityEncodeResponseInstances {
 
   /**
    * Convenience method for creating new [[EncodeResponse]] instances.
+   * @group LowPriorityEncodeResponse
    */
   def apply[A](ct: String, cs: Option[String] = Some("utf-8"))(fn: A => Buf): EncodeResponse[A] =
     new EncodeResponse[A] {
@@ -25,12 +28,16 @@ trait LowPriorityEncodeResponseInstances {
 
   /**
    * Convenience method for creating new [[EncodeResponse]] instances that treat String contents.
+   * @group LowPriorityEncodeResponse
    */
   def fromString[A](
     ct: String,
     cs: Option[String] = Some("utf-8")
   )(fn: A => String): EncodeResponse[A] = apply(ct, cs)(fn.andThen(Buf.Utf8.apply))
 
+  /**
+   * @group LowPriorityEncodeResponse
+   */
   implicit val encodeException: EncodeResponse[Exception] =
     fromString("text/plain")(e => Option(e.getMessage).getOrElse(""))
 }

--- a/core/src/main/scala/io/finch/internal/Mapper.scala
+++ b/core/src/main/scala/io/finch/internal/Mapper.scala
@@ -7,6 +7,10 @@ import shapeless.ops.function.FnToProduct
 
 /**
  * A type class that allows the [[Endpoint]] to be mapped to either `A => B` or `A => Future[B]`.
+ * @groupname LowPriorityMapper Low Priority Mapper Conversions
+ * @groupprio LowPriorityMapper 0
+ * @groupname HighPriorityMapper High priority mapper conversions
+ * @groupprio HighPriorityMapper 1
  */
 trait Mapper[A] {
   type Out
@@ -14,7 +18,7 @@ trait Mapper[A] {
   def apply(e: Endpoint[A]): Endpoint[Out]
 }
 
-trait LowPriorityMapperConversions {
+private[finch] trait LowPriorityMapperConversions {
   type Aux[A, B] = Mapper[A] { type Out = B }
 
   def instance[A, B](f: Endpoint[A] => Endpoint[B]): Mapper.Aux[A, B] = new Mapper[A] {
@@ -22,28 +26,50 @@ trait LowPriorityMapperConversions {
     def apply(e: Endpoint[A]): Endpoint[B] = f(e)
   }
 
+  /**
+    * @group LowPriorityMapper
+    */
   implicit def mapperFromOutputFunction[A, B](f: A => Output[B]): Mapper.Aux[A, B] =
     instance(_.mapOutput(f))
 
+  /**
+    * @group LowPriorityMapper
+    */
   implicit def mapperFromOutputFutureFunction[A, B](f: A => Output[Future[B]]): Mapper.Aux[A, B] =
     instance(_.mapOutputAsync(f.andThen(ofb => ofb.traverse(identity))))
 
+  /**
+    * @group LowPriorityMapper
+    */
   implicit def mapperFromFutureOutputFunction[A, B](f: A => Future[Output[B]]): Mapper.Aux[A, B] =
     instance(_.mapOutputAsync(f))
 }
 
-trait HighPriorityMapperConversions extends LowPriorityMapperConversions {
+private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConversions {
+
+  /**
+    * @group HighPriorityMapper
+    */
   implicit def mapperFromOutputHFunction[A, B, F, OB](f: F)(implicit
     ftp: FnToProduct.Aux[F, A => OB],
     ev: OB <:< Output[B]
   ): Mapper.Aux[A, B] = instance(_.mapOutput(value => ev(ftp(f)(value))))
 
+  /**
+   * @group HighPriorityMapper
+   */
   implicit def mapperFromOutputValue[A](o: => Output[A]): Mapper.Aux[HNil, A] =
     instance(_.mapOutput(_ => o))
 
+  /**
+    * @group HighPriorityMapper
+    */
   implicit def mapperFromOutputFutureValue[A](o: => Output[Future[A]]): Mapper.Aux[HNil, A] =
     instance(_.mapOutputAsync(_ => o.traverse(identity)))
 
+  /**
+    * @group HighPriorityMapper
+    */
   implicit def mapperFromFutureOutputValue[A](o: => Future[Output[A]]): Mapper.Aux[HNil, A] =
     instance(_.mapOutputAsync(_ => o))
 }

--- a/core/src/main/scala/io/finch/internal/PairJoin.scala
+++ b/core/src/main/scala/io/finch/internal/PairJoin.scala
@@ -6,12 +6,17 @@ import shapeless.ops.adjoin.Adjoin
 /**
  * We need a version of [[shapeless.ops.adjoin.Adjoin]] that provides slightly different behavior in
  * the case of singleton results (we simply return the value, not a singleton `HList`).
+ * @groupname LowPriorityPair Low priority `PairAdjoin`
+ * @groupprio LowPriorityPair 0
  */
 trait PairAdjoin[A, B] extends DepFn2[A, B]
 
-trait LowPriorityPairAdjoin {
+private[finch] trait LowPriorityPairAdjoin {
   type Aux[A, B, Out0] = PairAdjoin[A, B] { type Out = Out0 }
 
+  /**
+   * @group LowPriorityPair
+   */
   implicit def pairAdjoin[A, B, Out0](implicit
     adjoin: Adjoin.Aux[A :: B :: HNil, Out0]
   ): Aux[A, B, Out0] =

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -12,6 +12,9 @@ import shapeless.ops.coproduct.Folder
 /**
  * Represents a conversion from an [[Endpoint]] returning a result type `A` to a Finagle service
  * from a request-like type `R` to a [[Response]].
+ *
+ * @groupname LowPriorityToService Low priority `ToService`
+ * @groupprio LowPriorityToService 0
  */
 @implicitNotFound(
 """You can only convert a router into a Finagle service if the result type of the router is one of
@@ -29,15 +32,17 @@ trait ToService[A] {
   def apply(endpoint: Endpoint[A]): Service[Request, Response]
 }
 
-trait LowPriorityToServiceInstances {
+private[finch] trait LowPriorityToServiceInstances {
 
   /**
    * Returns an instance for a given type.
+   * @group LowPriorityToService
    */
   def apply[A](implicit ts: ToService[A]): ToService[A] = ts
 
   /**
    * Constructs an instance for a given type.
+   * @group LowPriorityToService
    */
   def instance[A](f: Endpoint[A] => Service[Request, Response]): ToService[A] = new ToService[A] {
     def apply(endpoint: Endpoint[A]): Service[Request, Response] = f(endpoint)
@@ -49,6 +54,7 @@ trait LowPriorityToServiceInstances {
 
   /**
    * An instance for types that can be transformed into a Finagle service.
+   * @group LowPriorityToService
    */
   implicit def valueRouterToService[A](implicit
     polyCase: EncodeAll.Case.Aux[A, Response],
@@ -75,6 +81,7 @@ trait LowPriorityToServiceInstances {
   protected object EncodeAll extends Poly1 {
     /**
      * Transforms an encodeable value into a constant service.
+     * @group LowPriorityToService
      */
     implicit def toResponseToResponse[A](implicit tr: ToResponse[A]): Case.Aux[A, Response] =
       at(a => tr(a))


### PR DESCRIPTION
Opening this instead of #537.