### PR TITLE
Add params example and clarify argument type

### DIFF
--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -169,7 +169,7 @@ Finch provides the following instances for reading HTTP params (evaluating endpo
 
 - `param("foo")` - required param "foo"
 - `paramOption("foo")` - optional param "foo"
-- `params("foos")` - multi-value param "foo" that might return an empty list
+- `params("foos")` - multi-value param "foo" that might return an empty sequence
 - `paramsNonEmpty("foos")` - multi-value param "foo" that fails when empty
 
 In addition to these evaluating endpoints, there is also one matching endpoint `paramExists("foo")`
@@ -180,6 +180,8 @@ You can extract params by composing endpoint definitions
 get("/hello" :: param("name")) { name: String => Ok(s"Hello, $name!") }
 
 get("/hello" :: paramOption("name")) { name: Option[String] => Ok(s"Hello, ${name.getOrElse("world")}!") }
+
+get("/hello" :: params("uids")) { uids: Seq[String] => Ok(s"Hello, ${uids.mkString(" and ")}!") }
 ```
 
 #### Headers


### PR DESCRIPTION
Since you have to provide types for each item in the argument tuple of the http verb method (e.g., `get`, `post`), and the error message you get when you try to use, e.g., `ids: List[String]` along with `:: params("ids")` takes a bit of scrutiny to figure out what it wants, I thought an example with the proper type would be helpful to newcomers like me.

Side question: I initially thought "multi-value param" would simply mean 'all the query parameters with that name will be aggregated and their values supplied in a single `Seq[String]`'. But it turns out finch also splits `params`-style query parameters on commas, and filters out empty strings. Which is handy in my current app, but more magical than I would have expected, and I'm not sure how I could get the pre-processed values if I wanted. Empty strings can be significant; I know of some client-side routing libraries (e.g., Angular's ui-router) that don't serialize query parameters with `null` or `undefined` values into the URL at all, but _do_ serialize `""` values as, well, empty strings. Anyways, the question was, is this behavior documented somewhere else, like maybe upstream in Finagle?