### PR TITLE
Use new Input API internally

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
@@ -1,6 +1,5 @@
 package io.finch.benchmarks
 
-import com.twitter.finagle.http.Request
 import com.twitter.io.Buf
 import io.finch._
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
@@ -8,14 +7,7 @@ import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 @State(Scope.Benchmark)
 class BodyBenchmark extends FinchBenchmark {
 
-  val input = {
-    val r = Request()
-    val content = Buf.Utf8("x" * 1024)
-    r.content = content
-    r.contentLength = content.length.toLong
-
-    Input(r)
-  }
+  val input = Input.post("/").withBody(Buf.Utf8("x" * 1024))
 
   @Benchmark
   def stringOption: Option[String] = bodyOption(input).value.get

--- a/benchmarks/src/main/scala/io/finch/benchmarks/EndpointBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/EndpointBenchmark.scala
@@ -1,6 +1,5 @@
 package io.finch.benchmarks
 
-import com.twitter.finagle.http.Request
 import com.twitter.util.Try
 import io.finch._
 import org.openjdk.jmh.annotations._
@@ -52,21 +51,21 @@ trait FooEndpointsAndRequests {
 
   val derivedFooReader: Endpoint[Foo] = Endpoint.derive[Foo].fromParams
 
-  val goodFooRequest: Input = Input(Request(
+  val goodFooRequest: Input = Input.get("/",
     "s" -> "Man hands on misery to man. It deepens like a coastal shelf.",
     "d" -> "0.234567",
     "i" -> "123456",
     "l" -> "1234567890",
     "b" -> "true"
-  ))
+  )
 
-  val badFooRequest: Input = Input(Request(
+  val badFooRequest: Input = Input.get("/",
     "s" -> "Man hands on misery to man. It deepens like a coastal shelf.",
     "d" -> "0.23h4567",
     "i" -> "123456",
     "l" -> "1234567890x",
     "b" -> "true"
-  ))
+  )
 
   val goodFooResult: Foo = Foo(
     "Man hands on misery to man. It deepens like a coastal shelf.",

--- a/benchmarks/src/main/scala/io/finch/benchmarks/ExtractorBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/ExtractorBenchmark.scala
@@ -1,16 +1,15 @@
 package io.finch.benchmarks
 
-import com.twitter.finagle.http.Request
 import io.finch._
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
 class ExtractorBenchmark extends FinchBenchmark {
 
-  val empty: Input = Input(Request())
-  val fooBarBaz: Input = Input(Request("/foo/bar/baz"))
-  val tenTwenty: Input = Input(Request("/10/20"))
-  val trueFalse: Input = Input(Request("/true/false"))
+  val empty: Input = Input.get("/")
+  val fooBarBaz: Input = Input.get("/foo/bar/baz")
+  val tenTwenty: Input = Input.get("/10/20")
+  val trueFalse: Input = Input.get("/true/false")
 
   @Benchmark
   def stringSome: Option[String] = string(fooBarBaz).value

--- a/benchmarks/src/main/scala/io/finch/benchmarks/MatcherBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/MatcherBenchmark.scala
@@ -1,6 +1,5 @@
 package io.finch.benchmarks
 
-import com.twitter.finagle.http.Request
 import io.finch._
 import org.openjdk.jmh.annotations._
 import shapeless.HNil
@@ -8,8 +7,8 @@ import shapeless.HNil
 @State(Scope.Benchmark)
 class MatcherBenchmark extends FinchBenchmark {
 
-  val empty: Input = Input(Request())
-  val fooBarBaz: Input = Input(Request("/foo/bar/baz"))
+  val empty: Input = Input.get("/")
+  val fooBarBaz: Input = Input.get("/foo/bar/baz")
 
   val foo: Endpoint0 = "foo"
 

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -4,7 +4,6 @@ import scala.reflect.ClassTag
 
 import cats.Alternative
 import cats.data.NonEmptyList
-import cats.instances.list._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Cookie, Request, Response, Status}
 import com.twitter.util.{Future, Return, Throw, Try}
@@ -286,7 +285,7 @@ trait Endpoint[A] { self =>
 
     private[this] val safeEndpoint = self.handle(basicEndpointHandler)
 
-    def apply(req: Request): Future[Response] = safeEndpoint(Input(req)) match {
+    def apply(req: Request): Future[Response] = safeEndpoint(Input.request(req)) match {
       case Some((remainder, output)) if remainder.isEmpty =>
         output.map(oa => oa.toResponse[CT](req.version)).run
       case _ => Future.value(Response(req.version, Status.NotFound))

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -1,10 +1,11 @@
 package io.finch
 
-import java.nio.charset.Charset
-
 import cats.Eq
-import com.twitter.finagle.http.{Method, Request, RequestBuilder}
-import com.twitter.io.Buf
+import com.twitter.finagle.http.{MediaType, Method, Request}
+import com.twitter.finagle.netty3.ChannelBufferBuf
+import com.twitter.io.{Buf, ConcatBuf}
+import org.jboss.netty.handler.codec.http.{DefaultHttpRequest, HttpMethod, HttpRequest, HttpVersion}
+import org.jboss.netty.handler.codec.http.multipart.{DefaultHttpDataFactory, HttpPostRequestEncoder}
 
 /**
  * An input for [[Endpoint]].
@@ -14,30 +15,60 @@ final case class Input(request: Request, path: Seq[String]) {
   def drop(n: Int): Input = copy(path = path.drop(n))
   def isEmpty: Boolean = path.isEmpty
 
-  def withBody(buf: Buf, charset: Option[Charset] = None): Input = {
+  /**
+   * Overrides (mutates) the payload (`buf` and `contentType`) of this input and
+   * returns `this`.
+   *
+   * @note The `contentType` value is passed as an HTTP header so it might also
+   *       contain a charset separated by `;`.
+   */
+  def withBody(buf: Buf, contentType: Option[String] = None): Input = {
     request.content = buf
+
     request.contentLength = buf.length.toLong
-    charset.foreach(cs => request.charset = charset.get.displayName())
+    contentType.foreach(ct => request.contentType = ct)
+
     this
   }
 
+  /**
+   * Adds (mutates) new `headers` to this input and returns `this`.
+   */
   def withHeaders(headers: (String, String)*): Input = {
     headers.foreach { case (k, v) => request.headerMap.set(k, v) }
     this
   }
 
+  /**
+   * Overrides (mutates) the payload of this input to be `application/x-www-form-urlencoded`.
+   *
+   * @note In addition to media type, this will also set charset to UTF-8.
+   */
   def withForm(params: (String, String)*): Input = {
-    require(request.host.isDefined, "The host has to be defined")
-    require(params.nonEmpty, "Cannot create request without params")
-    val req = RequestBuilder()
-      .addFormElement(params: _*)
-      .url(request.host.get)
-      .buildFormPost()
-    request.method = req.method
-    request.content = req.content
-    req.contentLength.foreach(cl => request.contentLength = req.contentLength.get)
-    req.charset.foreach(cs => request.charset = req.charset.get)
-    this
+    // TODO: Figure out way to do that w/o Netty.
+    val dataFactory = new DefaultHttpDataFactory(false) // we don't use disk
+    val encoder = new HttpPostRequestEncoder(
+      dataFactory,
+      new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, request.path),
+      false
+    )
+
+    params.foreach {
+      case (k, v) => encoder.addBodyAttribute(k, v)
+    }
+
+    val req = encoder.finalizeRequest()
+
+    val content = if (req.isChunked) {
+      ConcatBuf(
+        Iterator.continually(encoder.nextChunk())
+        .takeWhile(c => !c.isLast)
+        .map(c => ChannelBufferBuf.Owned(c.getContent))
+        .toVector
+      )
+    } else ChannelBufferBuf.Owned(req.getContent)
+
+    withBody(content, Some(MediaType.WwwForm + ";charset=utf-8"))
   }
 }
 
@@ -45,25 +76,40 @@ final case class Input(request: Request, path: Seq[String]) {
  * Creates an input for [[Endpoint]] from [[Request]].
  */
 object Input {
-  def apply(req: Request): Input = Input(req, req.path.split("/").toList.drop(1))
 
   implicit val inputEq: Eq[Input] = Eq.fromUniversalEquals
 
-  def get(path: String, params: (String, String)*): Input = Input(Request(path, params: _*))
-  def put(path: String, params: (String, String)*): Input = {
-    val req = Request(path, params: _*)
-    req.method = Method.Put
-    Input(req)
-  }
-  def patch(path: String, params: (String, String)*): Input = {
-    val req = Request(path, params: _*)
-    req.method = Method.Patch
-    Input(req)
-  }
-  def delete(path: String, params: (String, String)*): Input = {
-    val req = Request(path, params: _*)
-    req.method = Method.Patch
-    Input(req)
-  }
-  def post(path: String): Input = Input(Request(Method.Post, path))
+  /**
+   * Creates an [[Input]] from a given [[Request]].
+   */
+  def request(req: Request): Input = Input(req, req.path.split("/").toList.drop(1))
+
+  /**
+   * Creates a `GET` input with a given query string (represented as `params`).
+   */
+  def get(path: String, params: (String, String)*): Input =
+    request(Request(Method.Get, Request.queryString(path, params: _*)))
+
+  /**
+   * Creates a `PUT` input with a given query string (represented as `params`).
+   */
+  def put(path: String, params: (String, String)*): Input =
+    request(Request(Method.Put, Request.queryString(path, params: _*)))
+
+  /**
+   * Creates a `PATCH` input with a given query string (represented as `params`).
+   */
+  def patch(path: String, params: (String, String)*): Input =
+    request(Request(Method.Patch, Request.queryString(path, params: _*)))
+
+  /**
+   * Creates a `DELETE` input with a given query string (represented as `params`).
+   */
+  def delete(path: String, params: (String, String)*): Input =
+    request(Request(Method.Delete, Request.queryString(path, params: _*)))
+
+  /**
+   * Creates a `POST` input with empty payload.
+   */
+  def post(path: String): Input = request(Request(Method.Post, path))
 }

--- a/core/src/test/scala/io/finch/BasicAuthSpec.scala
+++ b/core/src/test/scala/io/finch/BasicAuthSpec.scala
@@ -25,7 +25,7 @@ class BasicAuthSpec extends FinchSpec {
       req.authorization = encode(c.user, c.pass)
 
       val e = BasicAuth(realm)((u, p) => Future(u == c.user && p == c.pass))(Endpoint(Ok("foo")))
-      val i = Input(req)
+      val i = Input.request(req)
 
       e(i).output === Some(Ok("foo")) && {
         req.authorization = "secret"
@@ -37,18 +37,18 @@ class BasicAuthSpec extends FinchSpec {
   it should "reach the unprotected endpoint" in {
     val e = BasicAuth("realm")((_, _) => Future.False)("a") :+: ("b" :: Endpoint(Ok("foo")))
 
-    val protectedInput = Input(Request("/a"))
+    val protectedInput = Input.get("/a")
     e(protectedInput).remainder shouldBe Some(protectedInput.drop(1))
     e(protectedInput).output shouldBe Some(unauthorized("realm"))
 
-    val unprotectedInput = Input(Request("/b"))
+    val unprotectedInput = Input.get("/b")
     e(unprotectedInput).remainder shouldBe Some(unprotectedInput.drop(1))
     e(unprotectedInput).output.map(_.status) shouldBe Some(Status.Ok)
 
-    val notFound = Input(Request("/c"))
+    val notFound = Input.get("/c")
     e(notFound).remainder shouldBe None // 404
 
-    val notFoundPartialMatch = Input(Request("/a/b"))
+    val notFoundPartialMatch = Input.get("/a/b")
     e(notFoundPartialMatch).remainder shouldBe Some(notFoundPartialMatch.drop(1)) // 404
   }
 }

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -2,21 +2,13 @@ package io.finch
 
 import java.util.UUID
 
-import com.twitter.finagle.http.Request
 import com.twitter.io.Buf
 
 class BodySpec extends FinchSpec {
 
   behavior of "param*"
 
-  def withBody(b: String): Input = Input {
-    val req = Request()
-    val buf = Buf.Utf8(b)
-    req.content = buf
-    req.headerMap.put("Content-Length", buf.length.toString)
-
-    req
-  }
+  def withBody(b: String): Input = Input.post("/").withBody(Buf.Utf8(b))
 
   checkAll("Body[String]", EndpointLaws[String](bodyOption)(withBody).evaluating)
   checkAll("Body[Int]", EndpointLaws[Int](bodyOption)(withBody).evaluating)

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import cats.Applicative
 import cats.laws.discipline.AlternativeTests
-import com.twitter.finagle.http.{Request, Method, Cookie}
+import com.twitter.finagle.http.{Method, Cookie}
 import com.twitter.util.{Throw, Try, Future}
 
 class EndpointSpec extends FinchSpec {
@@ -224,13 +224,13 @@ class EndpointSpec extends FinchSpec {
   }
 
   it should "not split comma separated param values" in {
-    val i = Input(Request("/index?foo=a,b"))
+    val i = Input.get("/index", "foo" -> "a,b")
     val e = params("foo")
     e(i).value shouldBe Some(Seq("a,b"))
   }
 
   it should "throw NotPresent if an item is not found" in {
-    val i = Input(Request())
+    val i = Input.get("/")
 
     Seq(
       param("foo"), header("foo"), body, cookie("foo").map(_.value),

--- a/core/src/test/scala/io/finch/HeaderSpec.scala
+++ b/core/src/test/scala/io/finch/HeaderSpec.scala
@@ -3,19 +3,13 @@ package io.finch
 import java.util.UUID
 
 import cats.Eq
-import com.twitter.finagle.http.Request
 import org.scalacheck.Arbitrary
 
 class HeaderSpec extends FinchSpec {
 
   behavior of "header*"
 
-  def withHeader(k: String)(v: String): Input = Input {
-    val req = Request()
-    req.headerMap.put(k, v)
-
-    req
-  }
+  def withHeader(k: String)(v: String): Input = Input.get("/").withHeaders(k -> v)
 
   checkAll("Header[String]",
     EndpointLaws[String](headerOption("x"))(withHeader("x"))

--- a/core/src/test/scala/io/finch/InputSpec.scala
+++ b/core/src/test/scala/io/finch/InputSpec.scala
@@ -1,39 +1,38 @@
 package io.finch
 
-import java.nio.charset.Charset
-
 import com.twitter.finagle.http.Method
 import com.twitter.io.Buf
-import org.scalacheck.Prop
-import org.scalacheck.Prop.forAll
 
 class InputSpec extends FinchSpec {
 
   behavior of "Input"
 
   it should "properly construct Inputs using factories with params for the different methods" in {
+
     def validateInput(
-        input: Input, method: Method, segments: Seq[String], params: Map[String, String]): Prop = {
-      input.request.method === method
-      input.request.path === (segments mkString "/")
-      input.request.params === params
+      input: Input,
+      method: Method,
+      segments: Seq[String],
+      params: Map[String, String]
+    ): Boolean =
+      input.request.method === method &&
+      input.request.path === "/" + segments.mkString("/") &&
+      input.request.params === params &&
       input.path === segments
-    }
-    check { ps: Params =>
-      forAll(genPath) { p: String =>
-        val segments = p.split("/").toList.drop(1)
-        validateInput(Input.get(p, ps.p.toSeq: _*), Method.Get, segments, ps.p)
-        validateInput(Input.put(p, ps.p.toSeq: _*), Method.Put, segments, ps.p)
-        validateInput(Input.patch(p, ps.p.toSeq: _*), Method.Patch, segments, ps.p)
-        validateInput(Input.delete(p, ps.p.toSeq: _*), Method.Delete, segments, ps.p)
-      }
+
+    check { (ps: Params, p: Path) =>
+      val segments = p.p.split("/").toList.drop(1)
+
+      validateInput(Input.get(p.p, ps.p.toSeq: _*), Method.Get, segments, ps.p)
+      validateInput(Input.put(p.p, ps.p.toSeq: _*), Method.Put, segments, ps.p)
+      validateInput(Input.patch(p.p, ps.p.toSeq: _*), Method.Patch, segments, ps.p)
+      validateInput(Input.delete(p.p, ps.p.toSeq: _*), Method.Delete, segments, ps.p)
     }
   }
 
-  it should "add content through withContent" in {
-    check { (i: Input, b: Buf, cs: Charset) =>
+  it should "add content through withBody" in {
+    check { (i: Input, b: Buf) =>
       i.withBody(b).request.content === b
-      i.withBody(b, Some(cs)).request.content === b
     }
   }
 
@@ -49,14 +48,11 @@ class InputSpec extends FinchSpec {
 
   it should "add form elements through withForm" in {
     check { (i: Input, ps: Params) =>
-      intercept[IllegalArgumentException](i.withForm(ps.p.toSeq: _*))
-      i.request.host = "http://www.google.com"
-      if (ps.p.isEmpty) {
-        intercept[IllegalArgumentException](i.withForm(ps.p.toSeq: _*))
-        true
-      } else {
+      ps.p.isEmpty || {
         val input = i.withForm(ps.p.toSeq: _*)
-        ps.p.forall { case (k, v) => input.request.contentString.contains(s"$k=$v") }
+        val contentString = input.request.contentString
+        ps.p.forall { case (k, v) => contentString.contains(s"$k=$v") } &&
+        input.request.contentType === Some("application/x-www-form-urlencoded;charset=utf-8")
       }
     }
   }

--- a/core/src/test/scala/io/finch/ParamSpec.scala
+++ b/core/src/test/scala/io/finch/ParamSpec.scala
@@ -2,13 +2,11 @@ package io.finch
 
 import java.util.UUID
 
-import com.twitter.finagle.http.Request
-
 class ParamSpec extends FinchSpec {
 
   behavior of "param*"
 
-  def withParam(k: String)(v: String): Input = Input(Request(k -> v))
+  def withParam(k: String)(v: String): Input = Input.get("/", k -> v)
 
   checkAll("Param[String]", EndpointLaws[String](paramOption("x"))(withParam("x")).evaluating)
   checkAll("Param[Int]", EndpointLaws[Int](paramOption("x"))(withParam("x")).evaluating)

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -106,10 +106,10 @@ import io.finch._
 scala> val e: Endpoint0 = "foo"
 e: io.finch.Endpoint0 = foo
 
-scala> e(Input(Request("/foo"))).isDefined
+scala> e(Input.get("/foo")).isDefined
 res1: Boolean = true
 
-scala> e(Input(Request("/bar"))).isDefined
+scala> e(Input.get("/bar")).isDefined
 res2: Boolean = false
 ```
 
@@ -154,10 +154,10 @@ import com.twitter.finagle.http.{Request, Method}
 scala> val e = get(/)
 e: io.finch.Endpoint[shapeless.HNil] = GET /
 
-scala> e(Input(Request(Method.Post, "/"))).isDefined
+scala> e(Input.post("/")).isDefined
 res1: Boolean = false
 
-scala> e(Input(Request(Method.Get, "/"))).isDefined
+scala> e(Input.get("/")).isDefined
 res2: Boolean = true
 ```
 

--- a/examples/src/main/scala/io/finch/wrk/Finagle.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finagle.scala
@@ -28,10 +28,10 @@ object Finagle extends App {
       if (req.method != Method.Post) Future.value(Response(req.version, Status.NotFound))
       else {
         val payloadIn = mapper.readValue(req.contentString, classOf[Payload])
-        val payloadOut = mapper.writeValueAsString(payloadIn)
+        val payloadOut = mapper.writeValueAsBytes(payloadIn)
 
         val rep = Response(req.version, Status.Ok)
-        rep.content =  Buf.Utf8(payloadOut)
+        rep.content =  Buf.ByteArray.Owned(payloadOut)
         rep.contentType = "application/json"
 
         Future.value(rep)

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -1,6 +1,6 @@
 package io.finch.oauth2
 
-import com.twitter.finagle.http.{Status, Request}
+import com.twitter.finagle.http.Status
 import com.twitter.finagle.oauth2._
 import com.twitter.util.Future
 import org.scalatest.mock.MockitoSugar
@@ -28,8 +28,8 @@ class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar 
       Ok(ai.user)
     }
 
-    val i1 = Input(Request("/user", "access_token" -> "bar"))
-    val i2 = Input(Request("/user"))
+    val i1 = Input.get("/user", "access_token" -> "bar")
+    val i2 = Input.get("/user")
 
     e(i1).output shouldBe Some(Ok(42))
     val Some(error) = e(i2).output
@@ -52,10 +52,11 @@ class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar 
       Ok(ghr.accessToken)
     }
 
-    val i1 = Input(Request("/token",
+    val i1 = Input.get("/token",
       "grant_type" -> "password", "username" -> "u", "password" -> "p", "client_id" -> "id"
-    ))
-    val i2 = Input(Request("/token"))
+    )
+
+    val i2 = Input.get("/token")
 
     e(i1).output shouldBe Some(Ok("foobar"))
     val Some(error) = e(i2).output


### PR DESCRIPTION
This PR makes use of an new `Input` API as well as cleans up an implementation.