### PR TITLE
Fix #600: Remove querystring params forced comma splitting

### DIFF
--- a/core/src/main/scala/io/finch/Endpoints.scala
+++ b/core/src/main/scala/io/finch/Endpoints.scala
@@ -272,7 +272,7 @@ trait Endpoints {
       .orElse(req.multipart.flatMap(m => m.attributes.get(param).flatMap(_.headOption)))
 
   private[this] def requestParams(params: String)(req: Request): Seq[String] =
-    req.params.getAll(params).toList.flatMap(_.split(","))
+    req.params.getAll(params).toList
 
   private[this] def requestHeader(header: String)(req: Request): Option[String] =
     req.headerMap.get(header)
@@ -349,7 +349,7 @@ trait Endpoints {
    * `Seq` may be empty) multi-value query-string param `name` from the request into a `Seq`.
    */
   def params(name: String): Endpoint[Seq[String]] =
-    option(items.ParamItem(name))(i => requestParams(name)(i).filter(_.nonEmpty))
+    option(items.ParamItem(name))(i => requestParams(name)(i))
 
   /**
    * An evaluating [[Endpoint]] that reads a required (in a meaning that a resulting `Seq` will have

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -223,6 +223,12 @@ class EndpointSpec extends FinchSpec {
     }
   }
 
+  it should "split comma separated param values" in {
+    val i = Input(Request("/index?foo=a,b"))
+    val e = params("foo")
+    e(i).value shouldBe Some(Seq("a", "b"))
+  }
+
   it should "throw NotPresent if an item is not found" in {
     val i = Input(Request())
 

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -223,10 +223,10 @@ class EndpointSpec extends FinchSpec {
     }
   }
 
-  it should "split comma separated param values" in {
+  it should "not split comma separated param values" in {
     val i = Input(Request("/index?foo=a,b"))
     val e = params("foo")
-    e(i).value shouldBe Some(Seq("a", "b"))
+    e(i).value shouldBe Some(Seq("a,b"))
   }
 
   it should "throw NotPresent if an item is not found" in {


### PR DESCRIPTION
Two commits:
* 590300f to establish previous behavior
* 0f92071 to fix it and test new behavior

I wasn't sure if there was any logic to the order of `it should ...`'s in `EndpointSpec.scala`, so I just put the new test near the other param/params test.