### PR TITLE
Make Input actually immutable

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -222,7 +222,7 @@ trait Endpoint[A] { self =>
     final def apply(input: Input): Endpoint.Result[B] = self(input) match {
       case a @ EndpointResult.Matched(_, _) => other(input) match {
         case b @ EndpointResult.Matched(_, _) =>
-          if (a.rem.path.length <= b.rem.path.length) a else b
+          if (a.rem.route.length <= b.rem.route.length) a else b
         case _ => a
       }
       case _ => other(input)

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -30,8 +30,8 @@ private[finch] final class ToService[A, CT <: String](
     rep
   }
 
-  def apply(req: Request): Future[Response] = underlying(Input.request(req)) match {
-    case EndpointResult.Matched(rem, out) if rem.isEmpty =>
+  def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
+    case EndpointResult.Matched(rem, out) if rem.route.isEmpty =>
       out.map(oa => conformHttp(oa.toResponse(tr, tre), req.version)).run
     case _ => Future.value(conformHttp(Response(Status.NotFound), req.version))
   }

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -33,7 +33,7 @@ class BodySpec extends FinchSpec {
   it should "not match on streaming requests" in {
     val req = Request()
     req.setChunked(true)
-    body[Foo, Text.Plain].apply(Input.request(req)).awaitValueUnsafe() === None
+    body[Foo, Text.Plain].apply(Input.fromRequest(req)).awaitValueUnsafe() === None
   }
 
   it should "respond with a value when present and required" in {

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -228,10 +228,10 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
   }
 
   implicit def arbitraryInput: Arbitrary[Input] =
-    Arbitrary(arbitraryRequest.arbitrary.map(Input.request))
+    Arbitrary(arbitraryRequest.arbitrary.map(Input.fromRequest))
 
   implicit def cogenInput: Cogen[Input] =
-    Cogen[(Request, Seq[String])].contramap(input => (input.request, input.path))
+    Cogen[(Request, Seq[String])].contramap(input => (input.request, input.route))
 
   implicit def arbitraryUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
 

--- a/core/src/test/scala/io/finch/InputSpec.scala
+++ b/core/src/test/scala/io/finch/InputSpec.scala
@@ -22,7 +22,7 @@ class InputSpec extends FinchSpec {
       input.request.method === method &&
       input.request.path === "/" + segments.mkString("/") &&
       input.request.params === params &&
-      input.path === segments
+      input.route === segments
 
     check { (ps: Params, p: Path) =>
       val segments = p.p.split("/").toList.drop(1)


### PR DESCRIPTION
While `Input` was always a case class it wasn't fully immutable given all the `withX` methods mutated the underlying (also mutable) Finagle's request. This PR makes it actually immutable by copying the request each time it's mutated.

In addition to that, I also decided to rebrand `Input.path` to `Input.route` to clearly distinguish it from `Request.path` and state that it's used with the matching/routing endpoints.