### PR TITLE
FromParams should be tolerant to optional and seq fields

### DIFF
--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -3,8 +3,9 @@ package io.finch.internal
 import scala.reflect.ClassTag
 
 import io.finch._
-import shapeless.{::, HList, HNil, Witness}
+import shapeless._
 import shapeless.labelled._
+import shapeless.poly._
 
 /**
  * A type class empowering a generic derivation of [[Endpoint]]s from query string params.
@@ -20,13 +21,36 @@ object FromParams {
   }
 
   implicit def hconsFromParams[HK <: Symbol, HV, T <: HList](implicit
-    dh: Decode[HV],
-    ct: ClassTag[HV],
     key: Witness.Aux[HK],
-    fpt: FromParams[T]
+    fpt: FromParams[T],
+    hс: Case1.Aux[Extractor.type, String, Endpoint[HV]]
   ): FromParams[FieldType[HK, HV] :: T] = new FromParams[FieldType[HK, HV] :: T] {
-    def endpoint: Endpoint[FieldType[HK, HV] :: T] =
-      param(key.value.name).as(dh, ct).map(field[HK](_)) :: fpt.endpoint
+    def endpoint: Endpoint[FieldType[HK, HV] :: T] = {
+      hс(key.value.name).map(field[HK](_)) :: fpt.endpoint
+    }
   }
 }
 
+private[internal] object Extractor extends Poly1 {
+
+  implicit def optionalExtractor[V](implicit
+    dh: Decode[V],
+    ct: ClassTag[V]
+  ): Case.Aux[String, Endpoint[Option[V]]] = at[String] { key =>
+    paramOption(key).as(dh, ct)
+  }
+
+  implicit def collectionExtractor[V](implicit
+    dh: Decode[V],
+    ct: ClassTag[V]
+  ): Case.Aux[String, Endpoint[Seq[V]]] = at[String] { key =>
+    params(key).as(dh, ct)
+  }
+
+  implicit def extractor[V](implicit
+    dh: Decode[V],
+    ct: ClassTag[V]
+  ): Case.Aux[String, Endpoint[V]] = at[String] { key =>
+    param(key).as(dh, ct)
+  }
+}


### PR DESCRIPTION
#574 

I didn't succeed to make it work for all collections using `CanBuildFrom` due to some strange behaviour of implicit resolution and HKT. Tried for a few days, but still failed. Maybe I've missed something, but it just doesn't work for type `T[_]` even if there is an implicit instance of `cbf` in scope.

Anyway, I believe it would be useful even in it's current state. 

If someone could make it in more generic way, it would be super cool.