### PR TITLE
Fix json exception encoders

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Encoders.scala
@@ -15,6 +15,7 @@ trait Encoders {
     Encode.json((a, cs) => BufText(printer.pretty(e.encode(a)), cs))
 
   implicit def encodeExceptionArgonaut[A <: Exception]: EncodeJson[A] = new EncodeJson[A] {
-    override def encode(a: A): Json = Json.obj(("message", Json.jString(a.getMessage)))
+    override def encode(a: A): Json =
+      Json.obj(("message", Option(a.getMessage).fold(Json.jNull)(Json.jString)))
   }
 }

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -15,6 +15,7 @@ trait Encoders {
     Encode.json((a, cs) => BufText(print(e(a)), cs))
 
   implicit def encodeExceptionCirce[A <: Exception]: Encoder[A] = new Encoder[A] {
-    override def apply(e: A): Json = Json.obj(("message", Json.fromString(e.getMessage)))
+    override def apply(e: A): Json =
+      Json.obj(("message", Option(e.getMessage).fold(Json.Null)(Json.fromString)))
   }
 }

--- a/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
+++ b/json-test/src/main/scala/io/finch/test/json/JsonCodecProviderProperties.scala
@@ -1,7 +1,7 @@
 package io.finch.test.json
 
 import argonaut.{CodecJson, DecodeJson, EncodeJson, Json, Parse}
-import argonaut.Argonaut.{casecodec3, casecodec5, jString}
+import argonaut.Argonaut.{casecodec3, casecodec5, jNull, jString}
 import com.twitter.io.Buf
 import com.twitter.io.Buf.Utf8
 import com.twitter.util.Return
@@ -124,6 +124,11 @@ trait JsonCodecProviderProperties { self: Matchers with Checkers =>
       val jsonString = BufText.extract(ee(e, StandardCharsets.UTF_8), StandardCharsets.UTF_8)
       Parse.parseOption(jsonString) === Some(Json("message" -> jString(e.getMessage)))
     }
+
+    // Check that this encoder can encode exceptions with null messages
+    val e = new Exception()
+    val jsonString = BufText.extract(ee(e, StandardCharsets.UTF_8), StandardCharsets.UTF_8)
+    Parse.parseOption(jsonString) === Some(Json("message" -> jNull))
   }
 }
 

--- a/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
+++ b/sprayjson/src/main/scala/io/finch/sprayjson/package.scala
@@ -18,6 +18,7 @@ package object sprayjson {
     Encode.json((a, cs) => BufText(a.toJson.prettyPrint, cs))
 
   implicit def encodeExceptionSpray[A <: Exception]: JsonWriter[A] = new JsonWriter[A] {
-    override def write(e: A): JsValue = JsObject("message" -> JsString(e.getMessage))
+    override def write(e: A): JsValue =
+      JsObject("message" -> Option(e.getMessage).fold[JsValue](JsNull)(JsString.apply))
   }
 }


### PR DESCRIPTION
This commit fixes the bug, when exceptions with null messages are failed to be encoded into json by several json libraries supported by finch.