### PR TITLE
Embed ObjectMapper in finch-jackson

### DIFF
--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -1,8 +1,5 @@
 package io.finch.eval
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.finagle.Http
 import com.twitter.util.{Await, Eval}
 import io.finch._
@@ -26,14 +23,6 @@ import io.finch.jackson._
  * }}}
  */
 object Main {
-
-  // See https://github.com/FasterXML/jackson-module-scala/issues/187
-  implicit val objectMapper: ObjectMapper with ScalaObjectMapper = {
-    val mapper = new ObjectMapper with ScalaObjectMapper
-    mapper.registerModule(DefaultScalaModule)
-
-    mapper
-  }
 
   case class EvalInput(expression: String)
   case class EvalOutput(result: String)

--- a/jackson/src/main/scala/io/finch/jackson/package.scala
+++ b/jackson/src/main/scala/io/finch/jackson/package.scala
@@ -1,30 +1,42 @@
 package io.finch
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.io.Buf
 import com.twitter.util.Try
 import io.finch.internal.{BufText, HttpContent, Utf32}
 import java.nio.charset.StandardCharsets
 
 package object jackson {
 
-  implicit def decodeJackson[A](implicit
-    mapper: ObjectMapper with ScalaObjectMapper, m: Manifest[A]
-  ): Decode.Json[A] = Decode.json {
-    case (buf, StandardCharsets.UTF_8 | StandardCharsets.UTF_16 | Utf32) =>
-      val (array, offset, length) = buf.asByteArrayWithOffsetAndLength
-      Try(mapper.readValue[A](array, offset, length))
-    case (buf, cs) =>
-      Try(mapper.readValue[A](BufText.extract(buf, cs)))
+  // See https://github.com/FasterXML/jackson-module-scala/issues/187
+  val objectMapper: ObjectMapper with ScalaObjectMapper =
+     (new ObjectMapper with ScalaObjectMapper)
+       .registerModule(DefaultScalaModule)
+       .asInstanceOf[ObjectMapper with ScalaObjectMapper]
+
+  private[this] val encodeJacksonInstance: Encode.Json[Any] = Encode.json {
+    case (a, StandardCharsets.UTF_8) =>
+      Buf.ByteArray.Owned(objectMapper.writeValueAsBytes(a))
+    case (a, cs) =>
+      BufText(objectMapper.writeValueAsString(a), cs)
   }
 
-  implicit def encodeJackson[A](implicit mapper: ObjectMapper): Encode.Json[A] =
-    Encode.json((a, cs) => BufText(mapper.writeValueAsString(a), cs))
+  implicit def decodeJackson[A](implicit m: Manifest[A]): Decode.Json[A] = Decode.json {
+    case (buf, StandardCharsets.UTF_8 | StandardCharsets.UTF_16 | Utf32) =>
+      val (array, offset, length) = buf.asByteArrayWithOffsetAndLength
+      Try(objectMapper.readValue[A](array, offset, length))
+    case (buf, cs) =>
+      Try(objectMapper.readValue[A](BufText.extract(buf, cs)))
+  }
 
-  implicit def encodeExceptionJackson[A <: Exception](implicit mapper: ObjectMapper): Encode.Json[A] =
+  implicit def encodeJackson[A]: Encode.Json[A] = encodeJacksonInstance.asInstanceOf[Encode.Json[A]]
+
+  implicit def encodeExceptionJackson[A <: Exception]: Encode.Json[A] =
     Encode.json((a, cs) => {
-      val rootNode = mapper.createObjectNode()
+      val rootNode = objectMapper.createObjectNode()
       rootNode.put("message", a.getMessage)
-      BufText(mapper.writeValueAsString(rootNode), cs)
+      BufText(objectMapper.writeValueAsString(rootNode), cs)
     })
 }

--- a/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
+++ b/jackson/src/test/scala/io/finch/jackson/JacksonSpec.scala
@@ -1,19 +1,5 @@
 package io.finch.jackson
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala._
-import com.fasterxml.jackson.module.scala.experimental._
 import io.finch.test.AbstractJsonSpec
 
-class JacksonSpec extends AbstractJsonSpec {
-
-  // See https://github.com/FasterXML/jackson-module-scala/issues/187
-  implicit val objectMapper: ObjectMapper with ScalaObjectMapper = {
-    val mapper = new ObjectMapper with ScalaObjectMapper
-    mapper.registerModule(DefaultScalaModule)
-
-    mapper
-  }
-
-  checkJson("jackson")
-}
+class JacksonSpec extends AbstractJsonSpec { checkJson("jackson") }


### PR DESCRIPTION
I'm not sure I ever liked the idea of implicit `ObjectMapper` in finch-jackson and given that I'm not sure if that's actually useful, I propose we embed it (object mapper) in finch-jackson.