### PR TITLE
Refactor the way how JSON Encoders for Exceptions are provided

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
@@ -1,6 +1,6 @@
 package io.finch.argonaut
 
-import argonaut.{EncodeJson, PrettyParams}
+import argonaut.{EncodeJson, Json, PrettyParams}
 import io.finch.Encode
 import io.finch.internal.BufText
 
@@ -13,4 +13,8 @@ trait Encoders {
    */
   implicit def encodeArgonaut[A](implicit e: EncodeJson[A]): Encode.Json[A] =
     Encode.json((a, cs) => BufText(printer.pretty(e.encode(a)), cs))
+
+  implicit def encodeExceptionArgonaut[A <: Exception]: EncodeJson[A] = new EncodeJson[A] {
+    override def encode(a: A): Json = Json.obj(("message", Json.jString(a.getMessage)))
+  }
 }

--- a/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
+++ b/argonaut/src/test/scala/io/finch/argonaut/ArgonautSpec.scala
@@ -26,4 +26,5 @@ class ArgonautSpec extends FlatSpec with Matchers with Checkers with JsonCodecPr
   it should "encode a list of case class instances as JSON" in encodeCaseClassList
   it should "decode a list of case class instances from JSON" in decodeCaseClassList
   it should "provide encoders with the correct content type" in checkContentType
+  it should "encode an exception" in encodeException
 }

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -13,4 +13,8 @@ trait Encoders {
    */
   implicit def encodeCirce[A](implicit e: Encoder[A]): Encode.Json[A] =
     Encode.json((a, cs) => BufText(print(e(a)), cs))
+
+  implicit def encodeExceptionCirce[A <: Exception]: Encoder[A] = new Encoder[A] {
+    override def apply(e: A): Json = Json.obj(("message", Json.fromString(e.getMessage)))
+  }
 }

--- a/circe/src/test/scala/io/finch/circe/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/CirceSpec.scala
@@ -12,4 +12,5 @@ class CirceSpec extends FlatSpec with Matchers with Checkers with JsonCodecProvi
   it should "encode a list of case class instances as JSON" in encodeCaseClassList
   it should "decode a list of case class instances from JSON" in decodeCaseClassList
   it should "provide encoders with the correct content type" in checkContentType
+  it should "encode an exception" in encodeException
 }

--- a/core/src/main/scala/io/finch/Encode.scala
+++ b/core/src/main/scala/io/finch/Encode.scala
@@ -54,10 +54,6 @@ object Encode extends LowPriorityEncodeInstances {
     (e, cs) => BufText(Option(e.getMessage).getOrElse(""), cs)
   )
 
-  implicit val encodeExceptionAsJson: Json[Exception] = json(
-    (e, cs) => BufText(s"""{"message":"${Option(e.getMessage).getOrElse("")}"}""", cs)
-  )
-
   implicit val encodeString: Text[String] =
     text((s, cs) => BufText(s, cs))
 

--- a/core/src/test/scala/io/finch/EncodeSpec.scala
+++ b/core/src/test/scala/io/finch/EncodeSpec.scala
@@ -30,10 +30,9 @@ class EncodeSpec extends FinchSpec {
     check { (s: String, cs: Charset) =>
       val e = new Exception(s)
 
-      val json = Encode[Exception, Application.Json].apply(e, cs)
       val text = Encode[Exception, Text.Plain].apply(e, cs)
 
-      json === BufText(s"""{"message":"$s"}""", cs) && text === BufText(s, cs)
+      text === BufText(s, cs)
     }
   }
 }

--- a/core/src/test/scala/io/finch/InputSpec.scala
+++ b/core/src/test/scala/io/finch/InputSpec.scala
@@ -40,6 +40,10 @@ class InputSpec extends FinchSpec {
   }
 
   it should "add content corresponding to a class through withBody[JSON]" in {
+    implicit val encodeException: Encode.Json[Exception] = Encode.json(
+      (a, cc) => BufText(s"""{"message":"${a.getMessage}"}""", cc)
+    )
+
     check { (i: Input, s: String, cs: Charset) =>
       val input = i.withBody[Application.Json](new Exception(s), Some(cs))
 

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.Http
 import com.twitter.util.{Await, Eval}
 import io.finch._
-import io.finch.internal.BufText
 import io.finch.jackson._
 
 /**
@@ -28,10 +27,6 @@ import io.finch.jackson._
 object Main {
 
   implicit val objectMapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
-
-  implicit val ee: Encode.Json[Exception] = Encode.json((e, cs) =>
-    BufText(objectMapper.writeValueAsString(Map("error" -> e.getMessage)), cs)
-  )
 
   case class EvalInput(expression: String)
   case class EvalOutput(result: String)

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -18,4 +18,11 @@ package object jackson {
 
   implicit def encodeJackson[A](implicit mapper: ObjectMapper): Encode.Json[A] =
     Encode.json((a, cs) => BufText(mapper.writeValueAsString(a), cs))
+
+  implicit def encodeExceptionJackson[A <: Exception](implicit mapper: ObjectMapper): Encode.Json[A] =
+    Encode.json((a, cs) => {
+      val rootNode = mapper.createObjectNode()
+      rootNode.put("message", a.getMessage)
+      BufText(mapper.writeValueAsString(rootNode), cs)
+    })
 }

--- a/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
+++ b/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
@@ -15,4 +15,5 @@ class JacksonSpec extends FlatSpec with Matchers with Checkers with JsonCodecPro
   it should "properly fail to decode invalid JSON into a case class" in failToDecodeInvalidJson
   it should "encode a list of case class instances as JSON" in encodeCaseClassList
   it should "provide encoders with the correct content type" in checkContentType
+  it should "encode an exception" in encodeException
 }

--- a/json4s/src/main/scala/io/finch/json4s/package.scala
+++ b/json4s/src/main/scala/io/finch/json4s/package.scala
@@ -3,7 +3,7 @@ package io.finch
 import com.twitter.util.Try
 import io.finch.internal.BufText
 import org.json4s._
-import org.json4s.jackson.JsonMethods
+import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization._
 
 package object json4s {
@@ -13,7 +13,7 @@ package object json4s {
    * @tparam A the type of data to decode into
    */
   implicit def decodeJson[A : Manifest](implicit formats: Formats): Decode.Json[A] =
-    Decode.json((b, cs) => Try(JsonMethods.parse(BufText.extract(b, cs)).extract[A]))
+    Decode.json((b, cs) => Try(parse(BufText.extract(b, cs)).extract[A]))
 
   /**
    * @param formats json4s `Formats` to use for decoding
@@ -22,4 +22,9 @@ package object json4s {
    */
   implicit def encodeJson[A <: AnyRef](implicit formats: Formats): Encode.Json[A] =
     Encode.json((a, cs) => BufText(write(a), cs))
+
+  implicit def encodeJsonException[A <: Exception]: Encode.Json[A] =
+    Encode.json((a, cs) =>
+      BufText(compact(render(JObject("message" -> JString(a.getMessage)))), cs)
+    )
 }

--- a/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
+++ b/json4s/src/test/scala/io/finch/json4s/Json4sSpec.scala
@@ -14,4 +14,5 @@ class Json4sSpec extends FlatSpec with Matchers with Checkers with JsonCodecProv
   it should "encode a list of case class instances as JSON" in encodeCaseClassList
   it should "decode a list of case class instances from JSON" in decodeCaseClassList
   it should "provide encoders with the correct content type" in checkContentType
+  it should "encode an exception" in encodeException
 }

--- a/playjson/src/main/scala/io/finch/playjson/package.scala
+++ b/playjson/src/main/scala/io/finch/playjson/package.scala
@@ -24,4 +24,8 @@ package object playjson {
    */
   implicit def encodePlayJson[A](implicit writes: Writes[A]): Encode.Json[A] =
     Encode.json((a, cs) => BufText(Json.stringify(Json.toJson(a)), cs))
+
+  implicit val encodeExceptionPlayJson: Writes[Exception] = new Writes[Exception] {
+    override def writes(e: Exception): JsValue = Json.obj("message" -> e.getMessage)
+  }
 }

--- a/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
+++ b/playjson/src/test/scala/io/finch/playjson/PlayJsonSpec.scala
@@ -24,4 +24,5 @@ class PlayJsonSpec extends FlatSpec with Matchers with Checkers with JsonCodecPr
   it should "encode a list of case class instances as JSON" in encodeCaseClassList
   it should "decode a list of case class instances from JSON" in decodeCaseClassList
   it should "provide encoders with the correct content type" in checkContentType
+  it should "encode an exception" in encodeException
 }

--- a/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
+++ b/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
@@ -12,7 +12,7 @@ package object sprayjson {
     * @param format spray-json support for convert JSON val to specific type object
     * @tparam A the type of the data to decode into
     */
-  implicit def decodeSpray[A](implicit format: JsonFormat[A]): Decode.Json[A] =
+  implicit def decodeSpray[A](implicit format: JsonReader[A]): Decode.Json[A] =
     Decode.json { (b, cs) =>
       cs match {
         case StandardCharsets.UTF_8 =>
@@ -27,6 +27,10 @@ package object sprayjson {
     * @param format spray-json support for convert JSON val to specific type object
     * @tparam A the type of the data to decode from
     */
-  implicit def encodeSpray[A](implicit format: JsonFormat[A]): Encode.Json[A] =
+  implicit def encodeSpray[A](implicit format: JsonWriter[A]): Encode.Json[A] =
     Encode.json((a, cs) => BufText(a.toJson.prettyPrint, cs))
+
+  implicit def encodeExceptionSpray[A <: Exception]: JsonWriter[A] = new JsonWriter[A] {
+    override def write(e: A): JsValue = JsObject("message" -> JsString(e.getMessage))
+  }
 }

--- a/sprayjson/src/test/scala/io/finch/sprayjson/sprayjsonSpec.scala
+++ b/sprayjson/src/test/scala/io/finch/sprayjson/sprayjsonSpec.scala
@@ -17,4 +17,5 @@ class sprayjsonSpec extends FlatSpec with Matchers with Checkers with JsonCodecP
   it should "encode a list of case class instances as JSON" in encodeCaseClassList
   it should "decode a list of case class instances from JSON" in decodeCaseClassList
   it should "provide encoders with the correct content type" in checkContentType
+  it should "encode an exception" in encodeException
 }


### PR DESCRIPTION
This PR is a successor of #675.

The main goal of this commit is to delegate the process of transforming Exceptions into JSON to the JSON libraries instead of handling it in the core package. Thus JSON Encoder for Exceptions is removed from the core package, but appropriate instances are provided in each of subprojects responsible for integration with the corresponding JSON libraries.

The motivation is that transforming even very simple data structures into the valid JSON is not so trivial and at least involves some logic of escaping strings before inserting them into the JSON document. Also, it seems obvious, that in the situation when exception need to be encoded into JSON, other data should be JSON encoded as well. and user will end up using some JSON library anyway. So, delegating this process (of encoding Exceptions) to JSON libraries does not force users to use one of them, because they already do. On the other hand it corresponds to the SoC principle and make the code better.