### PR TITLE
Introduced sbt validate command + fixed scalastyle issues in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,14 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+before_cache:
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport scalastyle
-  - sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+  - sbt ++$TRAVIS_SCALA_VERSION validate
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
@@ -3,8 +3,8 @@ package io.finch.argonaut
 import argonaut._
 import argonaut.Argonaut._
 import io.finch.test.json._
-import org.scalatest.prop.Checkers
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.Checkers
 
 class ArgonautSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
 

--- a/benchmarks/src/test/scala/io/finch/benchmarks/EndpointBenchamrkSpec.scala
+++ b/benchmarks/src/test/scala/io/finch/benchmarks/EndpointBenchamrkSpec.scala
@@ -1,7 +1,7 @@
 package io.finch.benchmarks
 
-import io.finch._, items._
 import com.twitter.util.{Throw, Try}
+import io.finch._, items._
 import org.scalatest.{FlatSpec, Matchers}
 import scala.reflect.classTag
 
@@ -26,7 +26,7 @@ class FailingEndpointBenchmarkSpec extends FlatSpec with Matchers {
 
   val benchmark = new FailingEndpointBenchmark
 
-  def matchesAggregatedErrors(result: Try[Foo]) = result match {
+  private[this] def matchesAggregatedErrors(result: Try[Foo]) = result match {
     case Throw(
       Error.RequestErrors(
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -281,3 +281,16 @@ lazy val benchmarks = project
     )
   )
   .dependsOn(core, circe, jackson)
+
+val validateCommands = List(
+  "clean",
+  "scalastyle",
+  "test:scalastyle",
+  "compile",
+  "test:compile",
+  "coverage",
+  "test",
+  "coverageReport",
+  "coverageAggregate"
+)
+addCommandAlias("validate", validateCommands.mkString(";", ";", ""))

--- a/circe/src/test/scala/io/finch/circe/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/CirceSpec.scala
@@ -1,9 +1,9 @@
 package io.finch.circe
 
-import io.finch.test.json._
 import io.circe.generic.auto._
-import org.scalatest.prop.Checkers
+import io.finch.test.json._
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.Checkers
 
 class CirceSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
   "The circe codec provider" should "encode a case class as JSON" in encodeNestedCaseClass

--- a/core/src/test/scala/io/finch/DecodeEntityLaws.scala
+++ b/core/src/test/scala/io/finch/DecodeEntityLaws.scala
@@ -5,7 +5,7 @@ import cats.instances.AllInstances
 import cats.laws._
 import cats.laws.discipline._
 import com.twitter.util.{Return, Try}
-import org.scalacheck.{Prop, Arbitrary}
+import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
 
 trait DecodeEntityLaws[A] extends Laws with MissingInstances with AllInstances {

--- a/core/src/test/scala/io/finch/EncodeLaws.scala
+++ b/core/src/test/scala/io/finch/EncodeLaws.scala
@@ -1,12 +1,13 @@
 package io.finch
 
+import java.nio.charset.Charset
+
 import cats.Eq
+import cats.instances.AllInstances
 import cats.laws._
 import cats.laws.discipline._
-import cats.instances.AllInstances
 import com.twitter.io.Buf
 import io.finch.internal.BufText
-import java.nio.charset.Charset
 import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
 

--- a/core/src/test/scala/io/finch/internal/TooFastStringSpec.scala
+++ b/core/src/test/scala/io/finch/internal/TooFastStringSpec.scala
@@ -3,8 +3,8 @@ package io.finch.internal
 import com.twitter.util.Try
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
-import org.scalatest.prop.Checkers
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.Checkers
 
 class TooFastStringSpec extends FlatSpec with Matchers with Checkers {
 

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -45,5 +45,5 @@ object Main {
   }
 
   def main(): Unit =
-    Await.ready(Http.server.serve(":8081", eval.toService))
+    Await.ready(Http.server.serve(":8081", eval.toServiceAs[Application.Json]))
 }

--- a/examples/src/main/scala/io/finch/oauth2/Main.scala
+++ b/examples/src/main/scala/io/finch/oauth2/Main.scala
@@ -50,5 +50,5 @@ object Main extends App {
     Ok(UnprotectedUser("unprotected"))
   }
 
-  Await.ready(Http.server.serve(":8081", (tokens :+: users :+: unprotected).toService))
+  Await.ready(Http.server.serve(":8081", (tokens :+: users :+: unprotected).toServiceAs[Application.Json]))
 }

--- a/examples/src/main/scala/io/finch/todo/Main.scala
+++ b/examples/src/main/scala/io/finch/todo/Main.scala
@@ -84,7 +84,7 @@ object Main extends TwitterServer {
     getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo
   ).handle({
     case e: TodoNotFound => NotFound(e)
-  }).toService
+  }).toServiceAs[Application.Json]
 
   def main(): Unit = {
     log.info("Serving the Todo application")

--- a/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
+++ b/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
@@ -3,8 +3,8 @@ package io.finch.jackson
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import io.finch.test.json.JsonCodecProviderProperties
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.Checkers
-import org.scalatest.{Matchers, FlatSpec}
 
 class JacksonSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
 

--- a/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
@@ -2,8 +2,8 @@ package io.finch.json4s
 
 import io.finch.test.json.JsonCodecProviderProperties
 import org.json4s.DefaultFormats
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.Checkers
-import org.scalatest.{Matchers, FlatSpec}
 
 class Json4sSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {
   implicit val formats = DefaultFormats

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -3,11 +3,11 @@ package io.finch.oauth2
 import com.twitter.finagle.http.Status
 import com.twitter.finagle.oauth2._
 import com.twitter.util.Future
+import io.finch._
+import org.mockito.Mockito._
+import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.Checkers
-import org.scalatest.{Matchers, FlatSpec}
-import org.mockito.Mockito._
-import io.finch._
 
 class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar {
 

--- a/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
+++ b/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
@@ -1,10 +1,10 @@
 package io.finch.playjson
 
-import io.finch.test.json.JsonCodecProviderProperties
 import io.finch.test.json.ExampleCaseClass
 import io.finch.test.json.ExampleNestedCaseClass
-import org.scalatest.prop.Checkers
+import io.finch.test.json.JsonCodecProviderProperties
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.Checkers
 import play.api.libs.json._
 
 class PlayJsonSpec extends FlatSpec with Matchers with Checkers with JsonCodecProviderProperties {

--- a/sprayjson/src/test/scala/io/finch/sprayjson/sprayjsonSpec.scala
+++ b/sprayjson/src/test/scala/io/finch/sprayjson/sprayjsonSpec.scala
@@ -1,8 +1,8 @@
 package io.finch.sprayjson
 
 import io.finch.test.json._
-import org.scalatest.prop.Checkers
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.Checkers
 import spray.json._
 import DefaultJsonProtocol._
 

--- a/sse/src/test/scala/io/finch/sse/ServerSentEventSpec.scala
+++ b/sse/src/test/scala/io/finch/sse/ServerSentEventSpec.scala
@@ -6,11 +6,11 @@ import cats.Show
 import com.twitter.concurrent.AsyncStream
 import com.twitter.io.{Charsets, ConcatBuf}
 import io.finch.internal.BufText
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Gen.Choose
 import org.scalacheck.Prop.BooleanOperators
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.Checkers
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.Checkers
 
 class ServerSentEventSpec extends FlatSpec with Matchers with Checkers {
   behavior of "ServerSentEvent"


### PR DESCRIPTION
`sbt validate` allows to run CI script more easily locally.
