### PR TITLE
Fork Rerunnable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ lazy val finagleOAuth2Version = "0.6.45"
 lazy val finagleHttpAuthVersion = "0.1.0"
 lazy val circeVersion = "0.8.0"
 lazy val circeJacksonVersion = "0.8.0"
-lazy val catbirdVersion = "0.15.0"
 lazy val shapelessVersion = "2.3.2"
 lazy val catsVersion = "0.9.0"
 lazy val sprayVersion = "1.3.3"
@@ -49,8 +48,7 @@ val baseSettings = Seq(
     "com.chuusai" %% "shapeless" % shapelessVersion,
     "org.typelevel" %% "cats-core" % catsVersion,
     "com.twitter" %% "finagle-http" % finagleVersion,
-    scalaOrganization.value % "scala-reflect" % scalaVersion.value,
-    "io.catbird" %% "catbird-util" % catbirdVersion
+    scalaOrganization.value % "scala-reflect" % scalaVersion.value
   ) ++ testDependencies.map(_ % "test"),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -23,7 +23,7 @@ case class Bootstrap[ES <: HList, CTS <: HList](
 
   class Serve[CT <: String] {
     def apply[E](e: Endpoint[E]): Bootstrap[Endpoint[E] :: ES, CT :: CTS] =
-      self.copy(e :: self.endpoints)
+      self.copy(endpoints = e :: self.endpoints)
     }
 
   def serve[CT <: String]: Serve[CT] = new Serve[CT]

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -8,7 +8,6 @@ import cats.data.NonEmptyList
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Cookie, Request, Response}
 import com.twitter.util.{Future, Return, Throw, Try}
-import io.catbird.util.Rerunnable
 import io.finch.internal._
 import shapeless._
 import shapeless.ops.adjoin.Adjoin

--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -1,7 +1,7 @@
 package io.finch
 
 import com.twitter.util.{Await, Duration, Future, Try}
-import io.catbird.util.Rerunnable
+import io.finch.internal._
 
 /**
  * A result returned from an [[Endpoint]]. This models `Option[(Input, Future[Output])]` and

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -4,7 +4,6 @@ import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.http.Fields
 import com.twitter.io.Buf
 import com.twitter.util.{Return, Throw}
-import io.catbird.util.Rerunnable
 import io.finch._
 import io.finch.internal._
 import io.finch.items._

--- a/core/src/main/scala/io/finch/endpoint/cookie.scala
+++ b/core/src/main/scala/io/finch/endpoint/cookie.scala
@@ -1,7 +1,6 @@
 package io.finch.endpoint
 
 import com.twitter.finagle.http.{Cookie => FinagleCookie}
-import io.catbird.util.Rerunnable
 import io.finch._
 import io.finch.internal._
 

--- a/core/src/main/scala/io/finch/endpoint/fileUpload.scala
+++ b/core/src/main/scala/io/finch/endpoint/fileUpload.scala
@@ -1,9 +1,8 @@
 package io.finch.endpoint
 
 import com.twitter.finagle.http.exp.Multipart
-import io.catbird.util.Rerunnable
 import io.finch._
-import io.finch.internal.Rs
+import io.finch.internal._
 import io.finch.items._
 import scala.util.control.NonFatal
 

--- a/core/src/main/scala/io/finch/endpoint/param.scala
+++ b/core/src/main/scala/io/finch/endpoint/param.scala
@@ -2,7 +2,7 @@ package io.finch.endpoint
 
 import cats.data.NonEmptyList
 import io.finch._
-import io.finch.internal.Rs
+import io.finch.internal._
 
 private abstract class Param[A](name: String) extends Endpoint[A] {
 

--- a/core/src/main/scala/io/finch/endpoint/path.scala
+++ b/core/src/main/scala/io/finch/endpoint/path.scala
@@ -1,8 +1,7 @@
 package io.finch.endpoint
 
-import io.catbird.util.Rerunnable
 import io.finch._
-import io.finch.internal.Rs
+import io.finch.internal._
 import java.util.UUID
 import scala.reflect.ClassTag
 import shapeless.HNil

--- a/core/src/main/scala/io/finch/internal/Rerunnable.scala
+++ b/core/src/main/scala/io/finch/internal/Rerunnable.scala
@@ -1,0 +1,103 @@
+package io.finch.internal
+
+import cats.MonadError
+import com.twitter.util.{Future, Try}
+import scala.annotation.tailrec
+import scala.util.{Either, Left, Right}
+
+/**
+ * Makes Twitter [[Future]] re-runnable.
+ *
+ * This was originally designed and implemented by Travis Brown (https://twitter.com/travisbrown)
+ * for the Catbird project. Finch then forked it to avoid extra dependency and simplify the release
+ * process.
+ *
+ * @see https://github.com/finagle/finch/issues/793
+ * @see https://github.com/travisbrown/catbird
+ */
+abstract class Rerunnable[A] { self =>
+  def run: Future[A]
+
+  final def map[B](f: A => B): Rerunnable[B] = new Rerunnable[B] {
+    final def run: Future[B] = self.run.map(f)
+  }
+
+  final def flatMap[B](f: A => Rerunnable[B]): Rerunnable[B] = new Rerunnable.Bind[A, B](this, f)
+
+  final def flatMapF[B](f: A => Future[B]): Rerunnable[B] = new Rerunnable[B] {
+    final def run: Future[B] = self.run.flatMap(f)
+  }
+
+  final def product[B](other: Rerunnable[B]): Rerunnable[(A, B)] = new Rerunnable[(A, B)] {
+    final def run: Future[(A, B)] = self.run.join(other.run)
+  }
+
+  final def liftToTry: Rerunnable[Try[A]] = new Rerunnable[Try[A]] {
+    final def run: Future[Try[A]] = self.run.liftToTry
+  }
+
+  @tailrec
+  final def step: Rerunnable[A] = this match {
+    case outer: Rerunnable.Bind[_, A] => outer.fa match {
+      case inner: Rerunnable.Bind[_, _] => inner.fa.flatMap(x => inner.ff(x).flatMap(outer.ff)).step
+      case _ => this
+    }
+    case _ => this
+  }
+}
+
+object Rerunnable {
+  private class Bind[A, B](
+      val fa: Rerunnable[A],
+      val ff: A => Rerunnable[B]) extends Rerunnable[B] with (A => Future[B]) {
+
+    final def apply(a: A): Future[B] = ff(a).run
+
+    final def run: Future[B] = step match {
+      case bind: Bind[A, B] => bind.fa.run.flatMap(bind)
+      case other => other.run
+    }
+  }
+
+  def const[A](a: A): Rerunnable[A] = new Rerunnable[A] {
+    final def run: Future[A] = Future.value(a)
+  }
+
+  def apply[A](a: => A): Rerunnable[A] = new Rerunnable[A] {
+    final def run: Future[A] = Future(a)
+  }
+
+  def fromFuture[A](fa: => Future[A]): Rerunnable[A] = new Rerunnable[A] {
+    final def run: Future[A] = fa
+  }
+
+  implicit val rerunnableInstance: MonadError[Rerunnable, Throwable] =
+    new MonadError[Rerunnable, Throwable] {
+      final def pure[A](a: A): Rerunnable[A] = Rerunnable.const(a)
+
+      override final def map[A, B](fa: Rerunnable[A])(f: A => B): Rerunnable[B] = fa.map(f)
+
+      override final def product[A, B](fa: Rerunnable[A], fb: Rerunnable[B]): Rerunnable[(A, B)] =
+        fa.product(fb)
+
+      final def flatMap[A, B](fa: Rerunnable[A])(f: A => Rerunnable[B]): Rerunnable[B] =
+        fa.flatMap(f)
+
+      final def raiseError[A](e: Throwable): Rerunnable[A] = new Rerunnable[A] {
+        final def run: Future[A] = Future.exception[A](e)
+      }
+
+      final def handleErrorWith[A](fa: Rerunnable[A])(
+        f: Throwable => Rerunnable[A]
+      ): Rerunnable[A] = new Rerunnable[A] {
+        final def run: Future[A] = fa.run.rescue {
+          case error => f(error).run
+        }
+      }
+
+      final def tailRecM[A, B](a: A)(f: A => Rerunnable[Either[A, B]]): Rerunnable[B] = f(a).flatMap {
+        case Right(b) => pure(b)
+        case Left(nextA) => tailRecM(nextA)(f)
+      }
+    }
+}

--- a/core/src/main/scala/io/finch/internal/Rs.scala
+++ b/core/src/main/scala/io/finch/internal/Rs.scala
@@ -1,7 +1,6 @@
 package io.finch.internal
 
 import com.twitter.util.Future
-import io.catbird.util.Rerunnable
 import io.finch._
 import shapeless.HNil
 

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -9,7 +9,7 @@ import cats.instances.AllInstances
 import com.twitter.finagle.http._
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Try}
-import io.catbird.util.Rerunnable
+import io.finch.internal._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.Checkers

--- a/core/src/test/scala/io/finch/internal/RerunnableSpec.scala
+++ b/core/src/test/scala/io/finch/internal/RerunnableSpec.scala
@@ -1,0 +1,27 @@
+package io.finch.internal
+
+import cats.Eq
+import cats.laws.discipline.MonadErrorTests
+import com.twitter.conversions.time._
+import com.twitter.util.{Await, Future, Try}
+import io.finch.FinchSpec
+import org.scalacheck.Arbitrary
+
+class RerunnableSpec extends FinchSpec {
+  implicit def throwableEq: Eq[Throwable] = Eq.fromUniversalEquals
+
+  implicit def rerunnableEq[A](implicit A: Eq[Try[A]]): Eq[Rerunnable[A]] = Eq.instance { (a, b) =>
+    A.eqv(
+      Await.result(a.liftToTry.run, 10.seconds),
+      Await.result(b.liftToTry.run, 10.seconds)
+    )
+  }
+
+  implicit def futureArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[Future[A]] =
+    Arbitrary(A.arbitrary.map(Future.value))
+
+  implicit def rerunnableArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[Rerunnable[A]] =
+    Arbitrary(futureArbitrary[A].arbitrary.map(Rerunnable.fromFuture[A](_)))
+
+  checkAll("Rerunnable[Int]", MonadErrorTests[Rerunnable, Throwable].monadError[Int, Int, Int])
+}

--- a/oauth2/src/main/scala/io/finch/oauth2/package.scala
+++ b/oauth2/src/main/scala/io/finch/oauth2/package.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.OAuth2
 import com.twitter.finagle.http.Status
 import com.twitter.finagle.oauth2.{AuthInfo, DataHandler, GrantHandlerResult, OAuthError}
 import com.twitter.util.Future
-import io.catbird.util.Rerunnable
+import io.finch.internal._
 
 package object oauth2 {
 


### PR DESCRIPTION
This is to address #793.

How is it different from the original `Rerunnable`:

-  I decided not to port all cats instances for `Rerunnable` and only kept `MonadError` for the sake of testing. At least, we'll keep making sure monad laws (I think these are the only things we use from `Rerunnable` within Finch) stand.
- I removed support for `FuturePool`s
- I removed `Rerunnable.Unit`
- There is a tiny optimization in `Bind` that embeds a closure passed in `flatMap`.

Please, let me know what do you think.