### PR TITLE
Fix a markdown error (missing backtick) in json docs.

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -133,7 +133,7 @@ object Foo {
   //       No need for apply if there is no companion object
   implicit val fooformat = jsonFormat2(Foo.apply)
 }
-``
+```
 
 [argonaut]: http://argonaut.io
 [jackson]: http://wiki.fasterxml.com/JacksonHome


### PR DESCRIPTION
The [json docs](https://github.com/finagle/finch/blob/master/docs/json.md) is missing a backtick.