### PR TITLE
add content types

### DIFF
--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -34,6 +34,8 @@ package object finch extends Endpoints with Outputs with ValidationRules {
     type OctetStream = Witness.`"application/octet-stream"`.T
     type RssXml = Witness.`"application/rss+xml"`.T
     type WwwFormUrlencoded = Witness.`"application/x-www-form-urlencoded"`.T
+    type ThriftBinary = Witness.`"application/vnd.apache.thrift.binary"`.T
+    type ThriftCompact = Witness.`"application/vnd.apache.thrift.compact"`.T
   }
 
   object Text {


### PR DESCRIPTION
this adds the the official apache promoted content types to allow for clients to distinguish between compact and binary protocols. This is of use to me and hopefully of use more generally.