### PR TITLE
Decouple Endpoint from Mapper (syntax)

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -67,11 +67,6 @@ trait Endpoint[A] { self =>
   def item: items.RequestItem = items.MultipleItems
 
   /**
-   * Maps this endpoint to either `A => Output[B]` or `A => Output[Future[B]]`.
-   */
-  final def apply(mapper: Mapper[A]): Endpoint[mapper.Out] = mapper(self)
-
-  /**
    * Runs this endpoint.
    */
   def apply(input: Input): Endpoint.Result[A]

--- a/core/src/main/scala/io/finch/Endpoints.scala
+++ b/core/src/main/scala/io/finch/Endpoints.scala
@@ -1,8 +1,8 @@
 package io.finch
 
 import cats.data.NonEmptyList
-import com.twitter.finagle.http.{Cookie, Method, Request}
-import com.twitter.util.{Future, Try}
+import com.twitter.finagle.http.{Cookie, Request}
+import com.twitter.util.Future
 import io.catbird.util.Rerunnable
 import io.finch.endpoint._
 import io.finch.internal._
@@ -36,77 +36,6 @@ trait Endpoints extends Bodies with Paths with FileUploads {
 
     final override def toString: String = ""
   }
-
-  private[this] def method[A](m: Method)(r: Endpoint[A]): Endpoint[A] = new Endpoint[A] {
-    final def apply(input: Input): Endpoint.Result[A] =
-      if (input.request.method == m) r(input)
-      else EndpointResult.Skipped
-
-    final override def toString: String = s"${ m.toString().toUpperCase } /${ r.toString }"
-  }
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `GET` and the underlying
-   * endpoint succeeds on it.
-   */
-  def get[A]: Endpoint[A] => Endpoint[A] = method(Method.Get)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `POST` and the underlying
-   * endpoint succeeds on it.
-   */
-  def post[A]: Endpoint[A] => Endpoint[A] = method(Method.Post)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `PATCH` and the underlying
-   * endpoint succeeds on it.
-   */
-  def patch[A]: Endpoint[A] => Endpoint[A] = method(Method.Patch)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `DELETE` and the
-   * underlying endpoint succeeds on it.
-   */
-  def delete[A]: Endpoint[A] => Endpoint[A] = method(Method.Delete)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `HEAD` and the underlying
-   * endpoint succeeds on it.
-   */
-  def head[A]: Endpoint[A] => Endpoint[A] = method(Method.Head)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `OPTIONS` and the
-   * underlying endpoint succeeds on it.
-   */
-  def options[A]: Endpoint[A] => Endpoint[A] = method(Method.Options)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `PUT` and the underlying
-   * endpoint succeeds on it.
-   */
-  def put[A]: Endpoint[A] => Endpoint[A] = method(Method.Put)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `CONNECT` and the
-   * underlying endpoint succeeds on it.
-   */
-  def connect[A]: Endpoint[A] => Endpoint[A] = method(Method.Connect)
-
-  /**
-   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
-   * resulting [[Endpoint]] succeeds on the request only if its method is `TRACE` and the underlying
-   * router endpoint on it.
-   */
-  def trace[A]: Endpoint[A] => Endpoint[A] = method(Method.Trace)
 
   // Helper functions.
   private[this] def requestParam(param: String)(req: Request): Option[String] =

--- a/core/src/main/scala/io/finch/endpoint/fileUpload.scala
+++ b/core/src/main/scala/io/finch/endpoint/fileUpload.scala
@@ -51,7 +51,7 @@ private[finch] trait FileUploads {
     }
 
   /**
-   * An evaluating [[Endpoint]] that reads a required file upload from a multipart/form-data
+   * An evaluating [[Endpoint]] that reads a required file upload from a `multipart/form-data`
    * request.
    */
   def fileUpload(name: String): Endpoint[Multipart.FileUpload] =

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -6,7 +6,10 @@ import shapeless.Witness
  * This is a root package of the Finch library, which provides an immutable layer of functions and
  * types atop of Finagle for writing lightweight HTTP services.
  */
-package object finch extends Endpoints with Outputs with ValidationRules {
+package object finch extends Endpoints
+    with Outputs
+    with ValidationRules
+    with io.finch.syntax.EndpointMappers {
 
   object items {
     sealed abstract class RequestItem(val kind: String, val nameOption:Option[String] = None) {

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -1,0 +1,18 @@
+package io.finch.syntax
+
+import com.twitter.finagle.http.Method
+import io.finch._
+
+class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
+
+  /**
+   * Maps this endpoint to either `A => Output[B]` or `A => Future[Output[B]]`.
+   */
+  final def apply(mapper: Mapper[A]): Endpoint[mapper.Out] = mapper(self)
+
+  final def apply(input: Input): Endpoint.Result[A] =
+    if (input.request.method == m) e(input)
+    else EndpointResult.Skipped
+
+  final override def toString: String = s"${ m.toString.toUpperCase } /${ e.toString }"
+}

--- a/core/src/main/scala/io/finch/syntax/EndpointMappers.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMappers.scala
@@ -1,0 +1,70 @@
+package io.finch.syntax
+
+import com.twitter.finagle.http.Method
+import io.finch._
+
+private[finch] trait EndpointMappers {
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `GET` and the underlying
+   * endpoint succeeds on it.
+   */
+  def get[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Get, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `POST` and the underlying
+   * endpoint succeeds on it.
+   */
+  def post[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Post, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `PATCH` and the underlying
+   * endpoint succeeds on it.
+   */
+  def patch[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Patch, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `DELETE` and the
+   * underlying endpoint succeeds on it.
+   */
+  def delete[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Delete, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `HEAD` and the underlying
+   * endpoint succeeds on it.
+   */
+  def head[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Head, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `OPTIONS` and the
+   * underlying endpoint succeeds on it.
+   */
+  def options[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Options, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `PUT` and the underlying
+   * endpoint succeeds on it.
+   */
+  def put[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Put, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `CONNECT` and the
+   * underlying endpoint succeeds on it.
+   */
+  def connect[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Connect, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `TRACE` and the underlying
+   * router endpoint on it.
+   */
+  def trace[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Trace, e)
+}

--- a/core/src/main/scala/io/finch/syntax/Mapper.scala
+++ b/core/src/main/scala/io/finch/syntax/Mapper.scala
@@ -1,4 +1,4 @@
-package io.finch.internal
+package io.finch.syntax
 
 import com.twitter.finagle.http.Response
 import com.twitter.util.Future

--- a/core/src/main/scala/io/finch/syntax/package.scala
+++ b/core/src/main/scala/io/finch/syntax/package.scala
@@ -1,0 +1,6 @@
+package io.finch
+
+/**
+ * Enables Sinatra-like syntax extensions for endpoints.
+ */
+package object syntax extends EndpointMappers

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -264,7 +264,7 @@ class EndpointSpec extends FinchSpec {
   it should "maps lazily to values" in {
     val i = Input(emptyRequest, Seq.empty)
     var c = 0
-    val e = * { c = c + 1; Ok(c) }
+    val e = get(*) { c = c + 1; Ok(c) }
 
     e(i).awaitValueUnsafe() shouldBe Some(1)
     e(i).awaitValueUnsafe() shouldBe Some(2)


### PR DESCRIPTION
This PR decouples `Endpoint` from `Mapper` and is the first step towards dedicated "syntax" layer (as per #637).

Right now `Mapper` is coupled with every method-matching endpoint such that the most common pattern (i.e., `get(/)(mapper)`) still works/compiles. At this point, "syntax" is available by default (from the `io.finch._` import) but the plan is to make it explicit under `io.finch.syntax._` in the next releases (we have to think whether we need to provide a non-syntax way of matching methods).