### PR TITLE
derive instances for nested structures

### DIFF
--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -4,10 +4,10 @@ import scala.reflect.ClassTag
 
 import cats.data.NonEmptyList
 import io.finch._
+import io.finch.Endpoint._
 import shapeless._
 import shapeless.labelled._
 import shapeless.poly._
-import io.finch.Endpoint._
 
 /**
  * A type class empowering a generic derivation of [[Endpoint]]s from query string params.

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -7,6 +7,7 @@ import io.finch._
 import shapeless._
 import shapeless.labelled._
 import shapeless.poly._
+import io.finch.Endpoint._
 
 /**
  * A type class empowering a generic derivation of [[Endpoint]]s from query string params.
@@ -33,6 +34,13 @@ object FromParams {
 }
 
 private[internal] object Extractor extends Poly1 {
+
+  implicit def nestedExtractor[Repr <: HList,V](implicit
+    gen: LabelledGeneric.Aux[V, Repr],
+    fp:  FromParams[Repr]
+  ): Case.Aux[String,Endpoint[V]] = at[String]{key =>
+    derive[V].fromParams
+  }
 
   implicit def optionalExtractor[V](implicit
     dh: Decode[V],

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -41,6 +41,13 @@ private[internal] object Extractor extends Poly1 {
   ): Case.Aux[String,Endpoint[V]] = at[String]{key =>
     derive[V].fromParams
   }
+  
+  implicit def nestedExtractorLifted[Repr <: HList,V](implicit
+    gen: LabelledGeneric.Aux[V, Repr],
+    fp:  FromParams[Repr]
+  ): Case.Aux[String,Endpoint[Option[V]]] = at[String]{key =>
+    derive[V].fromParams.lift
+  }  
 
   implicit def optionalExtractor[V](implicit
     dh: Decode[V],

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -41,13 +41,13 @@ private[internal] object Extractor extends Poly1 {
   ): Case.Aux[String,Endpoint[V]] = at[String]{key =>
     derive[V].fromParams
   }
-  
+
   implicit def nestedExtractorLifted[Repr <: HList,V](implicit
     gen: LabelledGeneric.Aux[V, Repr],
     fp:  FromParams[Repr]
   ): Case.Aux[String,Endpoint[Option[V]]] = at[String]{key =>
     derive[V].fromParams.lift
-  }  
+  }
 
   implicit def optionalExtractor[V](implicit
     dh: Decode[V],


### PR DESCRIPTION
We will able to derive instances for 

```
case class Test(name: String, age: Int , nested: Nested)
case class Nested(a: String, b: Int)

val test = derive[Test].fromParams
```
