### PR TITLE
Introduce Bootstrap

### DIFF
--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -1,0 +1,32 @@
+package io.finch
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import io.finch.internal.ToService
+import shapeless._
+
+/**
+ * Bootstraps a Finagle HTTP service out of the collection of Finch endpoints.
+ *
+ * {{{
+ * val api: Service[Request, Response] = Bootstrap
+ *  .serve[Application.Json](getUser :+: postUser)
+ *  .serve[Text.Plain](healthcheck)
+ *  .toService
+ * }}}
+ *
+ * @note This API is experimental/unstable. Use with caution.
+ */
+case class Bootstrap[ES <: HList, CTS <: HList](endpoints: ES) { self =>
+
+  class Serve[CT <: String] {
+    def apply[E](e: Endpoint[E]): Bootstrap[Endpoint[E] :: ES, CT :: CTS] =
+      self.copy(e :: self.endpoints)
+    }
+
+  def serve[CT <: String]: Serve[CT] = new Serve[CT]
+
+  def toService(implicit ts: ToService[ES, CTS]): Service[Request, Response] = ts(endpoints)
+}
+
+object Bootstrap extends Bootstrap[HNil, HNil](HNil)

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -246,6 +246,8 @@ trait Endpoint[A] { self =>
 
   /**
    * Converts this endpoint to a Finagle service `Request => Future[Response]` that serves JSON.
+   *
+   * Consider using [[Bootstrap]] instead.
    */
   final def toService(implicit
     tr: ToResponse.Aux[A, Application.Json],
@@ -255,11 +257,13 @@ trait Endpoint[A] { self =>
   /**
    * Converts this endpoint to a Finagle service `Request => Future[Response]` that serves custom
    * content-type `CT`.
+   *
+   * Consider using [[Bootstrap]] instead.
    */
   final def toServiceAs[CT <: String](implicit
     tr: ToResponse.Aux[A, CT],
     tre: ToResponse.Aux[Exception, CT]
-  ): Service[Request, Response] = new ToService(self, tr, tre)
+  ): Service[Request, Response] = Bootstrap.serve[CT](this).toService
 
   /**
    * Recovers from any exception occurred in this endpoint by creating a new endpoint that will

--- a/core/src/main/scala/io/finch/internal/ToService.scala
+++ b/core/src/main/scala/io/finch/internal/ToService.scala
@@ -4,6 +4,34 @@ import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.util.Future
 import io.finch.{Endpoint, EndpointResult, Input, Output}
+import scala.annotation.implicitNotFound
+import shapeless._
+
+/**
+ * Wraps a given list of [[Endpoint]]s and their content-types with a Finagle [[Service]].
+ *
+ * Guarantees to:
+ *
+ * - handle Finch's own errors (i.e., [[Error]] and [[Error]]) as 400s
+ * - supply the date header to each response
+ * - copy requests's HTTP version onto a response
+ * - respond with 404 when en endpoint is not matched
+ */
+@implicitNotFound(
+"""An Endpoint you're trying to convert into a Finagle service is missing one or more encoders.
+
+  Make sure each endpoint in ${ES} is one of the following:
+
+  * A com.twitter.finagle.http.Response
+  * A value of a type with an io.finch.Encode instance (with the corresponding content-type)
+  * A coproduct made up of some combination of the above
+
+  See https://github.com/finagle/finch/blob/master/docs/cookbook.md#fixing-the-toservice-compile-error
+"""
+)
+trait ToService[ES <: HList, CTS <: HList] {
+  def apply(endpoints: ES): Service[Request, Response]
+}
 
 /**
  * Wraps a given [[Endpoint]] with a Finagle [[Service]].
@@ -14,25 +42,40 @@ import io.finch.{Endpoint, EndpointResult, Input, Output}
  * - copy requests's HTTP version onto a response
  * - respond with 404 when en endpoint is not matched
  */
-private[finch] final class ToService[A, CT <: String](
-    e: Endpoint[A],
-    tr: ToResponse.Aux[A, CT],
-    tre: ToResponse.Aux[Exception, CT]) extends Service[Request, Response] {
+object ToService {
 
-  private[this] val underlying = e.handle {
+  private val respond400OnErrors: PartialFunction[Throwable, Output[Nothing]] = {
     case e: io.finch.Error => Output.failure(e, Status.BadRequest)
     case es: io.finch.Errors => Output.failure(es, Status.BadRequest)
   }
 
-  private[this] def conformHttp(rep: Response, version: Version): Response = {
+  private def conformHttp(rep: Response, version: Version): Response = {
     rep.version = version
     rep.date = currentTime()
     rep
   }
 
-  def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
-    case EndpointResult.Matched(rem, out) if rem.route.isEmpty =>
-      out.map(oa => conformHttp(oa.toResponse(tr, tre), req.version)).run
-    case _ => Future.value(conformHttp(Response(Status.NotFound), req.version))
+  implicit val hnilTS: ToService[HNil, HNil] = new ToService[HNil, HNil] {
+    def apply(endpoints: HNil): Service[Request, Response] = new Service[Request, Response] {
+      def apply(req: Request): Future[Response] =
+        Future.value(conformHttp(Response(Status.NotFound), req.version))
+    }
+  }
+
+  implicit def hlistTS[A, EH <: Endpoint[A], ET <: HList, CTH <: String, CTT <: HList](implicit
+    trA: ToResponse.Aux[A, CTH],
+    trE: ToResponse.Aux[Exception, CTH],
+    tsT: ToService[ET, CTT]
+  ): ToService[Endpoint[A] :: ET, CTH :: CTT] = new ToService[Endpoint[A] :: ET, CTH :: CTT] {
+    def apply(endpoints: Endpoint[A] :: ET): Service[Request, Response] =
+      new Service[Request, Response] {
+        private[this] val underlying = endpoints.head.handle(respond400OnErrors)
+
+        def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
+          case EndpointResult.Matched(rem, out) if rem.route.isEmpty =>
+            out.map(oa => conformHttp(oa.toResponse(trA, trE), req.version)).run
+          case _ => tsT(endpoints.tail)(req)
+        }
+      }
   }
 }

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -1,16 +1,13 @@
 package io.finch
 
 import java.util.UUID
-import scala.reflect.ClassTag
 
 import cats.data.NonEmptyList
 import cats.laws.discipline.AlternativeTests
 import com.twitter.conversions.time._
 import com.twitter.finagle.http.{Cookie, Method, Request}
-import com.twitter.io.Buf
-import com.twitter.util.{Future, Throw, Try}
+import com.twitter.util.{Future, Throw}
 import io.finch.data.Foo
-import io.finch.items.BodyItem
 import shapeless._
 
 class EndpointSpec extends FinchSpec {


### PR DESCRIPTION
This suppresses #583 and fixes #575.

The idea is pretty much the same. Here is the syntax example based on our TE benchmark:

```scala
val service = Bootstrap
  .serve[Application.Json](json)
  .serve[Text.Plain](plaintext)
  .toService
```

The reason I decided to call it `Bootstrap` is that I believe we would be able to add more machinery to it so users can configure a bunch of other things in their derived services. Examples:

- Report stats per endpoint (into a given stats receiver), see #781 
- Enable responding 405, see #784 

This new `Bootstrap` type can also act as a config for our existing features. For example, we might think of providing a way to disable the `Date` header, supplied by default. Something along the lines (just using the case class `copy` method, somewhat close to what Circe does with `Printer`s):

```scala
val service = Bootstrap.copy(includeDateHeader = false, includeServerHeader = true)
  .serve[Application.Json](foo)
  .toService
```

This is an experimental API and I'm not deprecating anything. The goal is to solicit users' feedback in 0.16 and see if it gets any adoption.