### PR TITLE
Remove Encode instance for Either

### DIFF
--- a/core/src/main/scala/io/finch/Encode.scala
+++ b/core/src/main/scala/io/finch/Encode.scala
@@ -53,13 +53,6 @@ trait HighPriorityEncodeInstances extends LowPriorityEncodeInstances {
 
   implicit def encodeBuf[CT <: String]: Aux[Buf, CT] =
     bufToBuf.asInstanceOf[Aux[Buf, CT]]
-
-  implicit def encodeEither[A, B, CT <: String](implicit
-    ae: Encode.Aux[A, CT],
-    be: Encode.Aux[B, CT]
-  ): Aux[Either[A, B], CT] = instance[Either[A, B], CT](
-    (either, cs) => either.fold(a => ae(a, cs), b => be(b, cs))
-  )
 }
 
 object Encode extends HighPriorityEncodeInstances {


### PR DESCRIPTION
I doubt that instance is useful at all. That should be a responsibility of any of the adopted JSON (or whatever) library to provide this kind of encoding machinery.