### PR TITLE
Use Cats StateT to reprensent an Endpoint

### DIFF
--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -16,7 +16,7 @@ object Error {
   }
 
   /**
-   * An exception that collects multiple request reader errors.
+   * An exception that collects multiple endpoint errors.
    *
    * @param errors the errors collected from various request readers
    */

--- a/core/src/main/scala/io/finch/internal/ToResponse.scala
+++ b/core/src/main/scala/io/finch/internal/ToResponse.scala
@@ -1,7 +1,7 @@
 package io.finch.internal
 
 import com.twitter.concurrent.AsyncStream
-import com.twitter.finagle.http.Response
+import com.twitter.finagle.http.{Response, Status, Version}
 import com.twitter.io.Buf
 import io.finch.Encode
 import shapeless._
@@ -57,7 +57,7 @@ object ToResponse extends LowPriorityToResponseInstances {
   }
 
   implicit def cnilToResponse[CT <: String]: Aux[CNil, CT] =
-    instance(_ => sys.error("impossible"))
+    instance(_ => Response(Version.Http11, Status.NotFound))
 
   implicit def coproductToResponse[H, T <: Coproduct, CT <: String](implicit
     trH: ToResponse.Aux[H, CT],

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -179,7 +179,7 @@ class EndpointSpec extends FinchSpec {
 
     check { (s: String, i: Int) => (s: Endpoint0).map(_ => i).toString === s }
     check { (s: String, t: String) => ((s: Endpoint0) | (t: Endpoint0)).toString === s"($s|$t)" }
-    check { (s: String, t: String) => ((s: Endpoint0) :: (t: Endpoint0)).toString === s"$s/$t" }
+    check { (s: String, t: String) => ((s: Endpoint0) :: (t: Endpoint0)).toString === s"$s :: $t" }
     check { s: String => (s: Endpoint0).product[String](*.map(_ => "foo")).toString === s }
     check { (s: String, t: String) => (s: Endpoint0).mapAsync(_ => Future.value(t)).toString === s }
 
@@ -197,7 +197,7 @@ class EndpointSpec extends FinchSpec {
     uuids.toString shouldBe ":uuid*"
     booleans.toString shouldBe ":boolean*"
 
-    (int :: string).toString shouldBe ":int/:string"
+    (int :: string).toString shouldBe ":int :: :string"
     (boolean :+: long).toString shouldBe "(:boolean|:long)"
   }
 


### PR DESCRIPTION
I was experimenting with representing an `Endpoint[A]` as `StateT[Input, Option, Eval[Future[Output[A]]]]` . This approach seems pretty reasonable to me given how it simplifies a couple of things and make it a great use of Cats abstractions.

I'm not 100% sure, I'm happy with the current implementation. But I think it might be a reasonable step forward - I was focusing on a minimized diff rather than a super clean implementation. Maybe as a next step we could think about cleaning up `item` and `toString` methods on `Endpoint` so the entire story will be much simpler.
