### PR TITLE
Increase test coverage of the Error classes

### DIFF
--- a/benchmarks/src/test/scala/io/finch/benchmarks/EndpointBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/io/finch/benchmarks/EndpointBenchmarkSpec.scala
@@ -1,9 +1,10 @@
 package io.finch.benchmarks
 
+import scala.reflect.classTag
+
 import com.twitter.util.{Throw, Try}
 import io.finch._, items._
 import org.scalatest.{FlatSpec, Matchers}
-import scala.reflect.classTag
 
 class SuccessfulEndpointBenchmarkSpec extends FlatSpec with Matchers {
 
@@ -27,14 +28,13 @@ class FailingEndpointBenchmarkSpec extends FlatSpec with Matchers {
   val benchmark = new FailingEndpointBenchmark
 
   private[this] def matchesAggregatedErrors(result: Try[Foo]) = result match {
-    case Throw(
-      Error.RequestErrors(
-        Seq(
-          Error.NotParsed(ParamItem("d"), dTag, _: NumberFormatException),
-          Error.NotParsed(ParamItem("l"), lTag, _: NumberFormatException)
-        )
-      )
-    ) => dTag == classTag[Double] && lTag == classTag[Long]
+    case Throw(Error.Multiple(nel)) => nel.toList match {
+      case Seq(
+        Error.NotParsed(ParamItem("d"), dTag, _: NumberFormatException),
+        Error.NotParsed(ParamItem("l"), lTag, _: NumberFormatException)
+      ) => dTag == classTag[Double] && lTag == classTag[Long]
+      case _ => false
+    }
     case _ => false
   }
 

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -1,6 +1,9 @@
 package io.finch
 
-import cats.Alternative
+import java.nio.charset.Charset
+import scala.reflect.ClassTag
+
+import cats.{Alternative, Functor}
 import cats.data.NonEmptyList
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Cookie, Request, Response, Status}
@@ -8,8 +11,6 @@ import com.twitter.io.Buf
 import com.twitter.util.{Future, Return, Throw, Try}
 import io.catbird.util.Rerunnable
 import io.finch.internal._
-import java.nio.charset.Charset
-import scala.reflect.ClassTag
 import shapeless._
 import shapeless.ops.adjoin.Adjoin
 import shapeless.ops.hlist.Tupler
@@ -162,13 +163,13 @@ trait Endpoint[A] { self =>
         case (_, Throw(e)) => Future.exception(e)
       }
 
-    private[this] def collectExceptions(a: Throwable, b: Throwable): Error.RequestErrors = {
-      def collect(e: Throwable): Seq[Throwable] = e match {
-        case Error.RequestErrors(errors) => errors
-        case rest => Seq(rest)
+    private[this] def collectExceptions(a: Throwable, b: Throwable): Error.Multiple = {
+      def collect(e: Throwable): NonEmptyList[Throwable] = e match {
+        case Error.Multiple(errors) => errors
+        case rest => NonEmptyList.of(rest)
       }
 
-      Error.RequestErrors(collect(a) ++ collect(b))
+      Error.Multiple(collect(a).concat(collect(b)))
     }
 
     def apply(input: Input): Endpoint.Result[(A, B)] =
@@ -505,16 +506,16 @@ object Endpoint {
           case Throw(e) => Error.NotParsed(self.item, tag, e)
         }
 
-        if (errors.isEmpty)
-          Future.const(Try.collect(decoded).map(seq => NonEmptyList(seq.head, seq.tail.toList)))
-        else
-          Future.exception(Error.RequestErrors(errors))
+        NonEmptyList.fromList(errors) match {
+          case None => Future.const(Try.collect(decoded).map(seq => NonEmptyList(seq.head, seq.tail.toList)))
+          case Some(err) => Future.exception(Error.Multiple(Functor[NonEmptyList].widen(err)))
+        }
       }
   }
 
   /**
     * Implicit conversion that allows to call `as[A]` on any `Endpoint[Seq[String]]` to perform a
-    * type conversion based on an implicit ``DecodeRequest[A]` which must be in scope.
+    * type conversion based on an implicit `DecodeRequest[A]` which must be in scope.
     *
     * The resulting endpoint will fail when the result is non-empty and type conversion fails on one
     * or more of the elements in the `Seq`. It will succeed if the result is empty or type conversion
@@ -539,8 +540,10 @@ object Endpoint {
           case Throw(e) => Error.NotParsed(self.item, tag, e)
         }
 
-        if (errors.isEmpty) Future.const(Try.collect(decoded))
-        else Future.exception(Error.RequestErrors(errors))
+        NonEmptyList.fromList(errors.toList) match {
+          case None => Future.const(Try.collect(decoded))
+          case Some(err) => Future.exception(Error.Multiple(Functor[NonEmptyList].widen(err)))
+        }
       }
   }
 

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -164,9 +164,11 @@ trait Endpoint[A] { self =>
       }
 
     private[this] def collectExceptions(a: Throwable, b: Throwable): Error.Multiple = {
-      def collect(e: Throwable): NonEmptyList[Throwable] = e match {
+      def collect(e: Throwable): NonEmptyList[Error] = e match {
         case Error.Multiple(errors) => errors
-        case rest => NonEmptyList.of(rest)
+        case rest => NonEmptyList.of(
+          Error(Try(rest.getMessage).getOrElse("Exception message was null"))
+        )
       }
 
       Error.Multiple(collect(a).concat(collect(b)))

--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -1,6 +1,10 @@
 package io.finch
 
+import scala.compat.Platform.EOL
 import scala.reflect.ClassTag
+
+import cats.data.NonEmptyList
+import io.finch.items.RequestItem
 
 /**
  * A basic error from a Finch application.
@@ -9,10 +13,13 @@ trait Error extends Exception
 
 object Error {
 
-  import items._
-
   def apply(message: String): Error = new Error {
     override def getMessage: String = message
+  }
+
+  object RequestErrors {
+    @deprecated("Use Multiple instead", "0.11")
+    def unapply(e: Throwable): Option[Seq[Throwable]] = Some(Seq(e))
   }
 
   /**
@@ -20,9 +27,9 @@ object Error {
    *
    * @param errors the errors collected from various endpoints
    */
-  final case class RequestErrors(errors: Seq[Throwable]) extends Error {
+  final case class Multiple(errors: NonEmptyList[Throwable]) extends Error {
     override def getMessage: String =
-      "One or more errors reading request: " + errors.map(_.getMessage).mkString("\n  ","\n  ","")
+      "One or more errors reading request:" + errors.map(_.getMessage).toList.mkString(EOL + "  ", EOL + "  ","")
   }
 
   /**

--- a/core/src/test/scala/io/finch/ErrorSpec.scala
+++ b/core/src/test/scala/io/finch/ErrorSpec.scala
@@ -1,0 +1,85 @@
+package io.finch
+
+import scala.compat.Platform.EOL
+import scala.reflect.ClassTag
+
+import cats.data.NonEmptyList
+import cats.laws.discipline.arbitrary._
+import com.twitter.util.Try
+import io.finch.Error.{Multiple, NotParsed, NotPresent, NotValid}
+import io.finch.items.ParamItem
+
+class ErrorSpec extends FinchSpec {
+
+  behavior of "Error"
+
+  it should "construct Error messages for all RequestErrors" in {
+    check { (t: NonEmptyList[Throwable]) =>
+      val sut = Multiple(t)
+      val accResult = t.foldLeft("")((acc, b) => acc + EOL + "  " + Try(b.getMessage).getOrElse("Input was null"))
+      sut.getMessage.contains(accResult)
+    }
+  }
+
+  it should "construct an Error message for NotPresent" in {
+    val input = ParamItem("ParamItemName")
+    val sut = NotPresent(input)
+    sut.getMessage shouldBe s"Required ${input.description} not present in the request."
+  }
+
+  it should "construct an Error message for NotValid" in {
+    val input = ParamItem("ParamItemName")
+    val rule = "Rule#1"
+    val sut = NotValid(input, rule)
+    sut.getMessage shouldBe s"Validation failed: ${input.description} $rule."
+  }
+
+  it should "construct an Error message for NotParsed" in {
+    val input = ParamItem("ParamItemName")
+    val cause = new Throwable("thrown")
+    val targetType = ClassTag.Double
+    val sut = NotParsed(input, targetType, cause)
+    sut.getMessage shouldBe s"${input.description} cannot be converted to ${targetType.runtimeClass.getSimpleName}: " +
+    s"${cause.getMessage}."
+  }
+
+  it should "return the cause for NotParsed" in {
+    val input = ParamItem("ParamItemName")
+    val cause = new Throwable("thrown")
+    val targetType = ClassTag.Double
+    val sut = NotParsed(input, targetType, cause)
+    sut.getCause shouldBe cause
+  }
+
+  it should "construct an Error message for a Multiple" in {
+    val sut = Multiple(NonEmptyList.of(Error("My Throwable")))
+    sut.getMessage shouldBe
+      """One or more errors reading request:
+        |  My Throwable""".stripMargin
+  }
+
+  it should "construct an Error message from empty Error" in {
+    val sut = Multiple(NonEmptyList.of(Error("")))
+    sut.getMessage shouldBe
+      """One or more errors reading request:
+        |  """.stripMargin
+  }
+
+  it should "construct an Error message for a Multiple with multiple Throwables" in {
+    val sut = Multiple(NonEmptyList.of(new Throwable("My Throwable"), Error("My Error")))
+    sut.getMessage shouldBe
+      """One or more errors reading request:
+        |  My Throwable
+        |  My Error""".stripMargin
+  }
+
+  it should "unapply existing RequestErrors matches" in {
+    val t = new Throwable("My Throwable")
+    val result = t match {
+      case Error.RequestErrors(errors) => errors
+      case rest => fail()
+    }
+    result shouldBe Seq(t)
+  }
+
+}

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -42,6 +42,8 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
 
   def genNonEmptyString: Gen[String] = Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
 
+  def genError: Gen[Error] = Gen.alphaStr.map(Error(_))
+
   def genNonEmptyTuple: Gen[(String, String)] = for {
     key <- genNonEmptyString
     value <- genNonEmptyString
@@ -237,4 +239,5 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
 
   implicit def arbitraryOutput[A: Arbitrary]: Arbitrary[Output[A]] = Arbitrary(genOutput[A])
 
+  implicit def arbitraryError: Arbitrary[Error] = Arbitrary(genError)
 }

--- a/docs/endpoint.md
+++ b/docs/endpoint.md
@@ -566,7 +566,7 @@ converted into very basic 500 responses that don't carry any payload.
 Finch itself throws exceptions extending `io.finch.Error` that are already handled as 400s (bad
 requests):
 
-- `io.finch.Error.RequestErrors` - when multiple errors occurred during the
+- `io.finch.Error.Multiple` - when multiple errors occurred during the
   endpoint evaluation they are _accumulated_ into this instance
 - `io.finch.Error.NotFound` - when a required request part/item (header, param, body, cookie) was
   missing


### PR DESCRIPTION
The RequestError class accepts a Seq[Throwable], in case this is empty we should handle this accordingly and print a better message.