### PR TITLE
No charset for empty responses

### DIFF
--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -194,7 +194,11 @@ object Output {
 
       o.headers.foreach { case (k, v) => rep.headerMap.set(k, v) }
       o.cookies.foreach(rep.cookies.add)
-      o.charset.foreach(c => rep.charset = c.displayName.toLowerCase)
+      o.charset.foreach { c =>
+        if (!rep.content.isEmpty) {
+          rep.charset = c.displayName.toLowerCase
+        }
+      }
 
       rep
     }


### PR DESCRIPTION
We probably don't need to set a charset for empty responses.