### PR TITLE
Generalize Input.withBody

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
@@ -7,7 +7,7 @@ import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 @State(Scope.Benchmark)
 class BodyBenchmark extends FinchBenchmark {
 
-  val input = Input.post("/").withBody(Buf.Utf8("x" * 1024))
+  val input = Input.post("/").withBody[Text.Plain](Buf.Utf8("x" * 1024))
 
   @Benchmark
   def stringOption: Option[String] = bodyOption(input).value.get

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -8,7 +8,7 @@ class BodySpec extends FinchSpec {
 
   behavior of "param*"
 
-  def withBody(b: String): Input = Input.post("/").withBody(Buf.Utf8(b))
+  def withBody(b: String): Input = Input.post("/").withBody[Text.Plain](Buf.Utf8(b))
 
   checkAll("Body[String]", EndpointLaws[String](bodyOption)(withBody).evaluating)
   checkAll("Body[Int]", EndpointLaws[Int](bodyOption)(withBody).evaluating)

--- a/core/src/test/scala/io/finch/InputSpec.scala
+++ b/core/src/test/scala/io/finch/InputSpec.scala
@@ -35,26 +35,23 @@ class InputSpec extends FinchSpec {
 
   it should "add content through withBody" in {
     check { (i: Input, b: Buf) =>
-      i.withBody(b).request.content === b
+      i.withBody[Text.Plain](b).request.content === b
     }
   }
 
-  it should "add content corresponding to a class through withJson" in {
+  it should "add content corresponding to a class through withBody[JSON]" in {
     check { (i: Input, s: String, cs: Charset) =>
-      implicit val encode = Encode.encodeExceptionAsJson
-      val input = i.withJson(new Exception(s), Some(cs))
-      input.request.content === BufText(s"""{"message":"$s"}""", cs)
-      input.request.contentType === Some(s"application/json;charset=$cs")
+      val input = i.withBody[Application.Json](new Exception(s), Some(cs))
+
+      input.request.content === BufText(s"""{"message":"$s"}""", cs) &&
+      input.request.contentType === Some(s"application/json;charset=${cs.displayName.toLowerCase}")
     }
   }
 
   it should "add headers through withHeaders" in {
     check { (i: Input, hs: Headers) =>
       val hm = i.withHeaders(hs.m.toSeq: _*).request.headerMap
-      hs.m.forall { case (k, v) =>
-        hm.contains(k)
-        hm(k) === v
-      }
+      hs.m.forall { case (k, v) => hm.contains(k) && hm(k) === v}
     }
   }
 

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -640,7 +640,7 @@ import io.finch._
 import io.finch.circe._
 
 case class Baz(m: Map[String, String])
-val baz: Input = Input.put("/baz").withJson(Baz(Map("a" -> "b")))
+val baz: Input = Input.put("/baz").withBody[Application.Json](Baz(Map("a" -> "b")))
 ```
 
 Note that, assuming UTF-8 as the encoding, which is the default, `application/json;charset=UTF-8`

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -33,13 +33,13 @@ object Main {
     BufText(objectMapper.writeValueAsString(Map("error" -> e.getMessage)), cs)
   )
 
-  case class Input(expression: String)
-  case class Output(result: String)
+  case class EvalInput(expression: String)
+  case class EvalOutput(result: String)
 
   val execute: Eval = new Eval()
 
-  def eval: Endpoint[Output] = post("eval" :: body.as[Input]) { i: Input =>
-    Ok(Output(execute[Any](i.expression).toString))
+  def eval: Endpoint[EvalOutput] = post("eval" :: body.as[EvalInput]) { i: EvalInput =>
+    Ok(EvalOutput(execute[Any](i.expression).toString))
   } handle {
     case e: Exception => BadRequest(e)
   }

--- a/examples/src/test/scala/io/finch/eval/EvalSpec.scala
+++ b/examples/src/test/scala/io/finch/eval/EvalSpec.scala
@@ -1,32 +1,32 @@
 package io.finch.eval
 
 import com.twitter.finagle.http.Status
-import com.twitter.io.Buf
-import io.circe.generic.auto._
-import io.circe.syntax._
+import com.twitter.io.Charsets
 import io.finch._
+import io.finch.jackson._
 import org.scalatest.{FlatSpec, Matchers}
 
 class EvalSpec extends FlatSpec with Matchers {
   behavior of "the eval endpoint"
 
-  import Main.eval
+  import Main._
+
   it should "properly evaluate a well-formed expression" in {
     val result = eval(Input.post("/eval")
-      .withBody(Buf.Utf8(Main.Input("10 + 10").asJson.toString),
-        Some("application/json;charset=utf8"))).value
-    result shouldBe Some(Main.Output("20"))
+      .withBody[Application.Json](EvalInput("10 + 10"), Some(Charsets.Utf8))).value
+
+    result shouldBe Some(EvalOutput("20"))
   }
   it should "give back bad request if the expression isn't parseable" in {
     val output = eval(Input.post("/eval")
-      .withBody(Buf.Utf8(Main.Input("s = 12").asJson.toString),
-        Some("application/json;charset=utf8"))).output
+      .withBody[Application.Json](EvalInput("s = 12"), Some(Charsets.Utf8))).output
+
     output.map(_.status) shouldBe Some(Status.BadRequest)
   }
   it should "give back nothing for other verbs" in {
     val result = eval(Input.get("/eval")
-      .withBody(Buf.Utf8(Main.Input("10 + 10").asJson.toString),
-        Some("application/json;charset=utf8"))).value
+      .withBody[Application.Json](EvalInput("10 + 10"), Some(Charsets.Utf8))).value
+
     result shouldBe None
   }
 }


### PR DESCRIPTION
I figured since we have this powerful concept of content-type-as-a-type, why not to use it in `withBody` and make it generic? Basically, instead of duplicating logic in `withBody`, `withJson`, `withText`, `withXml`, `withWhatever`, we can just have one.


Before:
```scala
Input.post("/").withBody(Buf.Utf8("text"), Some("text/plain;charset=utf8"))
Input.post("/").withJson(Map("a" -> "b"), Some(Charsets.Utf8))
```

Now:

```scala
// Now:
Input.post("/").withBody[Text.Plain]("text", Some(Charsets.Utf8))
Input.post("/").withBody[Application.Json](Map("a" -> "b"), Some(Charsets.Utf8))

// We get the following for free:
import cats.instances.int._
Input.post("/").withBody[Text.Plain](42)
```

This not only looks nice but also compile-safe: there is no way to make a typo in `Application.Json` (it won't compile).

What do people think? /cc @BenFradet 