### PR TITLE
Encode to ByteBuffer in Circe

### DIFF
--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -14,8 +14,7 @@ trait Decoders {
    */
   implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json { (b, cs) =>
     val attemptJson = cs match {
-      case StandardCharsets.UTF_8 =>
-        parseByteBuffer(b.asByteBuffer).right.flatMap(_.as[A])
+      case StandardCharsets.UTF_8 => decodeByteBuffer[A](b.asByteBuffer)
       case _ => decode[A](BufText.extract(b, cs))
     }
 

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -1,18 +1,24 @@
 package io.finch.circe
 
+import com.twitter.io.Buf
 import io.circe.{Encoder, Json}
 import io.finch.Encode
 import io.finch.internal.BufText
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 
 trait Encoders {
 
-  protected def print(json: Json): String
+  protected def printString(json: Json): String
+  protected def printBytes(json: Json): ByteBuffer
 
   /**
    * Maps Circe's [[Encoder]] to Finch's [[Encode]].
    */
-  implicit def encodeCirce[A](implicit e: Encoder[A]): Encode.Json[A] =
-    Encode.json((a, cs) => BufText(print(e(a)), cs))
+  implicit def encodeCirce[A](implicit e: Encoder[A]): Encode.Json[A] = Encode.json {
+    case (a, StandardCharsets.UTF_8) => Buf.ByteBuffer.Owned(printBytes(e(a)))
+    case (a, cs) => BufText(printString(e(a)), cs)
+  }
 
   implicit def encodeExceptionCirce[A <: Exception]: Encoder[A] = new Encoder[A] {
     override def apply(e: A): Json =

--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -1,25 +1,30 @@
 package io.finch
 
 import io.circe.{Json, Printer}
-import io.circe.jackson._
+import java.nio.ByteBuffer
 
 package object circe extends Encoders with Decoders {
 
-  override protected def print(json: Json): String = Printer.noSpaces.pretty(json)
+  override protected def printString(json: Json): String = Printer.noSpaces.pretty(json)
+  override protected def printBytes(json: Json): ByteBuffer = Printer.noSpaces.prettyByteBuffer(json)
 
   /**
    * Provides a [[Printer]] that drops null keys.
    */
   object dropNullKeys extends Encoders with Decoders {
-    private val printer: Printer = Printer.noSpaces.copy(dropNullKeys = true)
-    override protected def print(json: Json): String = printer.pretty(json)
+    private[this] val printer: Printer = Printer.noSpaces.copy(dropNullKeys = true)
+    override protected def printString(json: Json): String = printer.pretty(json)
+    override protected def printBytes(json: Json): ByteBuffer = printer.prettyByteBuffer(json)
   }
 
   /**
    * Provides Jackson Serializer.
    */
   object jacksonSerializer extends Encoders with Decoders {
-    override protected def print(json: Json): String = jacksonPrint(json)
+    override protected def printString(json: Json): String =
+      io.circe.jackson.jacksonPrint(json)
+    override protected def printBytes(json: Json): ByteBuffer =
+      io.circe.jackson.jacksonPrintByteBuffer(json)
   }
 }
 


### PR DESCRIPTION
As discussed in #676 (and implemented in [Circe 0.7.0-M2](https://github.com/circe/circe/releases/tag/v0.7.0-M2)), encoding should be performed in terms of bytes to avoid extra to-string conversion hence reduce allocations.

New benchmark confirms that printing to bytes directly cuts allocations in half and improves the throughput by ~15-20%.

```
circe-core (string)

[info] Benchmark                                               Mode  Cnt        Score        Error   Units
[info] ToServiceBenchmark.foos                                thrpt   20      463.981 ±     24.913   ops/s
[info] ToServiceBenchmark.foos:·gc.alloc.rate.norm            thrpt   20  5002135.084 ±   3252.704    B/op
[info] ToServiceBenchmark.ints                                thrpt   20     2118.919 ±     49.846   ops/s
[info] ToServiceBenchmark.ints:·gc.alloc.rate.norm            thrpt   20   873272.466 ±    106.930    B/op

circe-core (bytes)

[info] Benchmark                                               Mode  Cnt        Score        Error   Units
[info] ToServiceBenchmark.foos                                thrpt   20      523.730 ±     21.871   ops/s
[info] ToServiceBenchmark.foos:·gc.alloc.rate.norm            thrpt   20  2602833.269 ±     76.806    B/op
[info] ToServiceBenchmark.ints                                thrpt   20     2234.631 ±    111.156   ops/s
[info] ToServiceBenchmark.ints:·gc.alloc.rate.norm            thrpt   20   545837.968 ±  43806.910    B/op

circe-jackson (string)

[info] Benchmark                                               Mode  Cnt        Score        Error   Units
[info] ToServiceBenchmark.foos                                thrpt   20      420.095 ±     15.935   ops/s
[info] ToServiceBenchmark.foos:·gc.alloc.rate.norm            thrpt   20  5158946.227 ±   8930.739    B/op
[info] ToServiceBenchmark.ints                                thrpt   20     3398.087 ±    244.404   ops/s
[info] ToServiceBenchmark.ints:·gc.alloc.rate.norm            thrpt   20   691384.267 ±    114.019    B/op

circe-jackson (bytes)

[info] Benchmark                                               Mode  Cnt        Score        Error   Units
[info] ToServiceBenchmark.foos                                thrpt   20      475.034 ±     16.369   ops/s
[info] ToServiceBenchmark.foos:·gc.alloc.rate.norm            thrpt   20  3520947.809 ±  36299.420    B/op
[info] ToServiceBenchmark.ints                                thrpt   20     4046.914 ±    185.765   ops/s
[info] ToServiceBenchmark.ints:·gc.alloc.rate.norm            thrpt   20   342040.224 ±      0.011    B/op
```