### PR TITLE
Fix a broken link in the doc

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -761,7 +761,7 @@ res6: Boolean = true
 You can find unit tests for the examples in the [examples folder][examples].
 
 --
-Read Next: [Authentication](auth.md)
+Read Next: [Cookbook](cookbook.md)
 
 [shapeless]: https://github.com/milessabin/shapeless
 [hlist]: https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#heterogenous-lists


### PR DESCRIPTION
Both auth.md and json.md were removed, so cookbook.md should be next, I guess.

https://github.com/finagle/finch/commit/bcb84a58dbebf38ce9435a321a04da8a05997d3b
https://github.com/finagle/finch/commit/dea22d72509c9a739b42aa2e900e95c89916eacb