### PR TITLE
Fix Date Header to conform to RFCs 7231 and 5322

### DIFF
--- a/core/src/main/scala/io/finch/internal/currentTime.scala
+++ b/core/src/main/scala/io/finch/internal/currentTime.scala
@@ -1,12 +1,15 @@
 package io.finch.internal
 
+import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
-import java.time.Instant
-import java.time.ZoneOffset
+import java.util.Locale
+
 
 object currentTime {
   private[this] val formatter: DateTimeFormatter =
-    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC)
+    DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
+      .withLocale(Locale.ENGLISH)
+      .withZone(ZoneId.of("GMT"))
 
   @volatile private[this] var last: (Long, String) = (0, "")
 


### PR DESCRIPTION
Today we noticed one of our HTTP clients logging a warning about our Finch services responding with an invalid Date header. The Date in question looked like `Thu, 2 Mar 2017 01:47:19 GMT`. As it turns out this is invalid according to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-7.1.1.1) (and also RFC 2616, but this was made obsolete by 7231). The problem is that the day of the month must be 2 digits. So the date should actually be `Thu, 02 Mar 2017 01:47:19 GMT`.

This change uses an explicit `DateTimeFormatter` pattern and uses a time zone of GMT to adhere to the spec. I could not find a way to make `DateTimeFormatter.RFC_1123_DATE_TIME` to pad the day of the month field, but if anyone knows of way I think that would better. Let me know what you think.

For reference:
The preferred date time is defined [here](https://tools.ietf.org/html/rfc7231#section-7.1.1.1).
It also references this section of [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.3)