### PR TITLE
Make Mapper accept responses

### DIFF
--- a/core/src/main/scala/io/finch/internal/Mapper.scala
+++ b/core/src/main/scala/io/finch/internal/Mapper.scala
@@ -1,5 +1,6 @@
 package io.finch.internal
 
+import com.twitter.finagle.http.Response
 import com.twitter.util.Future
 import io.finch.{Endpoint, Output}
 import shapeless.HNil
@@ -33,16 +34,22 @@ private[finch] trait LowPriorityMapperConversions {
     instance(_.mapOutput(f))
 
   /**
-    * @group LowPriorityMapper
-    */
-  implicit def mapperFromOutputFutureFunction[A, B](f: A => Output[Future[B]]): Mapper.Aux[A, B] =
-    instance(_.mapOutputAsync(f.andThen(ofb => ofb.traverse(identity))))
+   * @group LowPriorityMapper
+   */
+  implicit def mapperFromResponseFunction[A](f: A => Response): Mapper.Aux[A, Response] =
+    instance(_.mapOutput(f.andThen(r => Output.payload(r, r.status))))
 
   /**
     * @group LowPriorityMapper
     */
   implicit def mapperFromFutureOutputFunction[A, B](f: A => Future[Output[B]]): Mapper.Aux[A, B] =
     instance(_.mapOutputAsync(f))
+
+  /**
+   * @group LowPriorityMapper
+   */
+  implicit def mapperFromFutureResponseFunction[A](f: A => Future[Response]): Mapper.Aux[A, Response] =
+    instance(_.mapOutputAsync(f.andThen(fr => fr.map(r => Output.payload(r, r.status)))))
 }
 
 private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConversions {
@@ -55,6 +62,18 @@ private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConv
     ev: OB <:< Output[B]
   ): Mapper.Aux[A, B] = instance(_.mapOutput(value => ev(ftp(f)(value))))
 
+
+  /**
+   * @group HighPriorityMapper
+   */
+  implicit def mapperFromResponseHFunction[A, F, R](f: F)(implicit
+    ftp: FnToProduct.Aux[F, A => R],
+    ev: R <:< Response
+  ): Mapper.Aux[A, Response] = instance(_.mapOutput { value =>
+    val r = ev(ftp(f)(value))
+    Output.payload(r, r.status)
+  })
+
   /**
    * @group HighPriorityMapper
    */
@@ -62,26 +81,35 @@ private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConv
     instance(_.mapOutput(_ => o))
 
   /**
-    * @group HighPriorityMapper
-    */
-  implicit def mapperFromOutputFutureValue[A](o: => Output[Future[A]]): Mapper.Aux[HNil, A] =
-    instance(_.mapOutputAsync(_ => o.traverse(identity)))
+   * @group HighPriorityMapper
+   */
+  implicit def mapperFromResponseValue(r: => Response): Mapper.Aux[HNil, Response] =
+    instance(_.mapOutput(_ => Output.payload(r, r.status)))
 
   /**
     * @group HighPriorityMapper
     */
   implicit def mapperFromFutureOutputValue[A](o: => Future[Output[A]]): Mapper.Aux[HNil, A] =
     instance(_.mapOutputAsync(_ => o))
+
+  /**
+   * @group HighPriorityMapper
+   */
+  implicit def mapperFromFutureResponseValue(fr: => Future[Response]): Mapper.Aux[HNil, Response] =
+    instance(_.mapOutputAsync(_ => fr.map(r => Output.payload(r, r.status))))
 }
 
 object Mapper extends HighPriorityMapperConversions {
-  implicit def mapperFromOutputFutureHFunction[A, B, F, OFB](f: F)(implicit
-     ftp: FnToProduct.Aux[F, A => OFB],
-     ev: OFB <:< Output[Future[B]]
-  ): Mapper.Aux[A, B] = instance(_.mapOutputAsync(value => ev(ftp(f)(value)).traverse(identity)))
-
   implicit def mapperFromFutureOutputHFunction[A, B, F, FOB](f: F)(implicit
     ftp: FnToProduct.Aux[F, A => FOB],
     ev: FOB <:< Future[Output[B]]
   ): Mapper.Aux[A, B] = instance(_.mapOutputAsync(value => ev(ftp(f)(value))))
+
+  implicit def mapperFromFutureResponseHFunction[A, F, FR](f: F)(implicit
+    ftp: FnToProduct.Aux[F, A => FR],
+    ev: FR <:< Future[Response]
+  ): Mapper.Aux[A, Response] = instance(_.mapOutputAsync { value =>
+    val fr = ev(ftp(f)(value))
+    fr.map(r => Output.payload(r, r.status))
+  })
 }

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -217,7 +217,7 @@ class EndpointSpec extends FinchSpec {
 
   it should "rescue the exception occurred in it" in {
     check { (i: Input, s: String, e: Exception) =>
-      Endpoint(Ok(Future.exception(e)))
+      Endpoint(Future.exception(e).map(Ok))
         .handle({ case _ => Created(s) })(i)
         .output === Some(Created(s))
     }

--- a/examples/src/main/scala/io/finch/streaming/Main.scala
+++ b/examples/src/main/scala/io/finch/streaming/Main.scala
@@ -44,7 +44,7 @@ object Main extends App {
   //
   // For example, if input stream is `1, 2, 3` then output response would be `6`.
   val totalSum: Endpoint[Long] = post("totalSum" :: asyncBody) { as: AsyncStream[Buf] =>
-    Ok(as.foldLeft(0L)((acc, b) => acc + bufToLong(b)))
+    as.foldLeft(0L)((acc, b) => acc + bufToLong(b)).map(Ok)
   }
 
   // This endpoint takes a simple request with an integer number N and returns a


### PR DESCRIPTION
I was thinking about proving means that make it easier to return `Response`s from `Endpoint` since it's now an essential way of dealing with multiple content-types. Even though on the long run we have to fix that particular problem and allow multiple content-types, but this doesn't mean there is nothing's left uncovered. So I thought maybe having an established approach from the beginning is a good idea.

This PR makes `Mapper` accept `Response` so it's just less confusing to return that from an `Endpoint`.  Basically, instead of

```scala
val e = get("users" :: string) { s: String =>
  val rep = Response(Status.BadRequest)
  Future.value(BadResponse(rep))
}
```
We can write:

```scala
val e = get("users" :: string) { s: String =>
  Future.value(Response(Status.BadRequest))
}
```

Or even:

```scala
val e = get("users" :: string) { s: String =>
  Future.value(Output.payload("what", Status.BadResponse).toResponse[Text.Plain]())
}
```

The bottom line is that this patch wraps a given `Response` with `Output` automatically so it doesn't look that confusing (eg: `Ok(Ok("foo").toResponse[Text.Plain]())`).