### PR TITLE
Fix reference to incorrect decode object

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -525,7 +525,7 @@ since the epoch:
 import io.finch._
 
 implicit val dateTimeDecoder: DecodeEntity[DateTime] =
-  Decode.instance(s => Try(new DateTime(s.toLong)))
+  DecodeEntity.instance(s => Try(new DateTime(s.toLong)))
 ```
 
 All you need to implement is a simple function from `String` to `Try[A]`.


### PR DESCRIPTION
The function signature and context implies that `DecodeEntity` was intended instead of `Decode`.