### PR TITLE
Some cleanups after 0.13

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -99,9 +99,9 @@ class ProductBenchmark extends FinchBenchmark {
 
 @State(Scope.Benchmark)
 class CoproductBenchmark extends FinchBenchmark {
-  val both: Endpoint[String] = Endpoint.const("foo") | Endpoint.const("bar")
-  val left: Endpoint[String] = Endpoint.const("foo") | Endpoint.empty[String]
-  val right: Endpoint[String] = Endpoint.empty[String] | Endpoint.const("bar")
+  val both: Endpoint[String] = Endpoint.const("foo").coproduct(Endpoint.const("bar"))
+  val left: Endpoint[String] = Endpoint.const("foo").coproduct(Endpoint.empty[String])
+  val right: Endpoint[String] = Endpoint.empty[String].coproduct(Endpoint.const("bar"))
 
   @Benchmark
   def bothMatched: Option[String] = both(getRoot).awaitValueUnsafe()

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtunidoc.Plugin.UnidocKeys._
 
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
-  version := "0.13.0",
+  version := "0.14.0-SNAPSHOT",
   scalaVersion := "2.12.1",
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -1,8 +1,8 @@
 package io.finch
 
 import com.twitter.finagle.http.Message
-import com.twitter.io.{Buf, Charsets}
-import java.nio.{ByteBuffer, CharBuffer}
+import com.twitter.io.Buf
+import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
 
 /**
@@ -92,22 +92,6 @@ package object internal {
     final def tooLong: Option[Long] =
       if (s.length == 0 || s.length > 32) None
       else parseLong(s, Long.MinValue, Long.MaxValue)
-  }
-
-  object BufText {
-    @deprecated("Buf.ByteArray.Owned(string.getBytes(charset))", "0.13")
-    def apply(s: String, cs: Charset): Buf =  {
-      val enc = Charsets.encoder(cs)
-      val cb = CharBuffer.wrap(s.toCharArray)
-      Buf.ByteBuffer.Owned(enc.encode(cb))
-    }
-
-    @deprecated("HttpContent.asString(charset)", "0.13")
-    def extract(buf: Buf, cs: Charset): String = {
-      val dec = Charsets.decoder(cs)
-      val bb = Buf.ByteBuffer.Owned.extract(buf).asReadOnlyBuffer
-      dec.decode(bb).toString
-    }
   }
 
   implicit class HttpMessage(val self: Message) extends AnyVal {


### PR DESCRIPTION
- Remove deprecated `BufText`.
- Deprecate `|` and `adjoin`. Now there is `product` and `coproduct` (plain types) along with `::` and `:+:` (Shapeless types).
- Bump version to SNAPSHOT.