### PR TITLE
Add finagle-stats dependency to examples proj

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -312,6 +312,7 @@ lazy val examples = project
   .settings(
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-generic" % circeVersion,
+      "com.twitter" %% "finagle-stats" % finagleVersion,
       "com.twitter" %% "twitter-server" % twitterServerVersion,
       "com.twitter" %% "util-eval" % utilVersion,
       "com.github.finagle" %% "finagle-oauth2" % finagleOAuth2Version


### PR DESCRIPTION
This PR fixes the `Finagle server without metrics` warning when running the example Todo app. The warning is displayed when navigating to the admin dashboard. The `twitter-server` lint rule is defined [here](https://github.com/twitter/twitter-server/blob/master/src/main/scala/com/twitter/server/lint/NullStatsReceiversRule.scala#L22) and requires you have the finagle-stats jar on your classpath (see details [here](https://twitter.github.io/twitter-server/Features.html#metrics)).