### PR TITLE
Add new body endpoints

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks/BodyBenchmark.scala
@@ -1,29 +1,46 @@
 package io.finch.benchmarks
 
 import com.twitter.io.Buf
+import com.twitter.util.Return
 import io.finch._
+import io.finch.internal.BufText
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
 @State(Scope.Benchmark)
 class BodyBenchmark extends FinchBenchmark {
 
+  implicit val decodeJsonAsString: Decode.Json[String] =
+    Decode.json((b, cs) => Return(BufText.extract(b, cs)))
+
   val input = Input.post("/").withBody[Text.Plain](Buf.Utf8("x" * 1024))
 
-  @Benchmark
-  def bufOption: Option[Buf] = bodyOption(input).value.get
+  val bodyAsString = body.as[String]
+  val bodyOptionAsString = bodyOption.as[String]
+
+  val bodyAsString2 = body[String, Application.Json]
+  val bodyOptionAsString2 = bodyOption[String, Application.Json]
 
   @Benchmark
-  def buf: Buf = body(input).value.get
+  def jsonOption: Option[String] = bodyOptionAsString(input).value.get
 
   @Benchmark
-  def stringOption: Option[String] = bodyStringOption(input).value.get
+  def json: String = bodyAsString(input).value.get
 
   @Benchmark
-  def string: String = bodyString(input).value.get
+  def jsonOption2: Option[String] = bodyOptionAsString2(input).value.get
 
   @Benchmark
-  def byteArrayOption: Option[Array[Byte]] = bodyByteArrayOption(input).value.get
+  def json2: String = bodyAsString2(input).value.get
 
   @Benchmark
-  def byteArray: Array[Byte] = bodyByteArray(input).value.get
+  def stringOption: Option[String] = stringBodyOption(input).value.get
+
+  @Benchmark
+  def string: String = stringBody(input).value.get
+
+  @Benchmark
+  def byteArrayOption: Option[Array[Byte]] = binaryBodyOption(input).value.get
+
+  @Benchmark
+  def byteArray: Array[Byte] = binaryBody(input).value.get
 }

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -404,7 +404,7 @@ object Endpoint {
    * Creates an [[Endpoint]] that always matches and returns a given value (evaluated eagerly).
    */
   def const[A](a: A): Endpoint[A] = new Endpoint[A] {
-    def apply(input: Input): Result[A] = Some(input -> rerunnable(Output.payload(a)))
+    def apply(input: Input): Result[A] = Some(input -> Rs.const(Output.payload(a)))
   }
 
   /**

--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -60,8 +60,7 @@ object Error {
   }
 
   /**
-   * An exception that indicates a broken [[[io.finch.request.ValidationRule ValidationRule]] on the
-   * request item.
+   * An exception that indicates a broken [[ValidationRule]] on the request item.
    *
    * @param item the invalid request item
    * @param rule the rule description

--- a/core/src/main/scala/io/finch/endpoint/Body.scala
+++ b/core/src/main/scala/io/finch/endpoint/Body.scala
@@ -1,0 +1,52 @@
+package io.finch.endpoint
+
+import com.twitter.util.{Future, Return, Throw}
+import io.catbird.util.Rerunnable
+import io.finch._
+import io.finch.internal._
+import io.finch.items._
+import scala.reflect.ClassTag
+
+private[finch] abstract class Body[A, B, CT <: String](
+    d: Decode.Aux[A, CT], ct: ClassTag[A]) extends Endpoint[B] {
+
+  protected def whenNotPresent: Rerunnable[Output[B]]
+  protected def prepare(a: A): B
+
+  private[this] def decode(i: Input): Future[Output[B]] =
+    d(i.request.content, i.request.charsetOrUtf8) match {
+      case Return(r) => Future.value(Output.payload(prepare(r)))
+      case Throw(t) => Future.exception(Error.NotParsed(items.BodyItem, ct, t))
+    }
+
+  final def apply(input: Input): Endpoint.Result[B] =
+    if (input.request.isChunked) None
+    else {
+      val rr = input.request.contentLength match {
+        case None => whenNotPresent
+        case _ => Rerunnable.fromFuture(decode(input))
+      }
+
+      Some(input -> rr)
+    }
+
+  override def item: RequestItem = items.BodyItem
+  override def toString: String = "body"
+}
+
+private[finch] final class RequiredBody[A, CT <: String](
+    d: Decode.Aux[A, CT], ct: ClassTag[A]) extends Body[A, A, CT](d, ct) {
+
+  protected def prepare(a: A): A = a
+  protected def whenNotPresent: Rerunnable[Output[A]] =
+    Rs.BodyNotPresent.asInstanceOf[Rerunnable[Output[A]]]
+}
+
+private[finch] final class OptionalBody[A, CT <: String](
+    d: Decode.Aux[A, CT], ct: ClassTag[A]) extends Body[A, Option[A], CT](d, ct) {
+
+  protected def prepare(a: A): Option[A] = Some(a)
+  protected def whenNotPresent: Rerunnable[Output[Option[A]]] =
+    Rs.OutputNone.asInstanceOf[Rerunnable[Output[Option[A]]]]
+}
+

--- a/core/src/main/scala/io/finch/internal/Rs.scala
+++ b/core/src/main/scala/io/finch/internal/Rs.scala
@@ -1,0 +1,33 @@
+package io.finch.internal
+
+import com.twitter.util.Future
+import io.catbird.util.Rerunnable
+import io.finch._
+import io.finch.items._
+import shapeless.HNil
+
+/**
+ * Predefined, Finch-specific instances of [[Rerunnable]].
+ */
+private[finch] object Rs {
+  // See https://github.com/travisbrown/catbird/pull/32
+  final def const[A](a: A): Rerunnable[A] = new Rerunnable[A] {
+    override def run: Future[A] = Future.value(a)
+  }
+
+  final val OutputNone: Rerunnable[Output[Option[Nothing]]] =
+    new Rerunnable[Output[Option[Nothing]]] {
+      override val run: Future[Output[Option[Nothing]]] =
+        Future.value(Output.None)
+    }
+
+  final val BodyNotPresent: Rerunnable[Nothing] = new Rerunnable[Nothing] {
+    override val run: Future[Nothing] =
+      Future.exception(Error.NotPresent(BodyItem))
+  }
+
+  final val OutputHNil: Rerunnable[Output[HNil]] =
+    new Rerunnable[Output[HNil]] {
+      override val run: Future[Output[HNil]] = Future.value(Output.payload(HNil))
+    }
+}

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -16,11 +16,6 @@ import java.nio.charset.{Charset, StandardCharsets}
  */
 package object internal {
 
-  // See https://github.com/travisbrown/catbird/pull/32
-  def rerunnable[A](a: A): Rerunnable[A] = new Rerunnable[A] {
-    override def run: Future[A] = Future.value(a)
-  }
-
   @inline private[this] final val someTrue: Option[Boolean] = Some(true)
   @inline private[this] final val someFalse: Option[Boolean] = Some(false)
 

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -272,7 +272,7 @@ class EndpointSpec extends FinchSpec {
     Seq(
       param("foo"), header("foo"), body, cookie("foo").map(_.value),
       fileUpload("foo").map(_.fileName), paramsNel("foo").map(_.toList.mkString),
-      paramsNel("foor").map(_.toList.mkString), bodyByteArray.map(new String(_))
+      paramsNel("foor").map(_.toList.mkString), binaryBody.map(new String(_))
     ).foreach { ii => ii(i).tryValue shouldBe Some(Throw(Error.NotPresent(ii.item))) }
   }
 

--- a/core/src/test/scala/io/finch/data/Foo.scala
+++ b/core/src/test/scala/io/finch/data/Foo.scala
@@ -2,14 +2,23 @@ package io.finch.data
 
 import cats.Show
 import com.twitter.util.Return
-import io.finch.DecodeEntity
+import io.finch.{Decode, DecodeEntity}
+import io.finch.internal._
+import org.scalacheck.{Arbitrary, Gen}
 
 case class Foo(s: String)
+
 object Foo {
   implicit val showFoo: Show[Foo] =
     Show.show(_.s)
 
   implicit val decodeFoo: DecodeEntity[Foo] =
     DecodeEntity.instance(s => Return(Foo(s)))
+
+  implicit val decodeFooAsPlainText: Decode.Text[Foo] =
+    Decode.text((b, cs) => Return(Foo(BufText.extract(b, cs))))
+
+  implicit val arbitraryFoo: Arbitrary[Foo] =
+    Arbitrary(Gen.alphaStr.map(Foo.apply))
 }
 

--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -33,7 +33,7 @@ object Main {
 
   val execute: Eval = new Eval()
 
-  def eval: Endpoint[EvalOutput] = post("eval" :: body.as[EvalInput]) { i: EvalInput =>
+  def eval: Endpoint[EvalOutput] = post("eval" :: jsonBody[EvalInput]) { i: EvalInput =>
     Ok(EvalOutput(execute[Any](i.expression).toString))
   } handle {
     case e: Exception => BadRequest(e)

--- a/examples/src/main/scala/io/finch/oauth2/InMemoryDataHandler.scala
+++ b/examples/src/main/scala/io/finch/oauth2/InMemoryDataHandler.scala
@@ -41,7 +41,7 @@ object InMemoryDataHandler extends DataHandler[OAuthUser] {
   private[this] val authInfosByAccessToken = new ConcurrentHashMap[String, AuthInfo[OAuthUser]]().asScala
 
   private[this] def makeToken: AccessToken = {
-    new AccessToken(
+    AccessToken(
       token = s"AT-${UUID.randomUUID()}",
       refreshToken = Some(s"RT-${UUID.randomUUID()}"),
       scope = None,

--- a/examples/src/main/scala/io/finch/todo/Main.scala
+++ b/examples/src/main/scala/io/finch/todo/Main.scala
@@ -37,8 +37,7 @@ object Main extends TwitterServer {
 
   val todos: Counter = statsReceiver.counter("todos")
 
-  def postedTodo: Endpoint[Todo] =
-    body.as[UUID => Todo].map(_(UUID.randomUUID()))
+  def postedTodo: Endpoint[Todo] = jsonBody[UUID => Todo].map(_(UUID.randomUUID()))
 
   def postTodo: Endpoint[Todo] = post("todos" :: postedTodo) { t: Todo =>
     todos.incr()
@@ -47,7 +46,7 @@ object Main extends TwitterServer {
     Created(t)
   }
 
-  def patchedTodo: Endpoint[Todo => Todo] = body.as[Todo => Todo]
+  def patchedTodo: Endpoint[Todo => Todo] = jsonBody[Todo => Todo]
 
   def patchTodo: Endpoint[Todo] =
     patch("todos" :: uuid :: patchedTodo) { (id: UUID, pt: Todo => Todo) =>
@@ -69,7 +68,7 @@ object Main extends TwitterServer {
   def deleteTodo: Endpoint[Todo] = delete("todos" :: uuid) { id: UUID =>
     Todo.get(id) match {
       case Some(t) => Todo.delete(id); Ok(t)
-      case None => throw new TodoNotFound(id)
+      case None => throw TodoNotFound(id)
     }
   }
 

--- a/examples/src/main/scala/io/finch/wrk/Finch.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finch.scala
@@ -3,7 +3,6 @@ package io.finch.wrk
 import io.circe.generic.auto._
 import io.finch._
 import io.finch.circe._
-import shapeless.Witness
 
 /**
  * How to benchmark this:
@@ -18,8 +17,5 @@ import shapeless.Witness
  *   c = t * n * 1.5
  */
 object Finch extends App {
-
-  val roundTrip: Endpoint[Payload] = post(body.as[Payload])
-
-  serve(roundTrip.toServiceAs[Witness.`"application/json"`.T])
+  serve(post(jsonBody[Payload]).toServiceAs[Application.Json])
 }


### PR DESCRIPTION
This fixes #666.

This is a baby-step improvement that introduces a new way of decoding JSON/XML (anything with `Decode.Aux` instances) in Finch. Instead of using the `.as` machinery which became quite ambiguous already, this RP introduces a new API for building endpoints that read HTTP payloads.

```scala
def body[A, CT <: ContentType]: Endpoint[A]
def bodyOption[A, CT <: ContentType]: Endpoint[Option[A]]
```
The previous version `body.as[A]` is fixed to JSON and is still supported.

I was thinking back and forth on what kind of API would make sense here and decided to go with a very simple thing: just function with two type parameters. Here are some benefits of this approach vs. the previous one (`body.as[A]`).

1. It's less powerful.
2. It reduces the complexity/ambiguity of the `.as` API that might mean several things (decoding with `DecodeEntity` or converting from an `HList`).
3. It simpler so it involves fewer indirections (nested endpoints). Previously, `body` produces an endpoint (actually two nested endpoints) and then `.as` wraps it with one extra layer. Now `body[A, CT]` produces a flat endpoint. This means fewer allocations and better performance (see Performance section).

## Performance

1. 15% less running time and 20% fewer allocations for `body`.
2. 7% less running time and 15% fewer allocations for `bodyOption`.

`json(Option)` is before, `json(Option)2` is after.

```
[info] BodyBenchmark.json                       avgt    6  4824.580 ± 1205.444   ns/op
[info] BodyBenchmark.json:·gc.alloc.rate.norm   avgt    6  5896.004 ±  147.449    B/op
[info] BodyBenchmark.json2                      avgt    6  4179.209 ±  673.098   ns/op
[info] BodyBenchmark.json2:·gc.alloc.rate.norm  avgt    6  4936.004 ±   73.723    B/op

[info] BodyBenchmark.jsonOption                       avgt    6  4335.755 ±  150.928   ns/op
[info] BodyBenchmark.jsonOption:·gc.alloc.rate.norm   avgt    6  5712.004 ±    0.001    B/op
[info] BodyBenchmark.jsonOption2                      avgt    6  4050.681 ±  685.263   ns/op
[info] BodyBenchmark.jsonOption2:·gc.alloc.rate.norm  avgt    6  4940.004 ±   36.862    
```

## New Structure

This PR also starts a good tradition (I hope) and defines a new `Body` endpoint as an actual class in the `io.finch.endpoint` package. `Endpoints` already became quite big and it promoted a lot of design/implementation decisions that coupled lots of endpoints together by trade offing performance with code site.

At this point, I prefer we start extracting endpoints in their separate classes (similarly how [scodec does it](https://github.com/scodec/scodec/tree/series/1.10.x/shared/src/main/scala/scodec/codecs)) so they are not coupled to each other and could be evolved separately with performance/efficiency in mind.