### PR TITLE
Introduce EndpointResult

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -27,22 +27,22 @@ class BodyBenchmark extends FinchBenchmark {
   val fooAsText: Endpoint[Foo] = body[Foo, Text.Plain]
 
   @Benchmark
-  def fooOption: Option[Option[Foo]] = fooOptionAsText(postPayload).value
+  def fooOption: Option[Option[Foo]] = fooOptionAsText(postPayload).awaitValueUnsafe()
 
   @Benchmark
-  def foo: Option[Foo] = fooAsText(postPayload).value
+  def foo: Option[Foo] = fooAsText(postPayload).awaitValueUnsafe()
 
   @Benchmark
-  def stringOption: Option[Option[String]] = stringBodyOption(postPayload).value
+  def stringOption: Option[Option[String]] = stringBodyOption(postPayload).awaitValueUnsafe()
 
   @Benchmark
-  def string: Option[String] = stringBody(postPayload).value
+  def string: Option[String] = stringBody(postPayload).awaitValueUnsafe()
 
   @Benchmark
-  def byteArrayOption: Option[Option[Array[Byte]]] = binaryBodyOption(postPayload).value
+  def byteArrayOption: Option[Option[Array[Byte]]] = binaryBodyOption(postPayload).awaitValueUnsafe()
 
   @Benchmark
-  def byteArray: Option[Array[Byte]] = binaryBody(postPayload).value
+  def byteArray: Option[Array[Byte]] = binaryBody(postPayload).awaitValueUnsafe()
 }
 
 @State(Scope.Benchmark)
@@ -51,31 +51,31 @@ class MatchPathBenchmark extends FinchBenchmark {
   val foo: Endpoint[HNil] = "foo"
 
   @Benchmark
-  def stringSome: Option[HNil] = foo(getFooBarBaz).value
+  def stringSome: Option[HNil] = foo(getFooBarBaz).awaitValueUnsafe()
 
   @Benchmark
-  def stringNone: Option[HNil] = foo(getRoot).value
+  def stringNone: Option[HNil] = foo(getRoot).awaitValueUnsafe()
 }
 
 @State(Scope.Benchmark)
 class ExtractPathBenchmark extends FinchBenchmark {
   @Benchmark
-  def stringSome: Option[String] = string(getFooBarBaz).value
+  def stringSome: Option[String] = string(getFooBarBaz).awaitValueUnsafe()
 
   @Benchmark
-  def stringNone: Option[String] = string(getRoot).value
+  def stringNone: Option[String] = string(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def intSome: Option[Int] = int(getTenTwenty).value
+  def intSome: Option[Int] = int(getTenTwenty).awaitValueUnsafe()
 
   @Benchmark
-  def intNone: Option[Int] = int(getFooBarBaz).value
+  def intNone: Option[Int] = int(getFooBarBaz).awaitValueUnsafe()
 
   @Benchmark
-  def booleanSome: Option[Boolean] = boolean(getTrueFalse).value
+  def booleanSome: Option[Boolean] = boolean(getTrueFalse).awaitValueUnsafe()
 
   @Benchmark
-  def booleanNone: Option[Boolean] = boolean(getTenTwenty).value
+  def booleanNone: Option[Boolean] = boolean(getTenTwenty).awaitValueUnsafe()
 }
 
 @State(Scope.Benchmark)
@@ -85,13 +85,13 @@ class ProductBenchmark extends FinchBenchmark {
   val right: Endpoint[(Int, String)] = Endpoint.empty[Int].product(Endpoint.const("foo"))
 
   @Benchmark
-  def bothMatched: Option[(Int, String)] = both(getRoot).value
+  def bothMatched: Option[(Int, String)] = both(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def leftMatched: Option[(Int, String)] = left(getRoot).value
+  def leftMatched: Option[(Int, String)] = left(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def rightMatched: Option[(Int, String)] = right(getRoot).value
+  def rightMatched: Option[(Int, String)] = right(getRoot).awaitValueUnsafe()
 }
 
 @State(Scope.Benchmark)
@@ -101,13 +101,13 @@ class CoproductBenchmark extends FinchBenchmark {
   val right: Endpoint[String] = Endpoint.empty[String] | Endpoint.const("bar")
 
   @Benchmark
-  def bothMatched: Option[String] = both(getRoot).value
+  def bothMatched: Option[String] = both(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def leftMatched: Option[String] = left(getRoot).value
+  def leftMatched: Option[String] = left(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def rightMatched: Option[String] = right(getRoot).value
+  def rightMatched: Option[String] = right(getRoot).awaitValueUnsafe()
 }
 
 @State(Scope.Benchmark)
@@ -119,14 +119,14 @@ class MapBenchmark extends FinchBenchmark {
   val mapTenOutputAsync: Endpoint[Int] = ten.mapOutputAsync(a => Future.value(Ok(a + 10)))
 
   @Benchmark
-  def map: Option[Int] = mapTen(getRoot).value
+  def map: Option[Int] = mapTen(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def mapAsync: Option[Int] = mapTenAsync(getRoot).value
+  def mapAsync: Option[Int] = mapTenAsync(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def mapOutput: Option[Int] = mapTenOutput(getRoot).value
+  def mapOutput: Option[Int] = mapTenOutput(getRoot).awaitValueUnsafe()
 
   @Benchmark
-  def mapOutputAsync: Option[Int] = mapTenOutputAsync(getRoot).value
+  def mapOutputAsync: Option[Int] = mapTenOutputAsync(getRoot).awaitValueUnsafe()
 }

--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -1,0 +1,144 @@
+package io.finch
+
+import com.twitter.util.{Await, Duration, Try}
+import io.catbird.util.Rerunnable
+
+/**
+ * A result returned from an [[Endpoint]]. This models `Option[(Input, Future[Output])]` and
+ * represents two cases:
+ *
+ *  - Endpoint is matched so both `remainder` and `output` is returned.
+ *  - Endpoint is skipped so `None` is returned.
+ *
+ * API methods exposed on this type are mostly introduced for testing.
+ *
+ * This class also provides various of `awaitX` methods useful for testing and experimenting.
+ */
+sealed abstract class EndpointResult[+A] {
+
+  /**
+   * Whether the [[Endpoint]] is matched on a given [[Input]].
+   */
+  def isMatched: Boolean
+
+  /**
+   * Returns the remainder of the [[Input]] after an [[Endpoint]] is matched.
+   *
+   * @return `Some(remainder)` if this endpoint was matched on a given input,
+   *         `None` otherwise.
+   */
+  final def remainder: Option[Input] = this match {
+    case EndpointResult.Matched(rem, _) => Some(rem)
+    case _ => None
+  }
+
+  /**
+   * Awaits for an [[Output]] wrapped with [[Try]] (indicating if the [[com.twitter.util.Future]]
+   * is failed).
+   *
+   * @note This method is blocking. Never use it in production.
+   *
+   * @return `Some(output)` if this endpoint was matched on a given input, `None` otherwise.
+   */
+  final def awaitOutput(d: Duration = Duration.Top): Option[Try[Output[A]]] = this match {
+    case EndpointResult.Matched(_, out) => Some(Await.result(out.liftToTry.run, d))
+    case _ => None
+  }
+
+  /**
+   * Awaits an [[Output]] of the [[Endpoint]] result or throws an exception if an underlying
+   * [[com.twitter.util.Future]] is failed.
+   *
+   * @note This method is blocking. Never use it in production.
+   *
+   * @return `Some(output)` if this endpoint was matched on a given input, `None` otherwise.
+   */
+  final def awaitOutputUnsafe(d: Duration = Duration.Top): Option[Output[A]] =
+    awaitOutput(d).map(toa => toa.get)
+
+  /**
+   * Awaits a value from the [[Output]] wrapped with [[Try]] (indicating if either the
+   * [[com.twitter.util.Future]] is failed or [[Output]] wasn't a payload).
+   *
+   * @note This method is blocking. Never use it in production.
+   *
+   * @return `Some(value)` if this endpoint was matched on a given input, `None` otherwise.
+   */
+  final def awaitValue(d: Duration = Duration.Top): Option[Try[A]] =
+    awaitOutput(d).map(toa => toa.flatMap(oa => Try(oa.value)))
+
+  /**
+   * Awaits a value from the [[Output]] or throws an exception if either an underlying
+   * [[com.twitter.util.Future]] is failed or [[Output]] wasn't a payload.
+   *
+   * @note @note This method is blocking. Never use it in production.
+   *
+   * @return `Some(value)` if this endpoint was matched on a given input,
+   *         `None` otherwise.
+   */
+  final def awaitValueUnsafe(d: Duration = Duration.Top): Option[A] =
+    awaitOutputUnsafe(d).map(oa => oa.value)
+
+  /**
+   * Queries an [[Output]] wrapped with [[Try]] (indicating if the [[com.twitter.util.Future]] is
+   * failed).
+   *
+   * @note This method is blocking and awaits on the underlying [[com.twitter.util.Future]] with
+   *       the upper bound of 10 seconds.
+   *
+   * @return `Some(output)` if this endpoint was matched on a given input,
+   *         `None` otherwise.
+   */
+  @deprecated("Use awaitOutput(Duration) instead", "0.12")
+  final def tryOutput: Option[Try[Output[A]]] = awaitOutput(Duration.fromSeconds(10))
+
+  /**
+   * Queries a value from the [[Output]] wrapped with [[Try]] (indicating if either the
+   * [[com.twitter.util.Future]] is failed or [[Output]] wasn't a payload).
+   *
+   * @note This method is blocking and awaits on the underlying [[com.twitter.util.Future]] with
+   *       the upper bound of 10 seconds.
+   *
+   * @return `Some(value)` if this endpoint was matched on a given input,
+   *         `None` otherwise.
+   */
+  @deprecated("Use awaitValue(Duration) instead", "0.12")
+  final def tryValue: Option[Try[A]] = awaitValue(Duration.fromSeconds(10))
+
+  /**
+   * Queries an [[Output]] of the [[Endpoint]] result or throws an exception if an underlying
+   * [[com.twitter.util.Future]] is failed.
+   *
+   * @note This method is blocking and awaits on the underlying [[com.twitter.util.Future]]
+   *       with the upper bound of 10 seconds.
+   *
+   * @return `Some(output)` if this endpoint was matched on a given input,
+   *         `None` otherwise.
+   */
+  @deprecated("Use awaitOutputUnsafe(Duration) instead",  "0.12")
+  final def output: Option[Output[A]] = awaitOutputUnsafe(Duration.fromSeconds(10))
+
+  /**
+   * Queries the value from the [[Output]] or throws an exception if either an underlying
+   * [[com.twitter.util.Future]] is failed or [[Output]] wasn't a payload.
+   *
+   * @note This method is blocking and awaits on the underlying [[com.twitter.util.Future]] with
+   *       the upper bound of 10 seconds.
+   *
+   * @return `Some(value)` if this endpoint was matched on a given input,
+   *         `None` otherwise.
+   */
+  @deprecated("Use awaitValueUnsafe instead", "0.12")
+  final def value: Option[A] = awaitValueUnsafe(Duration.fromSeconds(10))
+}
+
+object EndpointResult {
+
+  case object Skipped extends EndpointResult[Nothing] {
+    def isMatched: Boolean = false
+  }
+
+  final case class Matched[A](rem: Input, out: Rerunnable[Output[A]]) extends EndpointResult[A] {
+    def isMatched: Boolean = true
+  }
+}

--- a/core/src/main/scala/io/finch/endpoint/Body.scala
+++ b/core/src/main/scala/io/finch/endpoint/Body.scala
@@ -20,14 +20,13 @@ private[finch] abstract class Body[A, B, CT <: String](
     }
 
   final def apply(input: Input): Endpoint.Result[B] =
-    if (input.request.isChunked) None
+    if (input.request.isChunked) EndpointResult.Skipped
     else {
-      val rr = input.request.contentLength match {
-        case None => whenNotPresent
-        case _ => Rerunnable.fromFuture(decode(input))
-      }
+      val out =
+        if (input.request.contentLength.isEmpty) whenNotPresent
+        else Rerunnable.fromFuture(decode(input))
 
-      Some(input -> rr)
+      EndpointResult.Matched(input, out)
     }
 
   override def item: RequestItem = items.BodyItem

--- a/core/src/main/scala/io/finch/internal/FromParams.scala
+++ b/core/src/main/scala/io/finch/internal/FromParams.scala
@@ -3,7 +3,6 @@ package io.finch.internal
 import scala.reflect.ClassTag
 
 import cats.data.NonEmptyList
-import io.catbird.util.Rerunnable
 import io.finch._
 import shapeless._
 import shapeless.labelled._
@@ -19,9 +18,7 @@ trait FromParams[L <: HList] {
 object FromParams {
 
   implicit val hnilFromParams: FromParams[HNil] = new FromParams[HNil] {
-    def endpoint: Endpoint[HNil] = Endpoint.embed(items.MultipleItems)(input =>
-      Some(input -> Rerunnable(Output.payload(HNil)))
-    )
+    def endpoint: Endpoint[HNil] = Endpoint.const(HNil)
   }
 
   implicit def hconsFromParams[HK <: Symbol, HV, T <: HList](implicit

--- a/core/src/main/scala/io/finch/internal/Rs.scala
+++ b/core/src/main/scala/io/finch/internal/Rs.scala
@@ -10,10 +10,13 @@ import shapeless.HNil
  * Predefined, Finch-specific instances of [[Rerunnable]].
  */
 private[finch] object Rs {
-  // See https://github.com/travisbrown/catbird/pull/32
-  final def const[A](a: A): Rerunnable[A] = new Rerunnable[A] {
-    override def run: Future[A] = Future.value(a)
+
+  final def constFuture[A](fa: Future[A]): Rerunnable[A] = new Rerunnable[A] {
+    override def run: Future[A] = fa
   }
+
+  // See https://github.com/travisbrown/catbird/pull/32
+  final def const[A](a: A): Rerunnable[A] = constFuture(Future.value(a))
 
   final val OutputNone: Rerunnable[Output[Option[Nothing]]] =
     new Rerunnable[Output[Option[Nothing]]] {

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -3,7 +3,7 @@ package io.finch.internal
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.util.Future
-import io.finch.{Endpoint, Input, Output}
+import io.finch.{Endpoint, EndpointResult, Input, Output}
 
 /**
  * Wraps a given [[Endpoint]] with a Finagle [[Service]].
@@ -30,8 +30,8 @@ private[finch] final class ToService[A, CT <: String](
   }
 
   def apply(req: Request): Future[Response] = underlying(Input.request(req)) match {
-    case Some(remainderAndOutput) if remainderAndOutput._1.isEmpty =>
-      remainderAndOutput._2.map(oa => copyVersion(req, oa.toResponse(tr, tre))).run
+    case EndpointResult.Matched(rem, out) if rem.isEmpty =>
+      out.map(oa => copyVersion(req, oa.toResponse(tr, tre))).run
     case _ => Future.value(Response(req.version, Status.NotFound))
   }
 }

--- a/core/src/test/scala/io/finch/BasicAuthSpec.scala
+++ b/core/src/test/scala/io/finch/BasicAuthSpec.scala
@@ -27,9 +27,9 @@ class BasicAuthSpec extends FinchSpec {
       val e = BasicAuth(realm)((u, p) => Future(u == c.user && p == c.pass))(Endpoint.const("foo"))
       val i = Input.request(req)
 
-      e(i).output === Some(Ok("foo")) && {
+      e(i).awaitOutputUnsafe() === Some(Ok("foo")) && {
         req.authorization = "secret"
-        e(i).output === Some(unauthorized(realm))
+        e(i).awaitOutputUnsafe() === Some(unauthorized(realm))
       }
     }
   }
@@ -39,11 +39,11 @@ class BasicAuthSpec extends FinchSpec {
 
     val protectedInput = Input.get("/a")
     e(protectedInput).remainder shouldBe Some(protectedInput.drop(1))
-    e(protectedInput).output shouldBe Some(unauthorized("realm"))
+    e(protectedInput).awaitOutputUnsafe() shouldBe Some(unauthorized("realm"))
 
     val unprotectedInput = Input.get("/b")
     e(unprotectedInput).remainder shouldBe Some(unprotectedInput.drop(1))
-    e(unprotectedInput).output.map(_.status) shouldBe Some(Status.Ok)
+    e(unprotectedInput).awaitOutputUnsafe().map(_.status) shouldBe Some(Status.Ok)
 
     val notFound = Input.get("/c")
     e(notFound).remainder shouldBe None // 404

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -22,30 +22,31 @@ class BodySpec extends FinchSpec {
   checkAll("Body[UUID]", EntityEndpointLaws[UUID](stringBodyOption)(withBody).evaluating)
 
   it should "respond with NotFound when it's required" in {
-    body[Foo, Text.Plain].apply(Input.get("/")).tryValue ===
+    body[Foo, Text.Plain].apply(Input.get("/")).awaitValue() ===
       Some(Throw(Error.NotPresent(items.BodyItem)))
   }
 
   it should "respond with None when it's optional" in {
-    body[Foo, Text.Plain].apply(Input.get("/")).tryValue === Some(Return(None))
+    body[Foo, Text.Plain].apply(Input.get("/")).awaitValue() === Some(Return(None))
   }
 
   it should "not match on streaming requests" in {
     val req = Request()
     req.setChunked(true)
-    body[Foo, Text.Plain].apply(Input.request(req)).value === None
+    body[Foo, Text.Plain].apply(Input.request(req)).awaitValueUnsafe() === None
   }
 
   it should "respond with a value when present and required" in {
     check { f: Foo =>
-      body[Foo, Text.Plain].apply(Input.post("/").withBody[Text.Plain](f)).value === Some(f)
+      val i = Input.post("/").withBody[Text.Plain](f)
+      body[Foo, Text.Plain].apply(i).awaitValueUnsafe() === Some(f)
     }
   }
 
   it should "respond with Some(value) when it's present and optional" in {
     check { f: Foo =>
-      bodyOption[Foo, Text.Plain].apply(Input.post("/").withBody[Text.Plain](f)).value ===
-        Some(Some(f))
+      val i = Input.post("/").withBody[Text.Plain](f)
+      bodyOption[Foo, Text.Plain].apply(i).awaitValueUnsafe().flatten === Some(f)
     }
   }
 }

--- a/core/src/test/scala/io/finch/EntityEndpointLaws.scala
+++ b/core/src/test/scala/io/finch/EntityEndpointLaws.scala
@@ -19,7 +19,7 @@ trait EntityEndpointLaws[A] extends Laws with MissingInstances with AllInstances
     val s = a.toString
     val i = serialize(s)
     val e = endpoint.as(decoder, classTag)
-    e(i).value.flatten <-> Some(a)
+    e(i).awaitValueUnsafe().flatten <-> Some(a)
   }
 
   def evaluating(implicit A: Arbitrary[A], eq: Eq[A]): RuleSet =

--- a/examples/src/test/scala/io/finch/div/DivSpec.scala
+++ b/examples/src/test/scala/io/finch/div/DivSpec.scala
@@ -9,12 +9,12 @@ class DivSpec extends FlatSpec with Matchers {
 
   import Main.div
   it should "work if the request is a put and the divisor is not 0" in {
-    div(Input.post("/20/10")).value shouldBe Some(2)
+    div(Input.post("/20/10")).awaitValueUnsafe() shouldBe Some(2)
   }
   it should "give back bad request if we divide by 0" in {
-    div(Input.post("/20/0")).output.map(_.status) shouldBe Some(Status.BadRequest)
+    div(Input.post("/20/0")).awaitOutputUnsafe().map(_.status) shouldBe Some(Status.BadRequest)
   }
   it should "give back nothing for other verbs" in {
-    div(Input.get("/20/10")).value shouldBe None
+    div(Input.get("/20/10")).awaitValueUnsafe() shouldBe None
   }
 }

--- a/examples/src/test/scala/io/finch/eval/EvalSpec.scala
+++ b/examples/src/test/scala/io/finch/eval/EvalSpec.scala
@@ -12,20 +12,26 @@ class EvalSpec extends FlatSpec with Matchers {
   import Main._
 
   it should "properly evaluate a well-formed expression" in {
-    val result = eval(Input.post("/eval")
-      .withBody[Application.Json](EvalInput("10 + 10"), Some(StandardCharsets.UTF_8))).value
+    val result = eval(
+      Input.post("/eval")
+        .withBody[Application.Json](EvalInput("10 + 10"), Some(StandardCharsets.UTF_8))
+    ).awaitValueUnsafe()
 
     result shouldBe Some(EvalOutput("20"))
   }
   it should "give back bad request if the expression isn't parseable" in {
-    val output = eval(Input.post("/eval")
-      .withBody[Application.Json](EvalInput("s = 12"), Some(StandardCharsets.UTF_8))).output
+    val output = eval(
+      Input.post("/eval")
+        .withBody[Application.Json](EvalInput("s = 12"), Some(StandardCharsets.UTF_8))
+    ).awaitOutputUnsafe()
 
     output.map(_.status) shouldBe Some(Status.BadRequest)
   }
   it should "give back nothing for other verbs" in {
-    val result = eval(Input.get("/eval")
-      .withBody[Application.Json](EvalInput("10 + 10"), Some(StandardCharsets.UTF_8))).value
+    val result = eval(
+      Input.get("/eval")
+        .withBody[Application.Json](EvalInput("10 + 10"), Some(StandardCharsets.UTF_8))
+    ).awaitValueUnsafe()
 
     result shouldBe None
   }

--- a/examples/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/examples/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -15,62 +15,82 @@ class OAuth2Spec extends FlatSpec with Matchers {
         "username" -> "user_name",
         "password" -> "user_password",
         "client_id" -> "user_id")
-    tokens(input).value.map(_.tokenType) shouldBe Some("Bearer")
+
+    tokens(input).awaitValueUnsafe().map(_.tokenType) shouldBe Some("Bearer")
   }
+
   it should "give an access token with the client credentials grant type" in {
     val input = Input.post("/users/auth")
       .withForm("grant_type" -> "client_credentials")
       .withHeaders("Authorization" -> "Basic dXNlcl9pZDp1c2VyX3NlY3JldA==")
-    tokens(input).value.map(_.tokenType) shouldBe Some("Bearer")
+
+    tokens(input).awaitValueUnsafe().map(_.tokenType) shouldBe Some("Bearer")
   }
+
   it should "give an access token with the auth code grant type" in {
     val input = Input.post("/users/auth")
       .withForm(
         "grant_type" -> "authorization_code",
         "code" -> "user_auth_code",
         "client_id" -> "user_id")
-    tokens(input).value.map(_.tokenType) shouldBe Some("Bearer")
+
+    tokens(input).awaitValueUnsafe().map(_.tokenType) shouldBe Some("Bearer")
   }
+
   it should "give back bad request if we omit the password for the password grant type" in {
     val input = Input.post("/users/auth")
       .withForm(
         "grant_type" -> "password",
         "username" -> "user_name",
         "client_id" -> "user_id")
-    tokens(input).output.map(_.status) shouldBe Some(Status.BadRequest)
+
+    tokens(input).awaitOutputUnsafe().map(_.status) shouldBe Some(Status.BadRequest)
   }
+
   it should "give back nothing for other verbs" in {
     val input = Input.get("/users/auth")
       .withForm("grant_type" -> "authorization_code", "code" -> "code", "client_id" -> "id")
-    tokens(input).value shouldBe None
+
+    tokens(input).awaitValueUnsafe() shouldBe None
   }
 
   behavior of "the authorized endpoint"
+
   it should "work if the access token is a valid one" in {
     val input = Input.post("/users/auth")
       .withForm("grant_type" -> "client_credentials")
       .withHeaders("Authorization" -> "Basic dXNlcl9pZDp1c2VyX3NlY3JldA==")
-    val authdUser = tokens(input).value
-      .map(_.accessToken)
-      .flatMap(t =>  users(Input.get("/users/current").withForm("access_token" -> t)).value)
+
+    val authdUser = tokens(input).awaitValueUnsafe()
+      .map(_.accessToken).flatMap(t =>
+        users(Input.get("/users/current").withForm("access_token" -> t)).awaitValueUnsafe()
+      )
+
     authdUser shouldBe Some(OAuthUser("user", "John Smith"))
   }
+
   it should "be unauthorized when using an invalid access token" in {
     val input = Input.get("/users/current")
       .withForm("access_token" -> "at-5b0e7e3b-943f-479f-beab-7814814d0315")
-    users(input).output.map(_.status) shouldBe Some(Status.Unauthorized)
+
+    users(input).awaitOutputUnsafe().map(_.status) shouldBe Some(Status.Unauthorized)
   }
+
   it should "give back nothing for other verbs" in {
     val input = Input.post("/users/current")
       .withForm("access_token" -> "at-5b0e7e3b-943f-479f-beab-7814814d0315")
-    users(input).value shouldBe None
+
+    users(input).awaitValueUnsafe() shouldBe None
   }
 
   behavior of "the unprotected users endpoint"
+
   it should "give back the unprotected user" in {
-    unprotected(Input.get("/users/unprotected")).value shouldBe Some(UnprotectedUser("unprotected"))
+    unprotected(Input.get("/users/unprotected")).awaitValueUnsafe() shouldBe
+      Some(UnprotectedUser("unprotected"))
   }
+
   it should "give back nothing for other verbs" in {
-    unprotected(Input.post("/users/unprotected")).value shouldBe None
+    unprotected(Input.post("/users/unprotected")).awaitValueUnsafe() shouldBe None
   }
 }

--- a/examples/src/test/scala/io/finch/streaming/StreamingSpec.scala
+++ b/examples/src/test/scala/io/finch/streaming/StreamingSpec.scala
@@ -8,27 +8,34 @@ class StreamingSpec extends FlatSpec with Matchers {
   import Main._
 
   behavior of "the sumTo endpoint"
+
   it should "give back a streaming sum" in {
-    sumTo(Input.post("/sumTo/3")).value.map(s => Await.result(s.toSeq())) shouldBe
+    sumTo(Input.post("/sumTo/3")).awaitValueUnsafe().map(s => Await.result(s.toSeq())) shouldBe
       Some(Seq(1L, 3L, 6L))
   }
+
   it should "give back an empty stream if param <= 0" in {
-    sumTo(Input.post("/sumTo/-3")).value.map(s => Await.result(s.toSeq())) shouldBe Some(Seq.empty)
+    sumTo(Input.post("/sumTo/-3")).awaitValueUnsafe().map(s => Await.result(s.toSeq())) shouldBe
+      Some(Seq.empty)
   }
+
   it should "give back nothing for other verbs" in {
-    sumTo(Input.get("/sumTo/3")).value shouldBe None
+    sumTo(Input.get("/sumTo/3")).awaitValueUnsafe() shouldBe None
   }
 
   behavior of "the examples endpoint"
+
   it should "give back a stream of examples" in {
-    examples(Input.get("/examples/3")).value.map(s => Await.result(s.toSeq())) shouldBe
+    examples(Input.get("/examples/3")).awaitValueUnsafe().map(s => Await.result(s.toSeq())) shouldBe
       Some(Seq(Example(0), Example(1), Example(2)))
   }
+
   it should "give back an empty stream if param <= 0" in {
-    examples(Input.get("/examples/-3")).value.map(s => Await.result(s.toSeq())) shouldBe
+    examples(Input.get("/examples/-3")).awaitValueUnsafe().map(s => Await.result(s.toSeq())) shouldBe
       Some(Seq.empty)
   }
+
   it should "give back nothing for other verbs" in {
-    examples(Input.post("/examples/3")).value shouldBe None
+    examples(Input.post("/examples/3")).awaitValueUnsafe() shouldBe None
   }
 }

--- a/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
+++ b/oauth2/src/test/scala/io/finch/oauth2/OAuth2Spec.scala
@@ -31,8 +31,8 @@ class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar 
     val i1 = Input.get("/user", "access_token" -> "bar")
     val i2 = Input.get("/user")
 
-    e(i1).output shouldBe Some(Ok(42))
-    val Some(error) = e(i2).output
+    e(i1).awaitOutputUnsafe() shouldBe Some(Ok(42))
+    val Some(error) = e(i2).awaitOutputUnsafe()
     error.status shouldBe Status.BadRequest
     error.headers should contain key "WWW-Authenticate"
   }
@@ -58,8 +58,8 @@ class OAuth2Spec extends FlatSpec with Matchers with Checkers with MockitoSugar 
 
     val i2 = Input.get("/token")
 
-    e(i1).output shouldBe Some(Ok("foobar"))
-    val Some(error) = e(i2).output
+    e(i1).awaitOutputUnsafe() shouldBe Some(Ok("foobar"))
+    val Some(error) = e(i2).awaitOutputUnsafe()
     error.status shouldBe Status.BadRequest
     error.headers should contain key "WWW-Authenticate"
   }


### PR DESCRIPTION
Currently, `Endpoint`s are backed by `Option[(Input, Rerrunable[Output[A]])]`s. There is nothing wrong with that type and it provides a great insight on what happens in the endpoint, but there is a way to make it 1) simpler and 2) faster.

Let's flatten`Option[Tuple2[_, _]]` into a new type `EndpointResult` (ADT with two cases: matched vs. skipped) and save some allocations on option creations.

In addition to that this PR cleans up a couple of places that I think were poorly structured:

1. All the testing methods on endpoint's result are now explicit (no need for implicit syntax class over the `Option`).
2. All blocking methods are renamed (deprecated) to `awaitX` variants to visually signal the reader that the call is blocking. They also take optional `Duration`, which comes in handy in tests.

UPDATE: I decided to give up on a mutable `EndpointResult` for now since it doesn't buy much of performance improvement but tradeoffs immutability. The most recent benchmark run is here (https://gist.github.com/vkostyukov/e54092f843280dc3f8930c1d359db342). TL;DR `EndpointResult[_]` performs better or same as `Option[Tuple2[_, _]]`.