### PR TITLE
Make Finagle in benchmark use Date header

### DIFF
--- a/examples/src/main/scala/io/finch/wrk/Finagle.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finagle.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Method, Request, Response, Status}
 import com.twitter.io.Buf
 import com.twitter.util.Future
+import io.finch.internal._
 
 /**
  * How to benchmark this:
@@ -33,6 +34,7 @@ object Finagle extends App {
         val rep = Response(req.version, Status.Ok)
         rep.content =  Buf.ByteArray.Owned(payloadOut)
         rep.contentType = "application/json"
+        rep.date = currentTime()
 
         Future.value(rep)
       }


### PR DESCRIPTION
It hardly has any effect on performance.
 * Before:
    * Run 1: Requests/sec:  17725.24
    * Run 3: Requests/sec:  34056.66
 * After:
    * Run 1: Requests/sec:  14805.84
    * Run 3: Requests/sec:  34134.74