### PR TITLE
Fix example code

### DIFF
--- a/examples/src/main/scala/io/finch/eval/Main.scala
+++ b/examples/src/main/scala/io/finch/eval/Main.scala
@@ -35,6 +35,6 @@ object Main {
     case e: Exception => BadRequest(e)
   }
 
-  def main(): Unit =
+  def main(args: Array[String]): Unit =
     Await.ready(Http.server.serve(":8081", eval.toServiceAs[Application.Json]))
 }

--- a/examples/src/main/scala/io/finch/streaming/Main.scala
+++ b/examples/src/main/scala/io/finch/streaming/Main.scala
@@ -86,7 +86,7 @@ object Main {
     Ok(AsyncStream.fromSeq(List.tabulate(num)(i => Example(i))))
   }
 
-  def main(): Unit =
+  def main(args: Array[String]): Unit =
     Await.result(Http.server
       .withStreaming(enabled = true)
       .serve(":8081", (sumSoFar :+: sumTo :+: totalSum :+: examples).toServiceAs[Text.Plain])


### PR DESCRIPTION
Some example programs are not runnable because of the wrong `main` signature.