### PR TITLE
Replace FlatSpec by Suite in ServiceSuite

### DIFF
--- a/test/src/main/scala/io/finch/test/ServiceIntegrationSuite.scala
+++ b/test/src/main/scala/io/finch/test/ServiceIntegrationSuite.scala
@@ -3,13 +3,12 @@ package io.finch.test
 import com.twitter.finagle.{Http, ListeningServer, Service}
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.Await
-import org.scalatest.Outcome
-import org.scalatest.fixture.FlatSpec
+import org.scalatest.{fixture, Outcome}
 
 /**
  * Extends [[ServiceSuite]] to support integration testing for services.
  */
-trait ServiceIntegrationSuite extends ServiceSuite { self: FlatSpec =>
+trait ServiceIntegrationSuite extends ServiceSuite { self: fixture.Suite =>
 
   /**
    * Override in implementing classes if a different port is desired for
@@ -23,8 +22,8 @@ trait ServiceIntegrationSuite extends ServiceSuite { self: FlatSpec =>
    */
   override def withFixture(test: OneArgTest): Outcome = {
     val service: Service[Request, Response] = createService()
-    var server: ListeningServer = Http.serve(s":$port", service)
-    var client: Service[Request, Response] = Http.newService(s"127.0.0.1:$port")
+    val server: ListeningServer = Http.serve(s":$port", service)
+    val client: Service[Request, Response] = Http.newService(s"127.0.0.1:$port")
 
     try {
       self.withFixture(test.toNoArgTest(FixtureParam(client)))

--- a/test/src/main/scala/io/finch/test/ServiceSuite.scala
+++ b/test/src/main/scala/io/finch/test/ServiceSuite.scala
@@ -3,15 +3,15 @@ package io.finch.test
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util.{Await, Duration}
-import org.scalatest.Outcome
-import org.scalatest.fixture.FlatSpec
+import org.scalatest.{fixture, Outcome}
 
 /**
  * A convenience class that is designed to make it easier to test HTTP services
  * both directly and in integration tests that are served locally. Implementing
- * classes must extend [[org.scalatest.fixture.FlatSpec]].
+ * classes must extend [[org.scalatest.fixture.Suite]] through [[org.scalatest.fixture.FlatSpec]]
+ * for example.
  */
-trait ServiceSuite { self: FlatSpec =>
+trait ServiceSuite { self: fixture.Suite =>
 
   /**
    * Create an instance of the service to be tested.


### PR DESCRIPTION
This PR replaces the self type annotation `FlatSpec` by `Suite` in `ServiceSuite` and `ServiceIntegrationSuite` so those can be mixed in with any scalatest specs (`WordSpec`, `FlatSpec`, etc).