### PR TITLE
Use Rerunnable

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/FinchBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/FinchBenchmark.scala
@@ -6,7 +6,7 @@ import org.openjdk.jmh.annotations._
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 6, time = 2, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 6, time = 2, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(2)
 abstract class FinchBenchmark

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val buildSettings = Seq(
 
 lazy val finagleVersion = "6.34.0"
 lazy val circeVersion = "0.4.0-RC1"
+lazy val catbirdVersion = "0.3.0"
 lazy val shapelessVersion = "2.3.0"
 lazy val catsVersion = "0.4.1"
 lazy val sprayVersion = "1.3.2"
@@ -42,6 +43,7 @@ val baseSettings = Seq(
     "org.typelevel" %% "cats-core" % catsVersion,
     "com.twitter" %% "finagle-http" % finagleVersion,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+    "io.catbird" %% "catbird-util" % catbirdVersion,
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ) ++ testDependencies.map(_ % "test"),
   resolvers ++= Seq(

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -155,8 +155,8 @@ object Output {
   }
 
   implicit class EndpointResultOps[A](val o: Endpoint.Result[A]) extends AnyVal {
-    private[finch] def poll: Option[Try[A]] = o.flatMap(_._2.value.poll.map(_.map(_.value)))
-    private[finch] def output: Option[Output[A]] = o.map({ case (_, oa) => Await.result(oa.value) })
+    private[finch] def poll: Option[Try[A]] = o.flatMap(_._2.run.poll.map(_.map(_.value)))
+    private[finch] def output: Option[Output[A]] = o.map({ case (_, oa) => Await.result(oa.run) })
     private[finch] def value: Option[A] = output.map(oa => oa.value)
     private[finch] def remainder: Option[Input] = o.map(_._1)
   }


### PR DESCRIPTION
Was experimenting with using `Rerunnable[A]` over `Eval[Future[A]]` and I'm quite pleased with the results. Less code, better performance (overall up to 25-35% in terms of allocations and running time improvements):

Pairs: before and after

Matchers and extractors:

```
[info] Benchmark                                              Mode  Cnt      Score       Error   Units

[info] BodyBenchmark.byteArray                                avgt    6   1311.400 ±   620.490   ns/op
[info] BodyBenchmark.byteArray                                avgt    6    570.330 ±    92.477   ns/op

[info] BodyBenchmark.byteArray:·gc.alloc.rate.norm            avgt    6   1872.001 ±     0.001    B/op
[info] BodyBenchmark.byteArray:·gc.alloc.rate.norm            avgt    6   1736.000 ±     0.001    B/op

----

[info] BodyBenchmark.byteArrayOption                         avgt    6    492.711 ±    94.691   ns/op
[info] BodyBenchmark.byteArrayOption                         avgt    6    308.205 ±   132.471   ns/op

[info] BodyBenchmark.byteArrayOption:·gc.alloc.rate.norm     avgt    6   1328.000 ±    24.575    B/op
[info] BodyBenchmark.byteArrayOption:·gc.alloc.rate.norm     avgt    6   1304.000 ±    24.575    B/op


----

[info] BodyBenchmark.string                                  avgt    6   1478.761 ±   636.099   ns/op
[info] BodyBenchmark.string                                  avgt    6   1135.306 ±    61.719   ns/op

[info] BodyBenchmark.string:·gc.alloc.rate.norm              avgt    6   2888.001 ±    24.575    B/op
[info] BodyBenchmark.string:·gc.alloc.rate.norm              avgt    6   2752.001 ±    73.724    B/op

----

[info] BodyBenchmark.stringOption                            avgt    6   1033.382 ±   343.271   ns/op
[info] BodyBenchmark.stringOption                            avgt    6   1043.801 ±   289.208   ns/op

[info] BodyBenchmark.stringOption:·gc.alloc.rate.norm        avgt    6   2344.000 ±     0.001    B/op
[info] BodyBenchmark.stringOption:·gc.alloc.rate.norm        avgt    6   2320.000 ±     0.001    B/op
```

Composite endpoints:

```
-----

[info] FailingEndpointBenchmark.derivedEndpoint                             avgt    6  40379.665 ± 18688.270   ns/op
[info] FailingEndpointBenchmark.derivedEndpoint                             avgt    6  39403.439 ±  7318.923   ns/op

[info] FailingEndpointBenchmark.derivedEndpoint:·gc.alloc.rate.norm         avgt    6  31360.821 ±    20.535    B/op
[info] FailingEndpointBenchmark.derivedEndpoint:·gc.alloc.rate.norm         avgt    6  24958.682 ±    71.468    B/op

------

[info] FailingEndpointBenchmark.hlistGenericEndpoint                        avgt    6  36594.813 ± 21092.112   ns/op
[info] FailingEndpointBenchmark.hlistGenericEndpoint                        avgt    6  37253.656 ± 22246.004   ns/op

[info] FailingEndpointBenchmark.hlistGenericEndpoint:·gc.alloc.rate.norm    avgt    6  25640.336 ±    20.978    B/op
[info] FailingEndpointBenchmark.hlistGenericEndpoint:·gc.alloc.rate.norm    avgt    6  20572.725 ±    42.633    B/op

-----
[info] SuccessfulEndpointBenchmark.derivedEndpoint                          avgt    6  16921.560 ±  2321.301   ns/op
[info] SuccessfulEndpointBenchmark.derivedEndpoint                          avgt    6  14736.037 ±  8920.483   ns/op

[info] SuccessfulEndpointBenchmark.derivedEndpoint:·gc.alloc.rate.norm      avgt    6  29744.008 ±    98.298    B/op
[info] SuccessfulEndpointBenchmark.derivedEndpoint:·gc.alloc.rate.norm      avgt    6  22056.007 ±     0.004    B/op

----

[info] SuccessfulEndpointBenchmark.hlistGenericEndpoint                      avgt    6  14481.747 ±  9113.843   ns/op
[info] SuccessfulEndpointBenchmark.hlistGenericEndpoint                      avgt    6  11472.738 ±  6660.089   ns/op

[info] SuccessfulEndpointBenchmark.hlistGenericEndpoint:·gc.alloc.rate.norm  avgt    6  22744.007 ±     0.004    B/op
[info] SuccessfulEndpointBenchmark.hlistGenericEndpoint:·gc.alloc.rate.norm  avgt    6  17336.005 ±    49.148    B/op
```