### PR TITLE
Encoding with charset

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
@@ -1,8 +1,8 @@
 package io.finch.argonaut
 
 import argonaut.{EncodeJson, PrettyParams}
-import com.twitter.io.Buf
 import io.finch.Encode
+import io.finch.internal.BufText
 
 trait Encoders {
 
@@ -11,6 +11,6 @@ trait Encoders {
   /**
    * Maps Argonaut's [[EncodeJson]] to Finch's [[Encode]].
    */
-  implicit def encodeArgonaut[A](implicit e: EncodeJson[A]): Encode.ApplicationJson[A] =
-    Encode.json(a => Buf.Utf8(printer.pretty(e.encode(a))))
+  implicit def encodeArgonaut[A](implicit e: EncodeJson[A]): Encode.Json[A] =
+    Encode.json((a, cs) => BufText(printer.pretty(e.encode(a)), cs))
 }

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -1,8 +1,8 @@
 package io.finch.circe
 
-import com.twitter.io.Buf
 import io.circe.{Encoder, Json}
 import io.finch.Encode
+import io.finch.internal.BufText
 
 trait Encoders {
 
@@ -11,6 +11,6 @@ trait Encoders {
   /**
    * Maps Circe's [[Encoder]] to Finch's [[Encode]].
    */
-  implicit def encodeCirce[A](implicit e: Encoder[A]): Encode.ApplicationJson[A] =
-    Encode.json(a => Buf.Utf8(print(e(a))))
+  implicit def encodeCirce[A](implicit e: Encoder[A]): Encode.Json[A] =
+    Encode.json((a, cs) => BufText(print(e(a)), cs))
 }

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -1,5 +1,9 @@
 package io.finch
 
+import com.twitter.io.{Buf, Charsets}
+import java.nio.CharBuffer
+import java.nio.charset.Charset
+
 /**
  * This package contains an internal-use only type-classes and utilities that power Finch's API.
  *
@@ -84,5 +88,20 @@ package object internal {
     def tooLong: Option[Long] =
       if (s.length == 0 || s.length > 32) None
       else parseLong(s, Long.MinValue, Long.MaxValue)
+  }
+
+  // TODO: Move to twitter/util
+  object BufText {
+    def apply(s: String, cs: Charset): Buf =  {
+      val enc = Charsets.encoder(cs)
+      val cb = CharBuffer.wrap(s.toCharArray)
+      Buf.ByteBuffer.Owned(enc.encode(cb))
+    }
+
+    def extract(buf: Buf, cs: Charset): String = {
+      val dec = Charsets.decoder(cs)
+      val bb = Buf.ByteBuffer.Owned.extract(buf).asReadOnlyBuffer
+      dec.decode(bb).toString
+    }
   }
 }

--- a/core/src/test/scala/io/finch/EncodeLaws.scala
+++ b/core/src/test/scala/io/finch/EncodeLaws.scala
@@ -4,17 +4,16 @@ import cats.Eq
 import cats.laws._
 import cats.laws.discipline._
 import cats.std.AllInstances
-import com.twitter.io.Buf
-import org.scalacheck.{Prop, Arbitrary}
+import com.twitter.io.{Buf, Charsets}
+import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
-import shapeless.Witness
 
 trait EncodeLaws[A, CT <: String] extends Laws with MissingInstances with AllInstances {
 
   def encode: Encode.Aux[A, CT]
 
   def roundTrip(a: A): IsEq[Buf] =
-    encode(a) <-> Buf.Utf8(a.toString)
+    encode(a, Charsets.Utf8) <-> Buf.Utf8(a.toString)
 
   def all(implicit A: Arbitrary[A], eq: Eq[A]): RuleSet = new DefaultRuleSet(
     name = "all",
@@ -24,8 +23,8 @@ trait EncodeLaws[A, CT <: String] extends Laws with MissingInstances with AllIns
 }
 
 object EncodeLaws {
-  def textPlain[A: Encode.TextPlain]: EncodeLaws[A, Witness.`"text/plain"`.T] =
-    new EncodeLaws[A, Witness.`"text/plain"`.T] {
-      val encode: Encode.Aux[A, Witness.`"text/plain"`.T] = implicitly[Encode.TextPlain[A]]
+  def textPlain[A: Encode.Text]: EncodeLaws[A, Text.Plain] =
+    new EncodeLaws[A, Text.Plain] {
+      val encode: Encode.Aux[A, Text.Plain] = implicitly[Encode.Text[A]]
     }
 }

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -1,19 +1,19 @@
 package io.finch
 
+import scala.collection.JavaConverters._
 import java.util.UUID
-
-import cats.Eq
+import java.nio.charset.Charset
 import cats.Alternative
-import cats.laws.discipline.eq._
+import cats.Eq
 import cats.std.AllInstances
 import com.twitter.finagle.http._
-import com.twitter.io.Buf
+import com.twitter.io.{Buf, Charsets}
 import com.twitter.util.{Await, Future, Try}
 import io.catbird.util.Rerunnable
 import io.finch.Endpoint.Result
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.Checkers
-import org.scalatest.{Matchers, FlatSpec}
 import org.typelevel.discipline.Laws
 
 trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
@@ -79,8 +79,13 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
     Status.NotExtended, Status.NetworkAuthenticationRequired
   )
 
+  def genCharset: Gen[Charset] = Gen.oneOf(
+    Charsets.UsAscii, Charsets.Utf8, Charsets.Utf16BE,
+    Charsets.Utf16, Charsets.Iso8859_1, Charsets.Utf16LE
+  )
+
   def genOutputMeta: Gen[Output.Meta] =
-    genStatus.map(s => Output.Meta(s, Map.empty[String, String], Seq.empty[Cookie]))
+    genStatus.map(s => Output.Meta(s, Option.empty, Map.empty[String, String], Seq.empty[Cookie]))
 
   def genEmptyOutput: Gen[Output.Empty] = for {
     m <- genOutputMeta
@@ -204,6 +209,8 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
   implicit def arbitraryCookies: Arbitrary[Cookies] = Arbitrary(genCookies)
 
   implicit def arbitraryParams: Arbitrary[Params] = Arbitrary(genParams)
+
+  implicit def arbitraryCharset: Arbitrary[Charset] = Arbitrary(genCharset)
 
   implicit def arbitraryOptionalNonEmptyString: Arbitrary[OptionalNonEmptyString] =
     Arbitrary(genOptionalNonEmptyString)

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -3,9 +3,9 @@ package io.finch.eval
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.Http
-import com.twitter.io.Buf
 import com.twitter.util.{Await, Eval}
 import io.finch._
+import io.finch.internal.BufText
 import io.finch.jackson._
 
 /**
@@ -29,8 +29,8 @@ object Main extends App {
 
   implicit val objectMapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
 
-  implicit val ee: Encode.ApplicationJson[Exception] = Encode.json(e =>
-    Buf.Utf8(objectMapper.writeValueAsString(Map("error" -> e.getMessage)))
+  implicit val ee: Encode.Json[Exception] = Encode.json((e, cs) =>
+    BufText(objectMapper.writeValueAsString(Map("error" -> e.getMessage)), cs)
   )
 
   case class Input(expression: String)

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -3,8 +3,8 @@ package io.finch
 import scala.reflect.ClassTag
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.twitter.io.Buf
 import com.twitter.util.Try
+import io.finch.internal.BufText
 
 package object jackson {
 
@@ -14,6 +14,6 @@ package object jackson {
     Try(mapper.readValue(s, ct.runtimeClass.asInstanceOf[Class[A]]))
   )
 
-  implicit def encodeJackson[A](implicit mapper: ObjectMapper): Encode.ApplicationJson[A] =
-    Encode.json(a => Buf.Utf8(mapper.writeValueAsString(a)))
+  implicit def encodeJackson[A](implicit mapper: ObjectMapper): Encode.Json[A] =
+    Encode.json((a, cs) => BufText(mapper.writeValueAsString(a), cs))
 }

--- a/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
+++ b/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
@@ -3,6 +3,7 @@ package io.finch.test.json
 import argonaut.{CodecJson, DecodeJson, EncodeJson, Parse}
 import argonaut.Argonaut.{casecodec3, casecodec5}
 import com.twitter.io.Buf.Utf8
+import com.twitter.io.Charsets
 import com.twitter.util.Return
 import io.finch.{Decode, Encode}
 import org.scalacheck.Arbitrary
@@ -53,9 +54,10 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
   /**
    * Confirm that this encoder can encode instances of our case class.
    */
-  def encodeNestedCaseClass(implicit ee: Encode.ApplicationJson[ExampleNestedCaseClass]): Unit =
+  def encodeNestedCaseClass(implicit ee: Encode.Json[ExampleNestedCaseClass]): Unit =
     check { (e: ExampleNestedCaseClass) =>
-      Parse.decodeOption(Utf8.unapply(ee(e)).get)(exampleNestedCaseClassCodecJson) === Some(e)
+      Parse.decodeOption(Utf8.unapply(ee(e, Charsets.Utf8)).get)(exampleNestedCaseClassCodecJson) ===
+        Some(e)
     }
 
   /**
@@ -83,9 +85,11 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
   /**
    * Confirm that this encoder can encode top-level lists of instances of our case class.
    */
-  def encodeCaseClassList(implicit encoder: Encode[List[ExampleNestedCaseClass]]): Unit =
+  def encodeCaseClassList(implicit encoder: Encode.Json[List[ExampleNestedCaseClass]]): Unit =
     check { (es: List[ExampleNestedCaseClass]) =>
-      Parse.decodeOption(Utf8.unapply(encoder(es)).getOrElse(""))(exampleNestedCaseClassListCodecJson) === Some(es)
+      Parse
+        .decodeOption(Utf8.unapply(encoder(es, Charsets.Utf8))
+        .getOrElse(""))(exampleNestedCaseClassListCodecJson) === Some(es)
     }
 
   /**
@@ -99,7 +103,7 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
   /**
    * Confirm that this encoder has the correct content type.
    */
-  def checkContentType(implicit ee: Encode.ApplicationJson[ExampleNestedCaseClass]): Unit = ()
+  def checkContentType(implicit ee: Encode.Json[ExampleNestedCaseClass]): Unit = ()
 }
 
 /**

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -1,7 +1,7 @@
 package io.finch
 
-import com.twitter.io.Buf
 import com.twitter.util.Try
+import io.finch.internal.BufText
 import org.json4s._
 import org.json4s.jackson.JsonMethods
 import org.json4s.jackson.Serialization._
@@ -20,6 +20,6 @@ package object json4s {
    * @tparam A the type of data to encode
    * @return
    */
-  implicit def encodeJson[A <: AnyRef](implicit formats: Formats): Encode.ApplicationJson[A] =
-    Encode.json(a => Buf.Utf8(write(a)))
+  implicit def encodeJson[A <: AnyRef](implicit formats: Formats): Encode.Json[A] =
+    Encode.json((a, cs) => BufText(write(a), cs))
 }

--- a/playjson/src/main/scala/io/finch/playjson/package.scala
+++ b/playjson/src/main/scala/io/finch/playjson/package.scala
@@ -1,7 +1,7 @@
 package io.finch
 
-import com.twitter.io.Buf
 import com.twitter.util.Try
+import io.finch.internal.BufText
 import play.api.libs.json._
 
 package object playjson {
@@ -17,6 +17,6 @@ package object playjson {
    * @param writes Play JSON `Writes` to use for encoding
    * @tparam A the type of the data to encode from
    */
-  implicit def encodePlayJson[A](implicit writes: Writes[A]): Encode.ApplicationJson[A] =
-    Encode.json(a => Buf.Utf8(Json.stringify(Json.toJson(a))))
+  implicit def encodePlayJson[A](implicit writes: Writes[A]): Encode.Json[A] =
+    Encode.json((a, cs) => BufText(Json.stringify(Json.toJson(a)), cs))
 }

--- a/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
+++ b/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
@@ -1,7 +1,7 @@
 package io.finch
 
-import com.twitter.io.Buf
 import com.twitter.util.Try
+import io.finch.internal.BufText
 import spray.json._
 
 package object sprayjson{
@@ -11,13 +11,13 @@ package object sprayjson{
     * @tparam A the type of the data to decode into
     */
   implicit def decodeSpray[A](implicit format: JsonFormat[A]): Decode[A] = Decode.instance[A](
-    s =>Try(s.parseJson.convertTo[A])
+    s => Try(s.parseJson.convertTo[A])
   )
 
   /**
     * @param format spray-json support for convert JSON val to specific type object
     * @tparam A the type of the data to decode from
     */
-  implicit def encodeSpray[A](implicit format: JsonFormat[A]): Encode.ApplicationJson[A] =
-    Encode.json(a => Buf.Utf8(a.toJson.prettyPrint))
+  implicit def encodeSpray[A](implicit format: JsonFormat[A]): Encode.Json[A] =
+    Encode.json((a, cs) => BufText(a.toJson.prettyPrint, cs))
 }


### PR DESCRIPTION
Once we migrated to content-type-as-a-type, we eliminated the notion of charsets b/c they're a big lie. It's time to bring them back.

The current approach makes it possible to actually apply a charset to an encoder, not only store it in a header. One of the challenges I faced was to pick the default behaviour and stick with it. I decided to go with:

- UTF-8 as a default value passed to an encoder (if not set by a user), as per [rfc6657](https://tools.ietf.org/html/rfc6657)
- If no charset is set on `Output`, none is copied over to an HTTP response

I think those conventions are reasonable enough so they can serve a good foundation to build both text- and binary-based endpoints with Finch.