### PR TITLE
Custom getClass.getSimpleName logic for error handling

### DIFF
--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -75,9 +75,14 @@ object Error {
   final case class NotParsed(item: RequestItem, targetType: ClassTag[_], cause: Throwable)
     extends Error {
 
-    override def getMessage: String =
-      s"${item.description} cannot be converted to ${targetType.runtimeClass.getSimpleName}: " +
+    override def getMessage: String = {
+      // Note: https://issues.scala-lang.org/browse/SI-2034
+      val className = targetType.runtimeClass.getName
+      val simpleName = className.substring(className.lastIndexOf(".")+1)
+
+      s"${item.description} cannot be converted to ${simpleName}: " +
       s"${cause.getMessage}."
+    }
 
     override def getCause: Throwable = cause
   }

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -50,12 +50,21 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
     )
   } yield i
 
+  // Structure for testing bug:
+  // https://issues.scala-lang.org/browse/SI-2034
+  object err1 {
+    object err2 {
+      case class Foo()
+    }
+  }
+
   def genError: Gen[Error] = for {
     i <- genRequestItem
     s <- genNonEmptyString
     e <- Gen.oneOf(
       Error.NotPresent(i),
       Error.NotParsed(i, implicitly[ClassTag[Int]], new Exception(s)),
+      Error.NotParsed(i, implicitly[ClassTag[err1.err2.Foo]], new Exception(s)),
       Error.NotValid(i, s)
     )
   } yield e


### PR DESCRIPTION
The JVM crashes with an InternalError in case a parsing
error is detected in a class that is neated inside two
objects