### PR TITLE
Update circe to second 0.4.0 release candidate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val finagleVersion = "6.34.0"
-lazy val circeVersion = "0.4.0-RC1"
+lazy val circeVersion = "0.4.0-RC2"
 lazy val catbirdVersion = "0.3.0"
 lazy val shapelessVersion = "2.3.0"
 lazy val catsVersion = "0.4.1"


### PR DESCRIPTION
I'm planning to have circe 0.4.0 out by Monday, and I've tested this locally, but I'm updating to RC2 just in case other people want to try it out with Finch as well.