### PR TITLE
Update Cats, circe, ScalaCheck, and ScalaTest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 sudo: false
 scala:
   - 2.10.6
-  - 2.11.7
+  - 2.11.8
 jdk:
   - openjdk7
   - oraclejdk7

--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,10 @@ lazy val finagleVersion = "6.35.0"
 lazy val utilVersion = "6.34.0"
 lazy val twitterServerVersion = "1.20.0"
 lazy val finagleOAuth2Version = "0.1.7"
-lazy val circeVersion = "0.5.3"
-lazy val catbirdVersion = "0.7.0"
+lazy val circeVersion = "0.6.0-RC1"
+lazy val catbirdVersion = "0.8.0"
 lazy val shapelessVersion = "2.3.2"
-lazy val catsVersion = "0.7.2"
+lazy val catsVersion = "0.8.0"
 lazy val sprayVersion = "1.3.2"
 
 lazy val compilerOptions = Seq(
@@ -33,10 +33,10 @@ lazy val compilerOptions = Seq(
 )
 
 val testDependencies = Seq(
-  "org.scalacheck" %% "scalacheck" % "1.12.5",
-  "org.scalatest" %% "scalatest" % "2.2.6",
+  "org.scalacheck" %% "scalacheck" % "1.13.3",
+  "org.scalatest" %% "scalatest" % "3.0.0",
   "org.typelevel" %% "cats-laws" % catsVersion,
-  "org.typelevel" %% "discipline" % "0.4"
+  "org.typelevel" %% "discipline" % "0.7.1"
 )
 
 val baseSettings = Seq(

--- a/core/src/main/scala/io/finch/Encode.scala
+++ b/core/src/main/scala/io/finch/Encode.scala
@@ -1,7 +1,6 @@
 package io.finch
 
 import cats.Show
-import cats.data.Xor
 import com.twitter.io.Buf
 import io.finch.internal.BufText
 import java.nio.charset.Charset
@@ -67,10 +66,10 @@ object Encode extends LowPriorityEncodeInstances {
   implicit val encodeString: Text[String] =
     text((s, cs) => BufText(s, cs))
 
-  implicit def encodeXor[A, B, CT <: String](implicit
+  implicit def encodeEither[A, B, CT <: String](implicit
     ae: Encode.Aux[A, CT],
     be: Encode.Aux[B, CT]
-  ): Encode.Aux[A Xor B, CT] = instance[A Xor B, CT](
-    (xor, cs) => xor.fold(a => ae(a, cs), b => be(b, cs))
+  ): Encode.Aux[Either[A, B], CT] = instance[Either[A, B], CT](
+    (either, cs) => either.fold(a => ae(a, cs), b => be(b, cs))
   )
 }

--- a/core/src/test/scala/io/finch/MissingInstances.scala
+++ b/core/src/test/scala/io/finch/MissingInstances.scala
@@ -1,9 +1,6 @@
 package io.finch
 
-import java.util.UUID
-
 import cats.Eq
-import cats.Show
 import com.twitter.io.Buf
 import com.twitter.util.{Return, Throw, Try}
 
@@ -16,10 +13,6 @@ trait MissingInstances {
     case (Throw(x), Throw(y)) => x == y
     case _ => false
   }
-
-  implicit def eqUUID: Eq[UUID] = Eq.fromUniversalEquals
-
-  implicit def showUUID: Show[UUID] = Show.fromToString
 
   implicit def eqBuf: Eq[Buf] = Eq.fromUniversalEquals
 }

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -3,7 +3,7 @@ package io.finch.oauth2
 import com.twitter.finagle.http.Status
 import com.twitter.finagle.oauth2._
 import com.twitter.util.Future
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.prop.Checkers
 import org.scalatest.{Matchers, FlatSpec}
 import org.mockito.Mockito._

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,10 +6,10 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.4.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0-RC2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.11")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")

--- a/test/src/main/scala/io/finch/test/ServiceIntegrationSuite.scala
+++ b/test/src/main/scala/io/finch/test/ServiceIntegrationSuite.scala
@@ -8,7 +8,7 @@ import org.scalatest.{fixture, Outcome}
 /**
  * Extends [[ServiceSuite]] to support integration testing for services.
  */
-trait ServiceIntegrationSuite extends ServiceSuite { self: fixture.Suite =>
+trait ServiceIntegrationSuite extends ServiceSuite { self: fixture.TestSuite =>
 
   /**
    * Override in implementing classes if a different port is desired for

--- a/test/src/main/scala/io/finch/test/ServiceSuite.scala
+++ b/test/src/main/scala/io/finch/test/ServiceSuite.scala
@@ -11,7 +11,7 @@ import org.scalatest.{fixture, Outcome}
  * classes must extend [[org.scalatest.fixture.Suite]] through [[org.scalatest.fixture.FlatSpec]]
  * for example.
  */
-trait ServiceSuite { self: fixture.Suite =>
+trait ServiceSuite { self: fixture.TestSuite =>
 
   /**
    * Create an instance of the service to be tested.


### PR DESCRIPTION
I'm not sure we want to merge this yet, but I wanted to show that it works. :smile: 

* `Xor` is gone.
* Cats provides its own `UUID` instances.
* ScalaTest has moved a couple of things around.
* `Arbitrary` instances for functions now require `Cogen` instances for the argument types.

I need to take a closer look at the `Cogen` instances, but I think they make sense.