### PR TITLE
handle io.finch.Errors

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -260,6 +260,7 @@ trait Endpoint[A] { self =>
 
     private[this] val basicEndpointHandler: PartialFunction[Throwable, Output[Nothing]] = {
       case e: io.finch.Error => Output.failure(e, Status.BadRequest)
+      case es: io.finch.Errors => Output.failure(es, Status.BadRequest)
     }
 
     private[this] val safeEndpoint = self.handle(basicEndpointHandler)


### PR DESCRIPTION
after asService...  io.finch.Errors and all io.finch.Error should be handled by default and translated into BadRequest. This adds that behavior for Errors.