### PR TITLE
Escape JSON strings while encoding exceptions

### DIFF
--- a/core/src/main/scala/io/finch/Encode.scala
+++ b/core/src/main/scala/io/finch/Encode.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import cats.Show
 import com.twitter.io.Buf
-import io.finch.internal.BufText
+import io.finch.internal.{BufText, JsonUtils}
 import java.nio.charset.Charset
 
 /**
@@ -55,7 +55,7 @@ object Encode extends LowPriorityEncodeInstances {
   )
 
   implicit val encodeExceptionAsJson: Json[Exception] = json(
-    (e, cs) => BufText(s"""{"message":"${Option(e.getMessage).getOrElse("")}"}""", cs)
+    (e, cs) => BufText(s"""{"message":"${Option(e.getMessage).map(JsonUtils.escape).getOrElse("")}"}""", cs)
   )
 
   implicit val encodeString: Text[String] =

--- a/core/src/main/scala/io/finch/internal/JsonUtils.scala
+++ b/core/src/main/scala/io/finch/internal/JsonUtils.scala
@@ -1,0 +1,38 @@
+package io.finch.internal
+
+import scala.annotation.switch
+
+/**
+  * Utility to escape JSON strings
+  *
+  * This code is borrowed from Circe JSON Library
+  */
+private[finch] object JsonUtils {
+  private[this] def escapeChar(c: Char): String = (c: @switch) match {
+    case '\\' => "\\\\"
+    case '"' => "\\\""
+    case '\b' => "\\b"
+    case '\f' => "\\f"
+    case '\n' => "\\n"
+    case '\r' => "\\r"
+    case '\t' => "\\t"
+    case possibleUnicode => if (Character.isISOControl(possibleUnicode)) {
+      "\\u%04x".format(possibleUnicode.toInt)
+    } else possibleUnicode.toString
+  }
+
+  private[this] def isNormalChar(c: Char): Boolean = (c: @switch) match {
+    case '\\' => false
+    case '"' => false
+    case '\b' => false
+    case '\f' => false
+    case '\n' => false
+    case '\r' => false
+    case '\t' => false
+    case possibleUnicode => !Character.isISOControl(possibleUnicode)
+  }
+
+  def escape(s: String): String = s.foldLeft("")((s, c) =>
+    s + (if (isNormalChar(c)) c else escapeChar(c))
+  )
+}

--- a/core/src/test/scala/io/finch/EncodeSpec.scala
+++ b/core/src/test/scala/io/finch/EncodeSpec.scala
@@ -4,7 +4,7 @@ import java.nio.charset.Charset
 import java.util.UUID
 
 import com.twitter.io.Buf
-import io.finch.internal.BufText
+import io.finch.internal.{BufText, JsonUtils}
 
 class EncodeSpec extends FinchSpec {
 
@@ -33,7 +33,7 @@ class EncodeSpec extends FinchSpec {
       val json = Encode[Exception, Application.Json].apply(e, cs)
       val text = Encode[Exception, Text.Plain].apply(e, cs)
 
-      json === BufText(s"""{"message":"$s"}""", cs) && text === BufText(s, cs)
+      json === BufText(s"""{"message":"${JsonUtils.escape(s)}"}""", cs) && text === BufText(s, cs)
     }
   }
 }


### PR DESCRIPTION
Current implementation of exceptions to JSON encoder doesn't take into account that exception message may contain special characters that must be escaped (double quotes for example). I borrowed a little piece of code from Circe Printer to fix it.