### PR TITLE
Update Circe to 0.4.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val finagleVersion = "6.34.0"
-lazy val circeVersion = "0.3.0"
+lazy val circeVersion = "0.4.0-RC1"
 lazy val shapelessVersion = "2.3.0"
 lazy val catsVersion = "0.4.1"
 lazy val sprayVersion = "1.3.2"


### PR DESCRIPTION
[Circe 0.4.0-RC1](https://github.com/travisbrown/circe/releases/tag/v0.4.0-RC1) is out!