### PR TITLE
Flexible Basic Auth

### DIFF
--- a/core/src/test/scala/io/finch/BasicAuthSpec.scala
+++ b/core/src/test/scala/io/finch/BasicAuthSpec.scala
@@ -1,7 +1,7 @@
 package io.finch
 
-import com.twitter.finagle.http.Request
-import com.twitter.util.Base64StringEncoder
+import com.twitter.finagle.http.{Request, Status}
+import com.twitter.util.{Base64StringEncoder, Future}
 
 class BasicAuthSpec extends FinchSpec {
 
@@ -10,23 +10,45 @@ class BasicAuthSpec extends FinchSpec {
   private[this] def encode(user: String, password: String) =
     "Basic " + Base64StringEncoder.encode(s"$user:$password".getBytes)
 
+  private[this] def unauthorized(realm: String) =
+    Unauthorized(BasicAuthFailed)
+      .withHeader("WWW-Authenticate" -> s"""Basic realm="$realm"""")
+
   it should "has a proper string representation" in {
-    check { s: String =>
-      BasicAuth("foo", "bar")(s: Endpoint0).toString === s"BasicAuth($s)"
+    check { (realm: String, s: String) =>
+      BasicAuth(realm)((_, _) => Future.False)(s: Endpoint0).toString === s"""BasicAuth(realm="$realm", $s)"""
     }
   }
 
   it should "auth the endpoint" in {
-    check { (u: String, p: String, req: Request) =>
-      req.authorization = encode(u, p)
+    check { (c: BasicAuthCredentials, realm: String, req: Request) =>
+      req.authorization = encode(c.user, c.pass)
 
-      val e = BasicAuth(u, p)(Endpoint(Ok("foo")))
+      val e = BasicAuth(realm)((u, p) => Future(u == c.user && p == c.pass))(Endpoint(Ok("foo")))
       val i = Input(req)
 
       e(i).output === Some(Ok("foo")) && {
         req.authorization = "secret"
-        e(i).output === Some(Unauthorized(BasicAuthFailed))
+        e(i).output === Some(unauthorized(realm))
       }
     }
+  }
+
+  it should "reach the unprotected endpoint" in {
+    val e = BasicAuth("realm")((_, _) => Future.False)("a") :+: ("b" :: Endpoint(Ok("foo")))
+
+    val protectedInput = Input(Request("/a"))
+    e(protectedInput).remainder shouldBe Some(protectedInput.drop(1))
+    e(protectedInput).output shouldBe Some(unauthorized("realm"))
+
+    val unprotectedInput = Input(Request("/b"))
+    e(unprotectedInput).remainder shouldBe Some(unprotectedInput.drop(1))
+    e(unprotectedInput).output.map(_.status) shouldBe Some(Status.Ok)
+
+    val notFound = Input(Request("/c"))
+    e(notFound).remainder shouldBe None // 404
+
+    val notFoundPartialMatch = Input(Request("/a/b"))
+    e(notFoundPartialMatch).remainder shouldBe Some(notFoundPartialMatch.drop(1)) // 404
   }
 }

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -26,11 +26,18 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
       }
   }
 
+  case class BasicAuthCredentials(user: String, pass: String)
+
   case class Headers(m: Map[String, String])
   case class Params(p: Map[String, String])
   case class Cookies(c: Seq[Cookie])
 
   case class OptionalNonEmptyString(o: Option[String])
+
+  def genBasicAuthCredentials: Gen[BasicAuthCredentials] = for {
+    u <- Gen.alphaStr.suchThat(!_.contains(':'))
+    p <- Gen.alphaStr
+  } yield BasicAuthCredentials(u, p)
 
   def genNonEmptyString: Gen[String] = Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
 
@@ -189,6 +196,8 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
   implicit def arbitraryUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
 
   implicit def arbitraryStatus: Arbitrary[Status] = Arbitrary(genStatus)
+
+  implicit def arbitraryBasicAuthCredentials: Arbitrary[BasicAuthCredentials] = Arbitrary(genBasicAuthCredentials)
 
   implicit def arbitraryHeaders: Arbitrary[Headers] = Arbitrary(genHeaders)
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -40,7 +40,9 @@ include its serialization logic into n instance of `EncodeResponse[Exception]`.
 ```scala
 import io.finch._
 
-val basicAuth: BasicAuth = BasicAuth("user", "password")
+val basicAuth: BasicAuth = BasicAuth("realm") { (user, password) =>
+  user == "user" && password == "password"
+}
 val e: Endpoint[String] = basicAuth(Endpoint(Ok("secret place")))
 ```
 


### PR DESCRIPTION
We are using finch at a project where we needed a more flexible BasicAuth implementation so we implemented one and I thought of contributing back.

The PR includes two big changes. The first, as per [rfc7235 section 4.1], is to always include a `WWW-Authenticate` header with a 401 Unauthorized response.
[rfc7235 section 4.1]: https://tools.ietf.org/html/rfc7235#section-4.1

The second is to replace the `BasicAuth` parameters by `authenticate: (String, String) => Boolean`. This way it is possible to reuse the same BasicAuth logic and authenticate the credentials by searching a database, reading from a file, or comparing to hard-coded credentials in the code.

Example:

```scala
val basicAuth: BasicAuth = BasicAuth("app-realm") { (user, pass) =>
  DB.query[Option[Boolean]](
    "SELECT true FROM users WHERE username = ? and password = ?", user, pass
  ).getOrElse(false)
}

// val basicAuth: BasicAuth = BasicAuth("user", "password") // This still works :)
// val basicAuth: BasicAuth = BasicAuth("app-realm", "user" -> "pass", "user2" -> "word") // This also works

val e: Endpoint[String] = basicAuth(Endpoint(Ok("secret place")))
```

In our case, and I believe in most cases, we started with a single hard-coded credential, then moved to a list of hard-coded credentials, and in the future we are planning to store credentials in a database.

Is this something you would like to include in `finch-core`?