### PR TITLE
Fix documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import com.twitter.finagle.Http
 
 val api: Endpoint[String] = get("hello") { Ok("Hello, World!") }
 
-Http.server.serve(":8080", api.toServiceAs[Plain.Text])
+Http.server.serve(":8080", api.toServiceAs[Text.Plain])
 ```
 
 See [examples](examples/src/main/scala/io/finch) sub-project for more complete examples.


### PR DESCRIPTION
I believe it should be `Text.Plain`  insted of `Plain.Text`.