### PR TITLE
Update Scala 2.11 and other dependencies and plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test benchmarks/it:test scalastyle
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test benchmarks/it:test coverageReport scalastyle
   - sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import ScoverageSbtPlugin._
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   version := "0.11.0-SNAPSHOT",
-  scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", "2.11.7")
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.10.6", "2.11.8")
 )
 
 lazy val finagleVersion = "6.33.0"
@@ -41,7 +41,7 @@ val baseSettings = Seq(
     "org.typelevel" %% "cats-core" % catsVersion,
     "com.twitter" %% "finagle-http" % finagleVersion,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ) ++ testDependencies.map(_ % "test"),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
@@ -159,8 +159,8 @@ lazy val argonaut = project
   .settings(allSettings)
   .settings(libraryDependencies ++= Seq(
     "io.argonaut" %% "argonaut" % "6.1",
-    "org.spire-math" %% "jawn-parser" % "0.8.3",
-    "org.spire-math" %% "jawn-argonaut" % "0.8.3"
+    "org.spire-math" %% "jawn-parser" % "0.8.4",
+    "org.spire-math" %% "jawn-argonaut" % "0.8.4"
   ))
   .dependsOn(core, jsonTest % "test")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,10 +6,10 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.5")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")


### PR DESCRIPTION
This doesn't include the Finagle update, since I didn't know whether we wanted to publish a new finagle-oauth2 first, but it updates everything else.