### PR TITLE
Remove String conversion in decoders.

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
@@ -1,9 +1,11 @@
 package io.finch.argonaut
 
 import argonaut.{CursorHistory, DecodeJson, Json}
+import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.{Return, Throw, Try}
 import io.finch._
 import io.finch.internal.BufText
+import java.nio.charset.StandardCharsets
 import jawn.Parser
 import jawn.support.argonaut.Parser._
 import scala.util.{Failure, Success}
@@ -16,12 +18,12 @@ trait Decoders {
   implicit def decodeArgonaut[A](implicit d: DecodeJson[A]): Decode.Json[A] =
     Decode.json { (b, cs) =>
       val err: (String, CursorHistory) => Try[A] = { (str, hist) => Throw[A](Error(str)) }
-
-      // TODO: Eliminate toString conversion
-      // See https://github.com/finagle/finch/issues/511
-      // Jawn can parse from ByteBuffer's if they represent UTF-8 strings.
-      // We can check the charset here and do parsing w/o extra to-string conversion.
-      Parser.parseFromString[Json](BufText.extract(b, cs))(facade) match {
+      val attemptJson = cs match {
+        case StandardCharsets.UTF_8 =>
+          Parser.parseFromByteBuffer[Json](ChannelBufferBuf.Owned.extract(b).toByteBuffer())(facade)
+        case _ => Parser.parseFromString[Json](BufText.extract(b, cs))(facade)
+      }
+      attemptJson match {
         case Success(value) => d.decodeJson(value).fold[Try[A]](err, Return(_))
         case Failure(error) => Throw[A](Error(error.getMessage))
       }

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -1,26 +1,25 @@
 package io.finch.circe
 
 import cats.syntax.show._
+import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.{Return, Throw, Try}
 import io.circe.Decoder
-import io.circe.jawn.decode
+import io.circe.jawn._
 import io.finch.{Decode, Error}
 import io.finch.internal.BufText
+import java.nio.charset.StandardCharsets
 
 trait Decoders {
 
   /**
    * Maps a Circe's [[Decoder]] to Finch's [[Decode]].
    */
-  implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json((b, cs) =>
-
-    // TODO: Eliminate toString conversion
-    // See https://github.com/finagle/finch/issues/511
-    // Jawn can parse from ByteBuffer's if they represent UTF-8 strings.
-    // We can check the charset here and do parsing w/o extra to-string conversion.
-    decode[A](BufText.extract(b, cs)).fold[Try[A]](
-      error => Throw[A](Error(error.show)),
-      value => Return(value)
-    )
-  )
+  implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json { (b, cs) =>
+    val attemptJson = cs match {
+      case StandardCharsets.UTF_8 =>
+        parseByteBuffer(ChannelBufferBuf.Owned.extract(b).toByteBuffer()).right.flatMap(_.as[A])
+      case _ => decode[A](BufText.extract(b, cs))
+    }
+    attemptJson.fold[Try[A]](error => Throw[A](Error(error.show)), value => Return(value))
+  }
 }

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.http.Message
 import com.twitter.io.{Buf, Charsets}
 import java.nio.CharBuffer
 import java.nio.charset.{Charset, StandardCharsets}
+import org.jboss.netty.buffer.ChannelBuffer
 
 /**
  * This package contains an internal-use only type-classes and utilities that power Finch's API.
@@ -59,6 +60,23 @@ package object internal {
     Some(if (negative) result else -result)
   }
   // scalastyle:on return
+
+  /** Extract a byte array from a ChannelBuffer that is backed by an array.
+    * Precondition: buf.hasArray == true
+    *
+    * @param buf The ChannelBuffer to extract the array from
+    * @return An array of bytes
+    */
+  def extractBytesFromArrayBackedBuf(buf: ChannelBuffer): Array[Byte] = {
+    val rawArray = buf.array
+    val size = buf.readableBytes()
+    if (rawArray.length == size) rawArray
+    else {
+      val dst = new Array[Byte](size)
+      System.arraycopy(buf.array(), 0, dst, 0, size)
+      dst
+    }
+  }
 
   /**
    * Enriches any string with fast `tooX` conversions.

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -1,21 +1,20 @@
 package io.finch
 
-import scala.reflect.ClassTag
-
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.Try
 import io.finch.internal.BufText
+import scala.reflect.ClassTag
 
 package object jackson {
 
   implicit def decodeJackson[A](implicit
     mapper: ObjectMapper, ct: ClassTag[A]
-  ): Decode.Json[A] = Decode.json((b, cs) =>
-    // TODO: Eliminate toString conversion
-    // See https://github.com/finagle/finch/issues/511
-    // Jackson can parse from byte[] automatically detecting the encoding.
-    Try(mapper.readValue(BufText.extract(b, cs), ct.runtimeClass.asInstanceOf[Class[A]]))
-  )
+  ): Decode.Json[A] = Decode.json { (b, cs) =>
+    val buf = ChannelBufferBuf.Owned.extract(b)
+    if (buf.hasArray) Try(mapper.readValue(buf.array(), 0, buf.readableBytes(), ct.runtimeClass.asInstanceOf[Class[A]]))
+    else Try(mapper.readValue(buf.toString(cs), ct.runtimeClass.asInstanceOf[Class[A]]))
+  }
 
   implicit def encodeJackson[A](implicit mapper: ObjectMapper): Encode.Json[A] =
     Encode.json((a, cs) => BufText(mapper.writeValueAsString(a), cs))


### PR DESCRIPTION
Proposed fix for #511. The only thing I was unsure about was whether to use `Buf.ByteArray.Owned` or `Buf.ByteArray.Shared` for the libraries that can convert `Array[Byte]`. I wound up using `Shared`, but I'm not sure this is necessary.