### PR TITLE
Add basic support for Server Sent Events.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,9 @@ lazy val finch = project.in(file("."))
     "io.circe" %% "circe-generic" % circeVersion,
     "io.spray" %%  "spray-json" % sprayVersion
   ))
-  .aggregate(core, argonaut, jackson, json4s, circe, playjson, sprayjson, benchmarks, test, jsonTest, oauth2, examples)
+  .aggregate(
+    core, argonaut, jackson, json4s, circe, playjson, sprayjson, benchmarks, test, jsonTest, oauth2, examples, sse
+  )
   .dependsOn(core, circe)
 
 lazy val core = project
@@ -221,6 +223,11 @@ lazy val oauth2 = project
   ))
   .dependsOn(core)
 
+lazy val sse = project
+  .settings(moduleName := "finch-sse")
+  .settings(allSettings)
+  .dependsOn(core)
+
 lazy val examples = project
   .settings(moduleName := "finch-examples")
   .settings(allSettings)
@@ -234,6 +241,7 @@ lazy val examples = project
       |io\.finch\.streaming\..*;
       |io\.finch\.oauth2\..*;
       |io\.finch\.wrk\..*;
+      |io\.finch\.sse\..*;
     """.stripMargin)
   .settings(
     libraryDependencies ++= Seq(

--- a/core/src/main/scala/io/finch/internal/ToResponse.scala
+++ b/core/src/main/scala/io/finch/internal/ToResponse.scala
@@ -38,7 +38,7 @@ trait LowPriorityToResponseInstances {
     def apply(a: A, cs: Charset): Response = fn(a, cs)
   }
 
-  protected def asyncResponseBuilder[A, CT <: String](writer: (A, Charset) => Buf)(implicit
+  protected[finch] def asyncResponseBuilder[A, CT <: String](writer: (A, Charset) => Buf)(implicit
     w: Witness.Aux[CT]
   ): Aux[AsyncStream[A], CT] = instance { (as, cs) =>
     val rep = Response()

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -39,5 +39,6 @@ package object finch extends Endpoints with Outputs with ValidationRules {
   object Text {
     type Plain = Witness.`"text/plain"`.T
     type Html = Witness.`"text/html"`.T
+    type EventStream = Witness.`"text/event-stream"`.T
   }
 }

--- a/sse/src/main/scala/io/finch/sse/ServerSentEvent.scala
+++ b/sse/src/main/scala/io/finch/sse/ServerSentEvent.scala
@@ -1,0 +1,46 @@
+package io.finch.sse
+
+import java.nio.charset.Charset
+
+import cats.Show
+import com.twitter.concurrent.AsyncStream
+import com.twitter.io.Buf
+import io.finch.{Encode, Ok, Output, Text}
+import io.finch.internal.{BufText, ToResponse}
+
+case class ServerSentEvent[A](
+  data: A,
+  id: Option[String] = None,
+  event: Option[String] = None,
+  retry: Option[Long] = None
+)
+
+object ServerSentEvent {
+
+  implicit def sseAsyncToResponse[A](implicit
+     e: Encode.Aux[A, Text.EventStream]
+  ): ToResponse.Aux[AsyncStream[A], Text.EventStream] =
+    ToResponse.asyncResponseBuilder((a, cs) => e(a, cs).concat(Buf.Utf8("\n")))
+
+  implicit def encodeEventStream[A](implicit s: Show[A]): Encode.Aux[ServerSentEvent[A], Text.EventStream] = {
+    Encode.instance[ServerSentEvent[A], Text.EventStream]({ (event: ServerSentEvent[A], c: Charset) =>
+      encodeEvent[A](event, c, { (a: A, cs: Charset) => BufText(s.show(a), cs) })
+    })
+  }
+
+  private[sse] def encodeEvent[A](sse: ServerSentEvent[A], cs: Charset, e: (A, Charset) => Buf): Buf = {
+    val dataBuf = BufText("data:", cs).concat(e(sse.data, cs)).concat(BufText("\n", cs))
+    val eventType = sse.event.map(e => s"event:$e\n").getOrElse("")
+    val id = sse.id.map(id => s"id:$id\n").getOrElse("")
+    val retry = sse.retry.map(retry => s"retry:$retry\n").getOrElse("")
+    val restBuf = BufText(eventType + id + retry, cs)
+    dataBuf.concat(restBuf)
+  }
+
+  /** By default Finch encodes an exception as a Comment */
+  implicit val encodeSseException: Encode.Aux[Exception, Text.EventStream] = {
+    Encode.instance[Exception, Text.EventStream]({ (e: Exception, c: Charset) =>
+      BufText(s":${Option(e.getMessage).getOrElse("Unknown Error")}\n", c)
+    })
+  }
+}

--- a/sse/src/test/scala/io/finch/sse/ServerSentEventSpec.scala
+++ b/sse/src/test/scala/io/finch/sse/ServerSentEventSpec.scala
@@ -1,0 +1,110 @@
+package io.finch.sse
+
+import java.nio.charset.Charset
+
+import cats.Show
+import com.twitter.concurrent.AsyncStream
+import com.twitter.io.{Charsets, ConcatBuf}
+import io.finch.internal.BufText
+import org.scalacheck.Gen.Choose
+import org.scalacheck.Prop.BooleanOperators
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.Checkers
+import org.scalatest.{FlatSpec, Matchers}
+
+class ServerSentEventSpec extends FlatSpec with Matchers with Checkers {
+  behavior of "ServerSentEvent"
+
+  import ServerSentEvent._
+
+  def dataOnlySse: Gen[ServerSentEvent[String]] = for {
+    data  <- Gen.alphaStr
+  } yield ServerSentEvent(data)
+
+  def sseWithId: Gen[ServerSentEvent[String]] = for {
+    sse <- dataOnlySse
+    id <- Gen.alphaStr
+  } yield sse.copy(id = Some(id))
+
+  def sseWithEventType: Gen[ServerSentEvent[String]] = for {
+    sse <- dataOnlySse
+    eventType <- Gen.alphaStr
+  } yield sse.copy(event = Some(eventType))
+
+  def sseWithRetry: Gen[ServerSentEvent[String]] = for {
+    sse <- dataOnlySse
+    retry <- Choose.chooseLong.choose(-1000, 1000)
+  } yield sse.copy(retry = Some(retry))
+
+  def streamDataOnlyGenerator: Gen[AsyncStream[ServerSentEvent[String]]] = for {
+    strs <- Gen.nonEmptyListOf(dataOnlySse)
+  } yield AsyncStream.fromSeq(strs)
+
+  def genCharset: Gen[Charset] = Gen.oneOf(
+    Charsets.UsAscii, Charsets.Utf8, Charsets.Utf16BE,
+    Charsets.Utf16, Charsets.Iso8859_1, Charsets.Utf16LE
+  )
+
+  implicit def arbitrarySse: Arbitrary[AsyncStream[ServerSentEvent[String]]] = Arbitrary(streamDataOnlyGenerator)
+
+  implicit def arbitraryCharset: Arbitrary[Charset] = Arbitrary(genCharset)
+
+  val encoder = encodeEventStream[String](Show.fromToString)
+
+  it should "encode the event when only 'data' is present" in {
+    implicit def arbitraryEvents: Arbitrary[ServerSentEvent[String]] = Arbitrary(dataOnlySse)
+
+    check { (event: ServerSentEvent[String], cs: Charset) =>
+      val encoded = encoder(event, cs)
+      val expected = ConcatBuf(Vector(BufText("data:", cs), BufText(event.data, cs), BufText("\n", cs)))
+      encoded === expected
+    }
+  }
+
+  it should "encode the event when an 'eventType' is present" in {
+    implicit def arbitraryEvents: Arbitrary[ServerSentEvent[String]] = Arbitrary(sseWithEventType)
+
+    check { (event: ServerSentEvent[String], cs: Charset) =>
+      (event.event.isDefined && event.id.isEmpty && event.retry.isEmpty) ==> {
+        val encoded = encoder(event, cs)
+        val actualText = BufText.extract(encoded, cs)
+        val expectedParts = ConcatBuf(Vector(
+          BufText("data:", cs), BufText(event.data, cs), BufText("\n", cs), BufText(s"event:${event.event.get}\n", cs)
+        ))
+        actualText === BufText.extract(expectedParts, cs)
+      }
+    }
+  }
+
+  it should "encode the event when an 'id' is present" in {
+    implicit def arbitraryEvents: Arbitrary[ServerSentEvent[String]] = Arbitrary(sseWithId)
+
+    check { (event: ServerSentEvent[String], cs: Charset) =>
+      val encoded = encodeEventStream[String](Show.fromToString).apply(event, cs)
+      (event.event.isEmpty && event.id.isDefined && event.retry.isEmpty) ==> {
+        val encoded = encoder(event, cs)
+        val actualText = BufText.extract(encoded, cs)
+        val expectedParts = ConcatBuf(Vector(
+          BufText("data:", cs), BufText(event.data, cs), BufText("\n", cs), BufText(s"id:${event.id.get}\n", cs)
+        ))
+        actualText === BufText.extract(expectedParts, cs)
+      }
+    }
+  }
+
+  it should "encode the event when a 'retry' is present" in {
+    implicit def arbitraryEvents: Arbitrary[ServerSentEvent[String]] = Arbitrary(sseWithRetry)
+
+    check { (event: ServerSentEvent[String], cs: Charset) =>
+      val encoded = encodeEventStream[String](Show.fromToString).apply(event, cs)
+      (event.event.isEmpty && event.id.isEmpty && event.retry.isDefined) ==> {
+        val encoded = encoder(event, cs)
+        val actualText = BufText.extract(encoded, cs)
+        val expectedParts = ConcatBuf(Vector(
+          BufText("data:", cs), BufText(event.data, cs), BufText("\n", cs), BufText(s"retry:${event.retry.get}\n", cs)
+        ))
+        actualText === BufText.extract(expectedParts, cs)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Proposed fix for #593 
Adds a ToResponse to create to hook into the asyncBodyResponse
Adds an example of SSE
Adds a section to the cookbook about SSE

Two things to call out:
- This support is very bare-bones and makes it the responsibility of the user to provide properly formatted events
- The [EventSource Standards](https://html.spec.whatwg.org/multipage/comms.html#authoring-notes) advises against using chunked requests, but `asyncResponseBuilder` does use chunked requests. When I tried implementing my own version of `asyncResponseBuilder` that didn't use chunking the `writer` would not write any data into the event. Not sure if it just isn't possible or if there was some method on the writer that I missed that would get it to write.
