### PR TITLE
Introduce ServiceBuilder

### DIFF
--- a/core/src/main/scala/io/finch/ServiceBuilder.scala
+++ b/core/src/main/scala/io/finch/ServiceBuilder.scala
@@ -1,0 +1,34 @@
+package io.finch
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import io.finch.internal.ToService
+import shapeless._
+
+/**
+ * Captures the `HList` of endpoints as well as the `HList` of their content-types in order to do
+ * the `toService` conversion.
+ *
+ * {{{
+ *
+ * val api: Service[Request, Response] = ServiceBuilder()
+ *   .respond[Application.Json](getUser :+: postUser)
+ *   .respond[Text.Plain](healthcheck)
+ *   .toService
+ * }}}
+ */
+case class ServiceBuilder[ES <: HList, CTS <: HList](endpoints: ES) { self =>
+
+  class Respond[CT <: String] {
+    def apply[E](e: Endpoint[E]): ServiceBuilder[Endpoint[E] :: ES, CT :: CTS] =
+      self.copy(e :: self.endpoints)
+  }
+
+  def respond[CT <: String]: Respond[CT] = new Respond[CT]
+
+  def toService(implicit ts: ToService[ES, CTS]): Service[Request, Response] = ts(endpoints)
+}
+
+object ServiceBuilder {
+  def apply(): ServiceBuilder[HNil, HNil] = ServiceBuilder(HNil)
+}

--- a/core/src/main/scala/io/finch/internal/ToResponse.scala
+++ b/core/src/main/scala/io/finch/internal/ToResponse.scala
@@ -23,6 +23,8 @@ trait LowPriorityToResponseInstances {
     def apply(a: A): Response = fn(a)
   }
 
+  implicit def responseToResponse[CT <: String]: Aux[Response, CT] = instance(identity)
+
   private[this] def asyncStreamResponseBuilder[A, CT <: String](writer: A => Buf)(implicit
     w: Witness.Aux[CT]
   ): Aux[AsyncStream[A], CT] = instance { as =>

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -1,0 +1,49 @@
+package io.finch.internal
+
+import scala.annotation.implicitNotFound
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.util.Future
+import io.finch._
+import shapeless._
+
+@implicitNotFound("""
+You can only convert an endpoint into a Finagle service if its result type is one of the following:
+
+ * 'com.twitter.finagle.http.Response'
+ * a value of type 'A' with 'io.finch.Encode' instance available (for requested Content-Type)
+ * a 'shapeless.Coproduct' made up of some combination of the above
+
+Make sure this rule evaluates for every endpoint passed to 'respond' method on 'ServiceBuilder'.
+""")
+trait ToService[ES <: HList, CTS <: HList] {
+  def apply(endpoints: ES): Service[Request, Response]
+}
+
+object ToService {
+
+  implicit val hnilToService: ToService[HNil, HNil] = new ToService[HNil, HNil] {
+    def apply(endpoints: HNil): Service[Request, Response] =
+      Service.mk(_ => Future.value(Response(Status.NotFound)))
+  }
+
+  implicit def hconsToService[A, EH <: Endpoint[A], ET <: HList, CTH <: String, CTT <: HList](implicit
+    trH: ToResponse.Aux[Output[A], CTH],
+    tsT: ToService[ET, CTT]
+  ): ToService[Endpoint[A] :: ET, CTH :: CTT] = new ToService[Endpoint[A] :: ET, CTH :: CTT] {
+     def apply(endpoints: Endpoint[A] :: ET): Service[Request, Response] = new Service[Request, Response] {
+       private[this] val basicEndpointHandler: PartialFunction[Throwable, Output[Nothing]] = {
+         case e: io.finch.Error => Output.failure(e, Status.BadRequest)
+       }
+
+       private[this] val safeEndpoint = endpoints.head.handle(basicEndpointHandler)
+
+       def apply(req: Request): Future[Response] = safeEndpoint(Input(req)) match {
+         case Some((remainder, output)) if remainder.isEmpty =>
+           output.map(o => o.toResponse[CTH](req.version)).run
+         case _ => tsT(endpoints.tail)(req)
+       }
+     }
+  }
+}

--- a/examples/src/main/scala/io/finch/div/Main.scala
+++ b/examples/src/main/scala/io/finch/div/Main.scala
@@ -4,7 +4,6 @@ import cats.std.int._
 import com.twitter.finagle.Http
 import com.twitter.util.Await
 import io.finch._
-import shapeless._
 
 /**
  * A tiny Finch application that serves a single endpoint `POST /:a/b:` that divides `a` by `b`.
@@ -32,5 +31,7 @@ object Main extends App {
     case e: ArithmeticException => BadRequest(e)
   }
 
-  Await.ready(Http.server.serve(":8081", div.toServiceAs[Text.Plain]))
+  Await.ready(Http.server.serve(":8081",
+    ServiceBuilder().respond[Text.Plain](div).toService
+  ))
 }

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -44,5 +44,7 @@ object Main extends App {
     case e: Exception => BadRequest(e)
   }
 
-  Await.ready(Http.server.serve(":8081", eval.toService))
+  Await.ready(Http.server.serve(":8081",
+    ServiceBuilder().respond[Application.Json](eval).toService
+  ))
 }

--- a/examples/src/main/scala/io/finch/oauth2/Main.scala
+++ b/examples/src/main/scala/io/finch/oauth2/Main.scala
@@ -49,5 +49,7 @@ object Main extends App {
     Ok(UnprotectedUser("unprotected"))
   }
 
-  Await.ready(Http.server.serve(":8081", (tokens :+: users :+: unprotected).toService))
+  Await.ready(Http.server.serve(":8081",
+    ServiceBuilder().respond[Application.Json](tokens :+: users :+: unprotected).toService
+  ))
 }

--- a/examples/src/main/scala/io/finch/todo/package.scala
+++ b/examples/src/main/scala/io/finch/todo/package.scala
@@ -5,8 +5,8 @@ import io.circe.{Encoder, Json}
 package object todo {
   implicit val encodeException: Encoder[Exception] = Encoder.instance(e =>
     Json.obj(
-      "type" -> Json.string(e.getClass.getSimpleName),
-      "message" -> Json.string(e.getMessage)
+      "type" -> Json.fromString(e.getClass.getSimpleName),
+      "message" -> Json.fromString(e.getMessage)
     )
   )
 }

--- a/examples/src/main/scala/io/finch/wrk/Finch.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finch.scala
@@ -3,7 +3,6 @@ package io.finch.wrk
 import io.circe.generic.auto._
 import io.finch._
 import io.finch.circe._
-import shapeless.Witness
 
 /**
  * How to benchmark this:
@@ -21,5 +20,5 @@ object Finch extends App {
 
   val roundTrip: Endpoint[Payload] = post(body.as[Payload])
 
-  serve(roundTrip.toServiceAs[Witness.`"application/json"`.T])
+  serve(ServiceBuilder().respond[Application.Json](roundTrip).toService)
 }


### PR DESCRIPTION
This is an attempt to solve #575 and a last PR in 0.11.

The idea is to use new abstraction `ServiceBuilder` that maps an `HList` of endpoints (even coproduct endpoints) to an `HList` of content-types. When an actual conversion (`toService`) happens we _fold_ un underlying list of endpoints and apply them one-by-one to a given request until it matches. The `HNil` case behaves as 404 (which is very nice).

The high-level API is following:

``` scala
val service = ServiceBuilder()
  .respond[Application.Json](getUsers :+: postUsers :+: deleteUser)
  .respond[Text.Plain](healthcheck)
  .toService
```

Note that `toService` still works, but marked as deprecated.

This is probably not the most efficient and clean solution, but I admire its simplicity and how small the diff itself. None of the `Endpoint`, `ToResponse`, `Encode` internals/API were touched - everything is done by new code.

Please, let me know how do you like the API. The only thing I'm worried about right now is whether or not it's good enough for further steps in this direction (content-type negotiation).
