### PR TITLE
Revert sbt-scoverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val core = project
 lazy val test = project
   .settings(moduleName := "finch-test")
   .settings(allSettings)
-  .settings(coverageExcludedPackages := "io\\.finch\\.test\\..*")
+  .settings(ScoverageKeys.coverageExcludedPackages := "io\\.finch\\.test\\..*")
   .settings(libraryDependencies ++= testDependencies)
   .dependsOn(core)
 
@@ -150,7 +150,7 @@ lazy val jsonTest = project.in(file("json-test"))
   .settings(moduleName := "finch-json-test")
   .settings(allSettings)
   .settings(noPublish)
-  .settings(coverageExcludedPackages := "io\\.finch\\.test\\..*")
+  .settings(ScoverageKeys.coverageExcludedPackages := "io\\.finch\\.test\\..*")
   .settings(
     libraryDependencies ++= "io.argonaut" %% "argonaut" % "6.1" +: testDependencies
   )
@@ -220,7 +220,7 @@ lazy val examples = project
   .settings(allSettings)
   .settings(noPublish)
   .settings(resolvers += "TM" at "http://maven.twttr.com")
-  .settings(coverageExcludedPackages :=
+  .settings(ScoverageKeys.coverageExcludedPackages :=
     """
       |io\.finch\.div\..*;
       |io\.finch\.todo\..*;
@@ -246,7 +246,7 @@ lazy val benchmarks = project
   .settings(noPublish)
   .settings(libraryDependencies += "io.circe" %% "circe-generic" % circeVersion)
   .settings(
-    coverageExcludedPackages := "io\\.finch\\.benchmarks\\..*;"
+    ScoverageKeys.coverageExcludedPackages := "io\\.finch\\.benchmarks\\..*;"
   )
   .settings(
     javaOptions in run ++= Seq(

--- a/core/src/test/scala/io/finch/OutputSpec.scala
+++ b/core/src/test/scala/io/finch/OutputSpec.scala
@@ -9,19 +9,19 @@ class OutputSpec extends FinchSpec {
   behavior of "Output"
 
   it should "propagate status to response" in {
-    check { o: Output[String] => o.toResponse().status == o.status }
+    check { o: Output[String] => o.toResponse[Witness.`"text/plain"`.T]().status == o.status }
   }
 
   it should "propagate headers to response" in {
     check { (o: Output[String], headers: Headers) =>
-      val rep = headers.m.foldLeft(o)((acc, h) => acc.withHeader(h._1 -> h._2)).toResponse()
+      val rep = headers.m.foldLeft(o)((acc, h) => acc.withHeader(h._1 -> h._2)).toResponse[Witness.`"text/plain"`.T]()
       headers.m.forall(h => rep.headerMap(h._1) === h._2)
     }
   }
 
   it should "propagate cookies to response" in {
     check { (o: Output[String], cookies: Cookies) =>
-      val rep = cookies.c.foldLeft(o)((acc, c) => acc.withCookie(c)).toResponse()
+      val rep = cookies.c.foldLeft(o)((acc, c) => acc.withCookie(c)).toResponse[Witness.`"text/plain"`.T]()
       cookies.c.forall(c => rep.cookies(c.name) === c)
     }
   }
@@ -72,7 +72,7 @@ class OutputSpec extends FinchSpec {
 
   it should "propagate payload to response" in {
     check { op: Output.Payload[String] =>
-      Some(op.toResponse().contentString) ===
+      Some(op.toResponse[Witness.`"text/plain"`.T]().contentString) ===
         Buf.Utf8.unapply(Encode.encodeString(op.value))
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,8 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
+// sbt-scoverage 1.3.5 has a bug that results in 2.10 tests not being run.
+// See https://github.com/scoverage/sbt-scoverage/issues/146
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")


### PR DESCRIPTION
Okay, I made a kind of annoying mistake last week.

Last fall I updated circe to sbt-scoverage 1.3.3, ran into [a terrible bug](https://github.com/travisbrown/circe/pull/72) that meant the 2.10 builds weren't running, and then reverted the update back to sbt-scoverage 1.2.0.

Last week I forgot entirely about this, saw that sbt-scoverage 1.3.5 was out, and updated both circe and Finch, without confirming that the bug (https://github.com/scoverage/sbt-scoverage/issues/146) had been fixed. In fact I'd forgotten about the bug entirely.

This means that since 81d89e20bc8c814a95d4aef88ddd956899e6d822 Travis CI hasn't been running 2.10 builds for Finch. Which wouldn't necessarily be a big deal, but some of the new content type stuff doesn't work on 2.10—or rather it works, but requires explicit type annotations.

I still don't think this is a terribly big deal. Lots of projects (like Play) are already dropping 2.10 support altogether, and we could provide helper methods if maintaining first-class 2.10 support is a priority here.

I've switched back to sbt-scoverage and added the type annotations to make the tests compile on 2.10. Sorry about this—I should have remembered the problem and been more careful.