### PR TITLE
sprayjson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val finagleVersion = "6.33.0"
 lazy val circeVersion = "0.3.0"
 lazy val shapelessVersion = "2.3.0"
 lazy val catsVersion = "0.4.1"
+lazy val sprayVersion = "1.3.2"
 
 lazy val compilerOptions = Seq(
   "-deprecation",
@@ -128,9 +129,10 @@ lazy val finch = project.in(file("."))
       """.stripMargin
   )
   .settings(libraryDependencies ++= Seq(
-    "io.circe" %% "circe-generic" % circeVersion
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.spray" %%  "spray-json" % sprayVersion
   ))
-  .aggregate(core, argonaut, jackson, json4s, circe, playjson, benchmarks, test, jsonTest, oauth2, examples)
+  .aggregate(core, argonaut, jackson, json4s, circe, playjson, sprayjson, benchmarks, test, jsonTest, oauth2, examples)
   .dependsOn(core, circe)
 
 lazy val core = project
@@ -196,6 +198,12 @@ lazy val playjson = project
   .settings(moduleName :="finch-playjson")
   .settings(allSettings)
   .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.9")
+  .dependsOn(core, jsonTest % "test")
+
+lazy val sprayjson = project
+  .settings(moduleName := "finch-sprayjson")
+  .settings(allSettings)
+  .settings(libraryDependencies += "io.spray" %%  "spray-json" % sprayVersion)
   .dependsOn(core, jsonTest % "test")
 
 lazy val oauth2 = project

--- a/docs/json.md
+++ b/docs/json.md
@@ -116,12 +116,32 @@ object Foo {
 }
 ```
 
+### Spray-Json
+
+* Bring the dependency to the `finch-sprayjson` module.
+* Create an implicit format convertor value for any type you denfined.
+
+```scala
+import io.finch.sprayjson._
+import spray.json._
+import Defaultjsonprotocol._
+
+case class Foo(name: String, age: Int)
+
+object Foo {
+  //Note: `2` means Foo has two members;
+  //       No need for apply if there is no companion object
+  implicit val fooformat = jsonFormat2(Foo.apply)
+}
+``
+
 [argonaut]: http://argonaut.io
 [jackson]: http://wiki.fasterxml.com/JacksonHome
 [json4s]: http://json4s.org/
 [circe]: https://github.com/travisbrown/circe
 [circe-jackson]: https://github.com/travisbrown/circe/pull/111
 [playjson]: https://www.playframework.com/documentation/2.4.x/ScalaJson
+[spray-json]: https://github.com/spray/spray-json
 
 --
 Read Next: [Cookbook](cookbook.md)

--- a/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
+++ b/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
@@ -7,6 +7,7 @@ import com.twitter.util.Return
 import io.finch.{Decode, Encode}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
 import org.scalacheck.Prop.BooleanOperators
 import org.scalatest.prop.Checkers
 import org.scalatest.Matchers
@@ -23,7 +24,7 @@ case class ExampleNestedCaseClass(
 object ExampleCaseClass {
   implicit val exampleCaseClassArbitrary: Arbitrary[ExampleCaseClass] = Arbitrary(
     for {
-      a <- arbitrary[String]
+      a <- Gen.alphaStr
       b <- arbitrary[Int]
       c <- arbitrary[Boolean]
     } yield ExampleCaseClass(a, b, c)
@@ -33,7 +34,7 @@ object ExampleCaseClass {
 object ExampleNestedCaseClass {
   implicit val exampleNestedCaseClassArbitrary: Arbitrary[ExampleNestedCaseClass] = Arbitrary(
     for {
-      s <- arbitrary[String]
+      s <- Gen.alphaStr
       d <- arbitrary[Double]
       l <- arbitrary[Long]
       i <- arbitrary[List[Int]]

--- a/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
+++ b/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
@@ -1,0 +1,23 @@
+package io.finch
+
+import com.twitter.io.Buf
+import com.twitter.util.Try
+import spray.json._
+
+package object sprayjson{
+
+  /**
+    * @param format spray-json support for convert JSON val to specific type object
+    * @tparam A the type of the data to decode into
+    */
+  implicit def decodeSpray[A](implicit format: JsonFormat[A]): Decode[A] = Decode.instance[A](
+    s =>Try(s.parseJson.convertTo[A])
+  )
+
+  /**
+    * @param format spray-json support for convert JSON val to specific type object
+    * @tparam A the type of the data to decode from
+    */
+  implicit def encodeSpray[A](implicit format: JsonFormat[A]): Encode.ApplicationJson[A] =
+    Encode.applicationJson(a => Buf.Utf8(a.toJson.prettyPrint))
+}

--- a/sprayjson/src/test/scala/io/finch/sprayjson/sprayjsonSpec.scala
+++ b/sprayjson/src/test/scala/io/finch/sprayjson/sprayjsonSpec.scala
@@ -1,0 +1,20 @@
+package io.finch.sprayjson
+
+import io.finch.test.json._
+import org.scalatest.prop.Checkers
+import org.scalatest.{FlatSpec, Matchers}
+import spray.json._
+import DefaultJsonProtocol._
+
+class sprayjsonSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
+  implicit val exampleFormat = jsonFormat3(ExampleCaseClass.apply)
+
+  implicit val nestedExampleFormat = jsonFormat5(ExampleNestedCaseClass.apply)
+
+  "The sprayjson codec provider" should "encode a case class as JSON" in encodeNestedCaseClass
+  it should "decode a case class from JSON" in decodeNestedCaseClass
+  it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson
+  it should "encode a list of case class instances as JSON" in encodeCaseClassList
+  it should "decode a list of case class instances from JSON" in decodeCaseClassList
+  it should "provide encoders with the correct content type" in checkContentType
+}


### PR DESCRIPTION
Add support for spray-json. Since the constraints of spray-json, I changed the ExampleCaseClass generating way.