### PR TITLE
Introduce Endpoint.liftX

### DIFF
--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -3,6 +3,8 @@ package io.finch
 import com.twitter.finagle.http.Message
 import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.io.{Buf, Charsets}
+import com.twitter.util.Future
+import io.catbird.util.Rerunnable
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset, StandardCharsets}
 
@@ -13,6 +15,11 @@ import java.nio.charset.{Charset, StandardCharsets}
  * deprecation cycles.
  */
 package object internal {
+
+  // See https://github.com/travisbrown/catbird/pull/32
+  def rerunnable[A](a: A): Rerunnable[A] = new Rerunnable[A] {
+    override def run: Future[A] = Future.value(a)
+  }
 
   @inline private[this] final val someTrue: Option[Boolean] = Some(true)
   @inline private[this] final val someFalse: Option[Boolean] = Some(false)

--- a/core/src/test/scala/io/finch/BasicAuthSpec.scala
+++ b/core/src/test/scala/io/finch/BasicAuthSpec.scala
@@ -24,7 +24,7 @@ class BasicAuthSpec extends FinchSpec {
     check { (c: BasicAuthCredentials, realm: String, req: Request) =>
       req.authorization = encode(c.user, c.pass)
 
-      val e = BasicAuth(realm)((u, p) => Future(u == c.user && p == c.pass))(Endpoint(Ok("foo")))
+      val e = BasicAuth(realm)((u, p) => Future(u == c.user && p == c.pass))(Endpoint.const("foo"))
       val i = Input.request(req)
 
       e(i).output === Some(Ok("foo")) && {
@@ -35,7 +35,7 @@ class BasicAuthSpec extends FinchSpec {
   }
 
   it should "reach the unprotected endpoint" in {
-    val e = BasicAuth("realm")((_, _) => Future.False)("a") :+: ("b" :: Endpoint(Ok("foo")))
+    val e = BasicAuth("realm")((_, _) => Future.False)("a") :+: ("b" :: Endpoint.const("foo"))
 
     val protectedInput = Input.get("/a")
     e(protectedInput).remainder shouldBe Some(protectedInput.drop(1))


### PR DESCRIPTION
I would like us to deprecate `Endpoint.apply` (on the companion object) and provide some explicit meanings for building constant endpoints.