### PR TITLE
update cats, circe and catbird dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.12.5",
   "org.scalatest" %% "scalatest" % "2.2.6",
   "org.typelevel" %% "cats-laws" % catsVersion,
-  "org.typelevel" %% "discipline" % "0.5"
+  "org.typelevel" %% "discipline" % "0.4"
 )
 
 val baseSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ lazy val buildSettings = Seq(
   crossScalaVersions := Seq("2.10.6", "2.11.8")
 )
 
-lazy val finagleVersion = "6.34.0"
-lazy val circeVersion = "0.4.1"
-lazy val catbirdVersion = "0.3.0"
-lazy val shapelessVersion = "2.3.0"
-lazy val catsVersion = "0.4.1"
+lazy val finagleVersion = "6.35.0"
+lazy val circeVersion = "0.5.0-M1"
+lazy val catbirdVersion = "0.5.0"
+lazy val shapelessVersion = "2.3.1"
+lazy val catsVersion = "0.6.0"
 lazy val sprayVersion = "1.3.2"
 
 lazy val compilerOptions = Seq(
@@ -32,9 +32,9 @@ lazy val compilerOptions = Seq(
 
 val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.12.5",
-  "org.scalatest" %% "scalatest" % "2.2.5",
+  "org.scalatest" %% "scalatest" % "2.2.6",
   "org.typelevel" %% "cats-laws" % catsVersion,
-  "org.typelevel" %% "discipline" % "0.4"
+  "org.typelevel" %% "discipline" % "0.5"
 )
 
 val baseSettings = Seq(
@@ -199,7 +199,7 @@ lazy val circe = project
 lazy val playjson = project
   .settings(moduleName :="finch-playjson")
   .settings(allSettings)
-  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.9")
+  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.10")
   .dependsOn(core, jsonTest % "test")
 
 lazy val sprayjson = project

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import algebra.Eq
+import cats.kernel.Eq
 import com.twitter.finagle.http.Request
 
 /**

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import cats.kernel.Eq
+import cats.Eq
 import com.twitter.finagle.http.Request
 
 /**

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import cats.kernel.Eq
+import cats.Eq
 import com.twitter.finagle.http.{Cookie, Response, Status, Version}
 import com.twitter.util.{Await, Future, Try}
 import io.finch.internal.ToResponse

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import algebra.Eq
+import cats.kernel.Eq
 import com.twitter.finagle.http.{Cookie, Response, Status, Version}
 import com.twitter.util.{Await, Future, Try}
 import io.finch.internal.ToResponse

--- a/core/src/test/scala/io/finch/DecodeLaws.scala
+++ b/core/src/test/scala/io/finch/DecodeLaws.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import cats.kernel.Eq
+import cats.Eq
 import cats.std.AllInstances
 import cats.laws._
 import cats.laws.discipline._

--- a/core/src/test/scala/io/finch/DecodeLaws.scala
+++ b/core/src/test/scala/io/finch/DecodeLaws.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import algebra.Eq
+import cats.kernel.Eq
 import cats.std.AllInstances
 import cats.laws._
 import cats.laws.discipline._

--- a/core/src/test/scala/io/finch/EncodeLaws.scala
+++ b/core/src/test/scala/io/finch/EncodeLaws.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import cats.kernel.Eq
+import cats.Eq
 import cats.laws._
 import cats.laws.discipline._
 import cats.std.AllInstances

--- a/core/src/test/scala/io/finch/EncodeLaws.scala
+++ b/core/src/test/scala/io/finch/EncodeLaws.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import algebra.Eq
+import cats.kernel.Eq
 import cats.laws._
 import cats.laws.discipline._
 import cats.std.AllInstances

--- a/core/src/test/scala/io/finch/EndpointLaws.scala
+++ b/core/src/test/scala/io/finch/EndpointLaws.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import cats.kernel.Eq
+import cats.Eq
 import cats.laws.IsEq
 import cats.std.AllInstances
 import cats.laws._

--- a/core/src/test/scala/io/finch/EndpointLaws.scala
+++ b/core/src/test/scala/io/finch/EndpointLaws.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import algebra.Eq
+import cats.kernel.Eq
 import cats.laws.IsEq
 import cats.std.AllInstances
 import cats.laws._

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import algebra.Eq
+import cats.kernel.Eq
 import cats.Alternative
 import cats.laws.discipline.eq._
 import cats.std.AllInstances

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import cats.kernel.Eq
+import cats.Eq
 import cats.Alternative
 import cats.laws.discipline.eq._
 import cats.std.AllInstances

--- a/core/src/test/scala/io/finch/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/HeaderSpec.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import algebra.Eq
+import cats.kernel.Eq
 import com.twitter.finagle.http.Request
 import org.scalacheck.Arbitrary
 

--- a/core/src/test/scala/io/finch/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/HeaderSpec.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import cats.kernel.Eq
+import cats.Eq
 import com.twitter.finagle.http.Request
 import org.scalacheck.Arbitrary
 

--- a/core/src/test/scala/io/finch/MissingInstances.scala
+++ b/core/src/test/scala/io/finch/MissingInstances.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import algebra.Eq
+import cats.kernel.Eq
 import cats.Show
 import com.twitter.io.Buf
 import com.twitter.util.{Return, Throw, Try}

--- a/core/src/test/scala/io/finch/MissingInstances.scala
+++ b/core/src/test/scala/io/finch/MissingInstances.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import java.util.UUID
 
-import cats.kernel.Eq
+import cats.Eq
 import cats.Show
 import com.twitter.io.Buf
 import com.twitter.util.{Return, Throw, Try}

--- a/core/src/test/scala/io/finch/internal/CaptureLaws.scala
+++ b/core/src/test/scala/io/finch/internal/CaptureLaws.scala
@@ -1,6 +1,6 @@
 package io.finch.internal
 
-import cats.kernel.Eq
+import cats.Eq
 import cats.std.AllInstances
 import cats.laws._
 import cats.laws.discipline._

--- a/core/src/test/scala/io/finch/internal/CaptureLaws.scala
+++ b/core/src/test/scala/io/finch/internal/CaptureLaws.scala
@@ -1,6 +1,6 @@
 package io.finch.internal
 
-import algebra.Eq
+import cats.kernel.Eq
 import cats.std.AllInstances
 import cats.laws._
 import cats.laws.discipline._


### PR DESCRIPTION
Also updated without issue were finagle and shapeless. the only actual issue encountered was the change in cats dependency on algebra. the net effect was to move Eq from algebra to cats.kernel