### PR TITLE
Netty-agnostic decoding

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
@@ -1,10 +1,9 @@
 package io.finch.argonaut
 
 import argonaut.{CursorHistory, DecodeJson, Json}
-import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.{Return, Throw, Try}
 import io.finch._
-import io.finch.internal.BufText
+import io.finch.internal.{BufText, HttpContent}
 import java.nio.charset.StandardCharsets
 import jawn.Parser
 import jawn.support.argonaut.Parser._
@@ -17,15 +16,17 @@ trait Decoders {
    */
   implicit def decodeArgonaut[A](implicit d: DecodeJson[A]): Decode.Json[A] =
     Decode.json { (b, cs) =>
-      val err: (String, CursorHistory) => Try[A] = { (str, hist) => Throw[A](Error(str)) }
+      val err: (String, CursorHistory) => Try[A] = { (str, hist) => Throw(Error(str)) }
+
       val attemptJson = cs match {
         case StandardCharsets.UTF_8 =>
-          Parser.parseFromByteBuffer[Json](ChannelBufferBuf.Owned.extract(b).toByteBuffer())(facade)
+          Parser.parseFromByteBuffer[Json](b.asByteBuffer)(facade)
         case _ => Parser.parseFromString[Json](BufText.extract(b, cs))(facade)
       }
+
       attemptJson match {
-        case Success(value) => d.decodeJson(value).fold[Try[A]](err, Return(_))
-        case Failure(error) => Throw[A](Error(error.getMessage))
+        case Success(value) => d.decodeJson(value).fold(err, Return.apply)
+        case Failure(error) => Throw(error)
       }
   }
 }

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -1,12 +1,10 @@
 package io.finch.circe
 
-import cats.syntax.show._
-import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.{Return, Throw, Try}
 import io.circe.Decoder
 import io.circe.jawn._
-import io.finch.{Decode, Error}
-import io.finch.internal.BufText
+import io.finch.Decode
+import io.finch.internal.{BufText, HttpContent}
 import java.nio.charset.StandardCharsets
 
 trait Decoders {
@@ -17,9 +15,10 @@ trait Decoders {
   implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json { (b, cs) =>
     val attemptJson = cs match {
       case StandardCharsets.UTF_8 =>
-        parseByteBuffer(ChannelBufferBuf.Owned.extract(b).toByteBuffer()).right.flatMap(_.as[A])
+        parseByteBuffer(b.asByteBuffer).right.flatMap(_.as[A])
       case _ => decode[A](BufText.extract(b, cs))
     }
-    attemptJson.fold[Try[A]](error => Throw[A](Error(error.show)), value => Return(value))
+
+    attemptJson.fold[Try[A]](Throw.apply, Return.apply)
   }
 }

--- a/core/src/main/scala/io/finch/internal/ToResponse.scala
+++ b/core/src/main/scala/io/finch/internal/ToResponse.scala
@@ -52,17 +52,17 @@ trait LowPriorityToResponseInstances {
     rep
   }
 
-  private[this] val newLine: Buf = Buf.Utf8("\n")
+  private[finch] val NewLine: Buf = Buf.Utf8("\n")
 
   implicit def jsonAsyncStreamToResponse[A](implicit
     e: Encode.Json[A]
   ): Aux[AsyncStream[A], Application.Json] =
-    asyncResponseBuilder((a, cs) => e(a, cs).concat(newLine))
+    asyncResponseBuilder((a, cs) => e(a, cs).concat(NewLine))
 
   implicit def textAsyncStreamToResponse[A](implicit
     e: Encode.Text[A]
   ): Aux[AsyncStream[A], Text.Plain] =
-    asyncResponseBuilder((a, cs) => e(a, cs).concat(newLine))
+    asyncResponseBuilder((a, cs) => e(a, cs).concat(NewLine))
 }
 
 trait HighPriorityToResponseInstances extends LowPriorityToResponseInstances {

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -1,19 +1,21 @@
 package io.finch
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.Try
-import io.finch.internal.BufText
+import io.finch.internal.{BufText, HttpContent, Utf32}
+import java.nio.charset.StandardCharsets
 import scala.reflect.ClassTag
 
 package object jackson {
 
   implicit def decodeJackson[A](implicit
     mapper: ObjectMapper, ct: ClassTag[A]
-  ): Decode.Json[A] = Decode.json { (b, cs) =>
-    val buf = ChannelBufferBuf.Owned.extract(b)
-    if (buf.hasArray) Try(mapper.readValue(buf.array(), 0, buf.readableBytes(), ct.runtimeClass.asInstanceOf[Class[A]]))
-    else Try(mapper.readValue(buf.toString(cs), ct.runtimeClass.asInstanceOf[Class[A]]))
+  ): Decode.Json[A] = Decode.json {
+    case (buf, StandardCharsets.UTF_8 | StandardCharsets.UTF_16 | Utf32) =>
+      val (array, offset, length) = buf.asByteArrayWithOffsetAndLength
+      Try(mapper.readValue(array, offset, length, ct.runtimeClass.asInstanceOf[Class[A]]))
+    case (buf, cs) =>
+      Try(mapper.readValue(BufText.extract(buf, cs), ct.runtimeClass.asInstanceOf[Class[A]]))
   }
 
   implicit def encodeJackson[A](implicit mapper: ObjectMapper): Encode.Json[A] =

--- a/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
+++ b/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
@@ -1,32 +1,19 @@
 package io.finch
 
-import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.util.Try
-import io.finch.internal.{extractBytesFromArrayBackedBuf, BufText}
+import io.finch.internal.{BufText, HttpContent}
 import java.nio.charset.StandardCharsets
 import spray.json._
 
 package object sprayjson {
 
-  /**
-    * @param format spray-json support for convert JSON val to specific type object
-    * @tparam A the type of the data to decode into
-    */
   implicit def decodeSpray[A](implicit format: JsonReader[A]): Decode.Json[A] =
-    Decode.json { (b, cs) =>
-      cs match {
-        case StandardCharsets.UTF_8 =>
-          val buf = ChannelBufferBuf.Owned.extract(b)
-          if (buf.hasArray) Try(JsonParser(extractBytesFromArrayBackedBuf(buf)).convertTo[A])
-          else Try(JsonParser(buf.toString(cs)).convertTo[A])
-        case _ => Try(BufText.extract(b, cs).parseJson.convertTo[A])
-      }
+    Decode.json {
+      case (buf, StandardCharsets.UTF_8) =>
+        Try(JsonParser(buf.asByteArray).convertTo[A])
+      case (buf, cs) => Try(BufText.extract(buf, cs).parseJson.convertTo[A])
     }
 
-  /**
-    * @param format spray-json support for convert JSON val to specific type object
-    * @tparam A the type of the data to decode from
-    */
   implicit def encodeSpray[A](implicit format: JsonWriter[A]): Encode.Json[A] =
     Encode.json((a, cs) => BufText(a.toJson.prettyPrint, cs))
 

--- a/sse/src/main/scala/io/finch/sse/ServerSentEvent.scala
+++ b/sse/src/main/scala/io/finch/sse/ServerSentEvent.scala
@@ -5,7 +5,7 @@ import java.nio.charset.Charset
 import cats.Show
 import com.twitter.concurrent.AsyncStream
 import com.twitter.io.Buf
-import io.finch.{Encode, Ok, Output, Text}
+import io.finch.{Encode, Text}
 import io.finch.internal.{BufText, ToResponse}
 
 case class ServerSentEvent[A](
@@ -20,7 +20,7 @@ object ServerSentEvent {
   implicit def sseAsyncToResponse[A](implicit
      e: Encode.Aux[A, Text.EventStream]
   ): ToResponse.Aux[AsyncStream[A], Text.EventStream] =
-    ToResponse.asyncResponseBuilder((a, cs) => e(a, cs).concat(Buf.Utf8("\n")))
+    ToResponse.asyncResponseBuilder((a, cs) => e(a, cs).concat(ToResponse.NewLine))
 
   implicit def encodeEventStream[A](implicit s: Show[A]): Encode.Aux[ServerSentEvent[A], Text.EventStream] = {
     Encode.instance[ServerSentEvent[A], Text.EventStream]({ (event: ServerSentEvent[A], c: Charset) =>


### PR DESCRIPTION
Finagle is very close to switching its HTTP implementation over to Netty 4. Let's make sure that Finch will keep working when this happens.