### PR TITLE
#562 Decode Refactoring

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
@@ -13,11 +13,13 @@ trait Decoders {
   /**
    * Maps Argonaut's [[DecodeJson]] to Finch's [[Decode]].
    */
-  implicit def decodeArgonaut[A](implicit d: DecodeJson[A]): Decode[A] = Decode.instance[A] { s =>
-    val err: (String, CursorHistory) => Try[A] = { (str, hist) => Throw[A](Error(str)) }
-    Parser.parseFromString[Json](s)(facade) match {
-      case Success(value) => d.decodeJson(value).fold[Try[A]](err, Return(_))
-      case Failure(error) => Throw[A](Error(error.getMessage))
+  implicit def decodeArgonaut[A](implicit d: DecodeJson[A]): Decode.ApplicationJson[String, A] = {
+    Decode.applicationJson { s =>
+      val err: (String, CursorHistory) => Try[A] = { (str, hist) => Throw[A](Error(str)) }
+      Parser.parseFromString[Json](s)(facade) match {
+        case Success(value) => d.decodeJson(value).fold[Try[A]](err, Return(_))
+        case Failure(error) => Throw[A](Error(error.getMessage))
+      }
     }
   }
 }

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -10,7 +10,7 @@ trait Decoders {
   /**
    * Maps a Circe's [[Decoder]] to Finch's [[Decode]].
    */
-  implicit def decodeCirce[A](implicit d: Decoder[A]): Decode[A] = Decode.instance(s =>
+  implicit def decodeCirce[A](implicit d: Decoder[A]): Decode.ApplicationJson[String, A] = Decode.applicationJson(s =>
     decode[A](s).fold[Try[A]](
       error => Throw[A](Error(error.getMessage)),
       value => Return(value)

--- a/core/src/main/scala/io/finch/Decode.scala
+++ b/core/src/main/scala/io/finch/Decode.scala
@@ -3,23 +3,36 @@ package io.finch
 import java.util.UUID
 
 import com.twitter.util.{Return, Throw, Try}
-import shapeless.{::, Generic, HNil}
+import shapeless.{::, Generic, HNil, Witness}
 
 /**
  * An abstraction that is responsible for decoding the value of type `A`.
  */
-trait Decode[A] {
-  def apply(s: String): Try[A]
+trait Decode[I, A] {
+  type ContentType <: String
+  def apply(i: I): Try[A]
 }
 
 trait LowPriorityDecodeInstances {
 
+  type Aux[I, A, CT <: String] = Decode[I, A] { type ContentType = CT }
+
+  type ApplicationJson[I, A] = Aux[I, A, Witness.`"application/json"`.T]
+  type TextPlain[I, A] = Aux[I, A, Witness.`"text/plain"`.T]
+
   /**
    * Creates an instance for a given type.
    */
-  def instance[A](f: String => Try[A]): Decode[A] = new Decode[A] {
-    def apply(s: String): Try[A] = f(s)
+  def instance[I, A, CT <: String](f: I => Try[A]): Aux[I, A, CT] = new Decode[I, A] {
+    type ContentType = CT
+    def apply(i: I): Try[A] = f(i)
   }
+
+  def applicationJson[I, A](fn: I => Try[A]): ApplicationJson[I, A] =
+    instance[I, A, Witness.`"application/json"`.T](fn)
+
+  def textPlain[I, A](fn: I => Try[A]): TextPlain[I, A] =
+    instance[I, A, Witness.`"text/plain"`.T](fn)
 
   /**
    * Creates a [[Decode]] from [[shapeless.Generic]].
@@ -28,52 +41,56 @@ trait LowPriorityDecodeInstances {
    *       because by some reason, compiler doesn't pick `ValueEndpointOps` for
    *       `Endpoint[String]`.
    */
-  implicit def decodeFromGeneric[A](implicit
-    gen: Generic.Aux[A, String :: HNil]
-  ): Decode[A] = instance(s => Return(gen.from(s :: HNil)))
+  implicit def decodeFromGeneric[A, CT <: String](implicit
+    gen: Generic.Aux[A, String :: HNil],
+    w: Witness.Aux[CT]
+  ): Decode.Aux[String, A, CT] = instance(s => Return(gen.from(s :: HNil)))
 }
 
 object Decode extends LowPriorityDecodeInstances {
 
-  /**
-   * Returns an instance for a given type.
-   */
-  @inline def apply[A](implicit dr: Decode[A]): Decode[A] = dr
+  class Implicitly[I, A] {
+    def apply[CT <: String](w: Witness.Aux[CT])(implicit
+      d: Decode.Aux[I, A, CT]
+    ): Decode.Aux[I, A, CT] = d
+  }
+
+  @inline def apply[I, A]: Implicitly[I, A] = new Implicitly[I, A]
 
   /**
    * A [[Decode]] instance for `String`.
    */
-  implicit val decodeString: Decode[String] = instance(s => Return(s))
+  implicit val decodeString: TextPlain[String, String] = textPlain(s => Return(s))
 
   /**
    * A [[Decode]] instance for `Int`.
    */
-  implicit val decodeInt: Decode[Int] = instance(s => Try(s.toInt))
+  implicit val decodeInt: Decode[String, Int] = textPlain(s => Try(s.toInt))
 
   /**
    * A [[Decode]] instance for `Long`.
    */
-  implicit val decodeLong: Decode[Long] = instance(s => Try(s.toLong))
+  implicit val decodeLong: Decode[String, Long] = textPlain(s => Try(s.toLong))
 
   /**
    * A [[Decode]] instance for `Float`.
    */
-  implicit val decodeFloat: Decode[Float] = instance(s => Try(s.toFloat))
+  implicit val decodeFloat: Decode[String, Float] = textPlain(s => Try(s.toFloat))
 
   /**
    * A [[Decode]] instance for `Double`.
    */
-  implicit val decodeDouble: Decode[Double] = instance(s => Try(s.toDouble))
+  implicit val decodeDouble: Decode[String, Double] = textPlain(s => Try(s.toDouble))
 
   /**
    * A [[Decode]] instance for `Boolean`.
    */
-  implicit val decodeBoolean: Decode[Boolean] = instance(s => Try(s.toBoolean))
+  implicit val decodeBoolean: Decode[String, Boolean] = textPlain(s => Try(s.toBoolean))
 
   /**
    * A [[Decode]] instance for `UUID`.
    */
-  implicit val decodeUUID: Decode[UUID] = instance(s =>
+  implicit val decodeUUID: Decode[String, UUID] = textPlain(s =>
     if (s.length != 36) Throw(new IllegalArgumentException(s"Too long for UUID: ${s.length}"))
     else Try(UUID.fromString(s))
   )

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -423,7 +423,7 @@ object Endpoint {
    * The resulting reader will fail when type conversion fails.
    */
   implicit class StringEndpointOps(val self: Endpoint[String]) extends AnyVal {
-    @deprecated("Use asText or asJson depending on expecting Content-Type", "0.11.0")
+    @deprecated("Use asText or asJson depending on expected Content-Type", "0.11.0")
     def as[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[A] = asText
 
     def asText[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[A] =
@@ -477,7 +477,18 @@ object Endpoint {
      * this class can safely extends AnyVal.
      */
 
-    def as[A](implicit decoder: Decode[String, A], tag: ClassTag[A]): Endpoint[Seq[A]] =
+    @deprecated("Use asText or asJson depending on expected Content-Type", "0.11.0")
+    def as[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[Seq[A]] = asText
+
+    def asText[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[Seq[A]] =
+      decode
+
+    def asJson[A](implicit decoder: Decode.ApplicationJson[String, A], tag: ClassTag[A]): Endpoint[Seq[A]] =
+      decode
+
+    private def decode[A, CT <: String](implicit
+      decoder: Decode.Aux[String, A, CT], tag: ClassTag[A]
+    ): Endpoint[Seq[A]] = {
       self.mapAsync { items =>
         val decoded = items.map(decoder.apply)
         val errors = decoded.collect {
@@ -487,6 +498,7 @@ object Endpoint {
         if (errors.isEmpty) Future.const(Try.collect(decoded))
         else Future.exception(Error.RequestErrors(errors))
       }
+    }
   }
 
   /**
@@ -497,13 +509,26 @@ object Endpoint {
    * will succeed if the result is empty or type conversion succeeds.
    */
   implicit class StringOptionEndpointOps(val self: Endpoint[Option[String]]) extends AnyVal {
-    def as[A](implicit decoder: Decode[String, A], tag: ClassTag[A]): Endpoint[Option[A]] =
+
+    @deprecated("Use asText or asJson depending on expected Content-Type", "0.11.0")
+    def as[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[Option[A]] = asText
+
+    def asText[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[Option[A]] =
+      decode
+
+    def asJson[A](implicit decoder: Decode.ApplicationJson[String, A], tag: ClassTag[A]): Endpoint[Option[A]] =
+      decode
+
+    private def decode[A, CT <: String](implicit
+      decoder: Decode.Aux[String, A, CT], tag: ClassTag[A]
+    ): Endpoint[Option[A]] = {
       self.mapAsync {
         case Some(value) =>
           Future.const(decoder(value).rescue(notParsed[A](self, tag)).map(Some.apply))
         case None =>
           Future.None
       }
+    }
 
     private[finch] def noneIfEmpty: Endpoint[Option[String]] = self.map {
       case Some(value) if value.isEmpty => None

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -423,7 +423,16 @@ object Endpoint {
    * The resulting reader will fail when type conversion fails.
    */
   implicit class StringEndpointOps(val self: Endpoint[String]) extends AnyVal {
-    def as[A](implicit decoder: Decode[String, A], tag: ClassTag[A]): Endpoint[A] =
+    @deprecated("Use asText or asJson depending on expecting Content-Type", "0.11.0")
+    def as[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[A] = asText
+
+    def asText[A](implicit decoder: Decode.TextPlain[String, A], tag: ClassTag[A]): Endpoint[A] =
+      decode
+
+    def asJson[A](implicit decoder: Decode.ApplicationJson[String, A], tag: ClassTag[A]): Endpoint[A] =
+      decode
+
+    private def decode[A, CT <: String](implicit decoder: Decode.Aux[String, A, CT], tag: ClassTag[A]): Endpoint[A] =
       self.mapAsync(value => Future.const(decoder(value).rescue(notParsed[A](self, tag))))
   }
 

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -423,7 +423,7 @@ object Endpoint {
    * The resulting reader will fail when type conversion fails.
    */
   implicit class StringEndpointOps(val self: Endpoint[String]) extends AnyVal {
-    def as[A](implicit decoder: Decode[A], tag: ClassTag[A]): Endpoint[A] =
+    def as[A](implicit decoder: Decode[String, A], tag: ClassTag[A]): Endpoint[A] =
       self.mapAsync(value => Future.const(decoder(value).rescue(notParsed[A](self, tag))))
   }
 
@@ -468,7 +468,7 @@ object Endpoint {
      * this class can safely extends AnyVal.
      */
 
-    def as[A](implicit decoder: Decode[A], tag: ClassTag[A]): Endpoint[Seq[A]] =
+    def as[A](implicit decoder: Decode[String, A], tag: ClassTag[A]): Endpoint[Seq[A]] =
       self.mapAsync { items =>
         val decoded = items.map(decoder.apply)
         val errors = decoded.collect {
@@ -488,7 +488,7 @@ object Endpoint {
    * will succeed if the result is empty or type conversion succeeds.
    */
   implicit class StringOptionEndpointOps(val self: Endpoint[Option[String]]) extends AnyVal {
-    def as[A](implicit decoder: Decode[A], tag: ClassTag[A]): Endpoint[Option[A]] =
+    def as[A](implicit decoder: Decode[String, A], tag: ClassTag[A]): Endpoint[Option[A]] =
       self.mapAsync {
         case Some(value) =>
           Future.const(decoder(value).rescue(notParsed[A](self, tag)).map(Some.apply))

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -20,13 +20,13 @@ object FromParams {
   }
 
   implicit def hconsFromParams[HK <: Symbol, HV, T <: HList](implicit
-    dh: Decode[String, HV],
+    dh: Decode.TextPlain[String, HV],
     ct: ClassTag[HV],
     key: Witness.Aux[HK],
     fpt: FromParams[T]
   ): FromParams[FieldType[HK, HV] :: T] = new FromParams[FieldType[HK, HV] :: T] {
     def endpoint: Endpoint[FieldType[HK, HV] :: T] =
-      param(key.value.name).as(dh, ct).map(field[HK](_)) :: fpt.endpoint
+      param(key.value.name).asText(dh, ct).map(field[HK](_)) :: fpt.endpoint
   }
 }
 

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -20,7 +20,7 @@ object FromParams {
   }
 
   implicit def hconsFromParams[HK <: Symbol, HV, T <: HList](implicit
-    dh: Decode[HV],
+    dh: Decode[String, HV],
     ct: ClassTag[HV],
     key: Witness.Aux[HK],
     fpt: FromParams[T]

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -7,7 +7,7 @@ package io
 package object finch extends Endpoints with Outputs with ValidationRules {
 
   @deprecated("Use io.finch.Decode instead", "0.11")
-  type DecodeRequest[A] = Decode[A]
+  type DecodeRequest[A] = Decode[String, A]
 
   @deprecated("Use io.finch.Encode instead", "0.11")
   type EncodeResponse[A] = Encode[A]

--- a/core/src/test/scala/io/finch/DecodeLaws.scala
+++ b/core/src/test/scala/io/finch/DecodeLaws.scala
@@ -10,7 +10,7 @@ import org.typelevel.discipline.Laws
 
 trait DecodeLaws[A] extends Laws with MissingInstances with AllInstances {
 
-  def decode: Decode[A]
+  def decode: Decode[String, A]
 
   def roundTrip(a: A): IsEq[Try[A]] =
     decode(a.toString) <-> Return(a)
@@ -23,7 +23,7 @@ trait DecodeLaws[A] extends Laws with MissingInstances with AllInstances {
 }
 
 object DecodeLaws {
-  def apply[A: Decode]: DecodeLaws[A] = new DecodeLaws[A] {
-    val decode: Decode[A] = Decode[A]
+  def apply[A](implicit d: Decode[String, A]): DecodeLaws[A] = new DecodeLaws[A] {
+    val decode: Decode[String, A] = d
   }
 }

--- a/core/src/test/scala/io/finch/EndToEndSpec.scala
+++ b/core/src/test/scala/io/finch/EndToEndSpec.scala
@@ -16,7 +16,7 @@ class EndToEndSpec extends FinchSpec {
     implicit val encodeFoo: Encode.TextPlain[Foo] =
       Encode.textPlain(s => Buf.Utf8(s.s))
 
-    implicit val decodeFoo: Decode[Foo] =
+    implicit val decodeFoo: Decode[String, Foo] =
       Decode.instance(s => Return(Foo(s)))
 
     implicit val encodeException: Encode.TextPlain[Exception] =

--- a/core/src/test/scala/io/finch/EndpointLaws.scala
+++ b/core/src/test/scala/io/finch/EndpointLaws.scala
@@ -12,7 +12,7 @@ import scala.reflect.ClassTag
 
 trait EndpointLaws[A] extends Laws with MissingInstances with AllInstances {
 
-  def decoder: Decode[A]
+  def decoder: Decode[String, A]
   def classTag: ClassTag[A]
   def endpoint: Endpoint[Option[String]]
   def serialize: String => Input
@@ -33,10 +33,10 @@ trait EndpointLaws[A] extends Laws with MissingInstances with AllInstances {
 }
 
 object EndpointLaws {
-  def apply[A: Decode: ClassTag](
+  def apply[A: ClassTag](
     e: Endpoint[Option[String]]
-  )(f: String => Input): EndpointLaws[A] = new EndpointLaws[A] {
-    val decoder: Decode[A] = Decode[A]
+  )(f: String => Input)(implicit d: Decode[String, A]): EndpointLaws[A] = new EndpointLaws[A] {
+    val decoder: Decode[String, A] = d
     val classTag: ClassTag[A] = implicitly[ClassTag[A]]
     val endpoint: Endpoint[Option[String]] = e
     val serialize: String => Input = f

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -10,7 +10,7 @@ package object jackson {
 
   implicit def decodeJackson[A](implicit
     mapper: ObjectMapper, ct: ClassTag[A]
-  ): Decode[A] = Decode.instance(s =>
+  ): Decode.ApplicationJson[String, A] = Decode.applicationJson(s =>
     Try(mapper.readValue(s, ct.runtimeClass.asInstanceOf[Class[A]]))
   )
 

--- a/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
+++ b/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
@@ -61,7 +61,7 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
   /**
    * Confirm that this encoder can decode instances of our case class.
    */
-  def decodeNestedCaseClass(implicit decoder: Decode[ExampleNestedCaseClass]): Unit =
+  def decodeNestedCaseClass(implicit decoder: Decode[String, ExampleNestedCaseClass]): Unit =
     check { (e: ExampleNestedCaseClass) =>
       decoder(exampleNestedCaseClassCodecJson.encode(e).nospaces) === Return(e)
     }
@@ -70,7 +70,7 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
    * Confirm that this encoder fails on invalid input (both ill-formed JSON and
    * invalid JSON).
    */
-  def failToDecodeInvalidJson(implicit decoder: Decode[ExampleNestedCaseClass]): Unit = {
+  def failToDecodeInvalidJson(implicit decoder: Decode[String, ExampleNestedCaseClass]): Unit = {
     check { (badJson: String) =>
       Parse.decodeOption(badJson)(exampleNestedCaseClassCodecJson).isEmpty ==>
         decoder(badJson).isThrow
@@ -91,7 +91,7 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
   /**
    * Confirm that this encoder can decode top-level lists of instances of our case class.
    */
-  def decodeCaseClassList(implicit decoder: Decode[List[ExampleNestedCaseClass]]): Unit =
+  def decodeCaseClassList(implicit decoder: Decode[String, List[ExampleNestedCaseClass]]): Unit =
     check { (es: List[ExampleNestedCaseClass]) =>
       decoder(exampleNestedCaseClassListCodecJson.encode(es).nospaces) === Return(es)
     }

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -12,8 +12,8 @@ package object json4s {
    * @param formats json4s `Formats` to use for decoding
    * @tparam A the type of data to decode into
    */
-  implicit def decodeJson[A : Manifest](implicit formats: Formats): Decode[A] =
-    Decode.instance(input => Try(JsonMethods.parse(input).extract[A]))
+  implicit def decodeJson[A : Manifest](implicit formats: Formats): Decode.ApplicationJson[String, A] =
+    Decode.applicationJson(input => Try(JsonMethods.parse(input).extract[A]))
 
   /**
    * @param formats json4s `Formats` to use for decoding

--- a/playjson/src/main/scala/io/finch/playjson/package.scala
+++ b/playjson/src/main/scala/io/finch/playjson/package.scala
@@ -10,8 +10,8 @@ package object playjson {
    * @param reads Play JSON `Reads` to use for decoding
    * @tparam A the type of the data to decode into
    */
-  implicit def decodePlayJson[A](implicit reads: Reads[A]): Decode[A] =
-    Decode.instance(input => Try(Json.parse(input).as[A]))
+  implicit def decodePlayJson[A](implicit reads: Reads[A]): Decode.ApplicationJson[String, A] =
+    Decode.applicationJson(input => Try(Json.parse(input).as[A]))
 
   /**
    * @param writes Play JSON `Writes` to use for encoding

--- a/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
+++ b/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
@@ -10,9 +10,11 @@ package object sprayjson{
     * @param format spray-json support for convert JSON val to specific type object
     * @tparam A the type of the data to decode into
     */
-  implicit def decodeSpray[A](implicit format: JsonFormat[A]): Decode[A] = Decode.instance[A](
-    s =>Try(s.parseJson.convertTo[A])
-  )
+  implicit def decodeSpray[A](implicit format: JsonFormat[A]): Decode.ApplicationJson[String, A] = {
+    Decode.applicationJson(
+      s =>Try(s.parseJson.convertTo[A])
+    )
+  }
 
   /**
     * @param format spray-json support for convert JSON val to specific type object


### PR DESCRIPTION
This PR is my vision of `Decode` refactored implementation #562

I propose to introduce second type parameter `I` (for Input) for `Decode` trait:
```
trait Decode[I, A] {
  type ContentType <: String
  def apply(i: I): Try[A]
}
```

In this case we could iteratively move from `String` to `Buf` as @vkostyukov suggested in #511 and support multiple inputs via kind of "ad-hoc" polymorphism. I.e. it'll be super useful for implementation of Decode for `AsyncStream` (#520) where `String` or `Buf` couldn't be a case obviously. Also it will allow us to live some time with current JSON decoders which doesn't support `Buf` without dirty hacks (or doesn't support it at all :fearful:)

I'd be very glad of your advices, opinions and suggestions.