### PR TITLE
Introduce ParseNumber

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -69,6 +69,12 @@ class ExtractPathBenchmark extends FinchBenchmark {
   def stringNone: Option[String] = string(getRoot).awaitValueUnsafe()
 
   @Benchmark
+  def longSome: Option[Long] = long(getTenTwenty).awaitValueUnsafe()
+
+  @Benchmark
+  def longNone: Option[Long] = long(getFooBarBaz).awaitValueUnsafe()
+
+  @Benchmark
   def intSome: Option[Int] = int(getTenTwenty).awaitValueUnsafe()
 
   @Benchmark
@@ -173,4 +179,19 @@ class ToServiceBenchmark extends FinchBenchmark {
 
   @Benchmark
   def ints: Response = Await.result(intService(Request()))
+}
+
+@State(Scope.Benchmark)
+class TooFastStringBenchmark extends FinchBenchmark {
+
+  import io.finch.internal.TooFastString
+
+  @Benchmark
+  def someBoolean: Option[Boolean] = "true".tooBoolean
+
+  @Benchmark
+  def someInt: Option[Int] = "12345".tooInt
+
+  @Benchmark
+  def someLong: Option[Long] = "12345678".tooLong
 }

--- a/core/src/main/scala/io/finch/internal/ParseNumber.scala
+++ b/core/src/main/scala/io/finch/internal/ParseNumber.scala
@@ -1,0 +1,64 @@
+package io.finch.internal
+
+abstract class ParseNumber[@specialized(Int, Long) A] {
+
+  protected def max: Long
+  protected def min: Long
+  protected def prepare(a: Long): A
+
+  // adopted from Java's Long.parseLong
+  // scalastyle:off return
+  final def apply(s: String): Option[A] = {
+    var negative = false
+    var limit = -max
+    var result = 0L
+
+    var i = 0
+    if (s.length > 0) {
+      val firstChar = s.charAt(0)
+      if (firstChar < '0') {
+        if (firstChar == '-') {
+          negative = true
+          limit = min
+        } else if (firstChar != '+') return None
+
+        if (s.length == 1) return None
+
+        i += 1
+      }
+
+      // skip zeros
+      while (i < s.length && s.charAt(i) == '0') i += 1
+
+      val mulMin = limit / 10L
+
+      while (i < s.length) {
+        val c = s.charAt(i)
+        if ('0' <= c && c <= '9') {
+          if (result < mulMin) return None
+          result = result * 10L
+          val digit = c - '0'
+          if (result < limit + digit) return None
+          result = result - digit
+        } else return None
+
+        i += 1
+      }
+    } else return None
+
+    Some(prepare(if (negative) result else -result))
+  }
+  // scalastyle:on return
+}
+
+object parseInt extends ParseNumber[Int] {
+  protected def min: Long = Int.MinValue
+  protected def max: Long = Int.MaxValue
+  protected def prepare(a: Long): Int = a.toInt
+}
+
+object parseLong extends ParseNumber[Long] {
+  protected def min: Long = Long.MinValue
+  protected def max: Long = Long.MaxValue
+  protected def prepare(a: Long): Long = a
+}

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -19,50 +19,6 @@ package object internal {
   // Missing in StandardCharsets.
   val Utf32: Charset = Charset.forName("UTF-32")
 
-  // adopted from Java's Long.parseLong
-  // scalastyle:off return
-  private[this] def parseLong(s: String, min: Long, max: Long): Option[Long] = {
-    var negative = false
-    var limit = -max
-    var result = 0L
-
-    var i = 0
-    if (s.length > 0) {
-      val firstChar = s.charAt(0)
-      if (firstChar < '0') {
-        if (firstChar == '-') {
-          negative = true
-          limit = min
-        } else if (firstChar != '+') return None
-
-        if (s.length == 1) return None
-
-        i += 1
-      }
-
-      // skip zeros
-      while (i < s.length && s.charAt(i) == '0') i += 1
-
-      val mulMin = limit / 10L
-
-      while (i < s.length) {
-        val c = s.charAt(i)
-        if ('0' <= c && c <= '9') {
-          if (result < mulMin) return None
-          result = result * 10L
-          val digit = c - '0'
-          if (result < limit + digit) return None
-          result = result - digit
-        } else return None
-
-        i += 1
-      }
-    } else return None
-
-    Some(if (negative) result else -result)
-  }
-  // scalastyle:on return
-
   /**
    * Enriches any string with fast `tooX` conversions.
    */
@@ -83,15 +39,15 @@ package object internal {
      */
     final def tooInt: Option[Int] =
       if (s.length == 0 || s.length > 32) None
-      else parseLong(s, Int.MinValue, Int.MaxValue).map(_.toInt)
+      else parseInt(s)
 
     /**
-     * Converts this string to the optional integer value. The maximum allowed length for a number
+     * Converts this string to the optional long value. The maximum allowed length for a number
      * string is 32.
      */
     final def tooLong: Option[Long] =
       if (s.length == 0 || s.length > 32) None
-      else parseLong(s, Long.MinValue, Long.MaxValue)
+      else parseLong(s)
   }
 
   implicit class HttpMessage(val self: Message) extends AnyVal {


### PR DESCRIPTION
With the cost of slightly more code we can achieve better throughput (and fewer allocations):

```
NEW:

[info] Benchmark                                             Mode  Cnt    Score     Error   Units
[info] TooFastStringBenchmark.someInt                        avgt   10   13.562 ±   0.606   ns/op
[info] TooFastStringBenchmark.someInt:·gc.alloc.rate.norm    avgt   10   16.000 ±   0.001    B/op

OLD:

[info] Benchmark                                             Mode  Cnt     Score     Error   Units
[info] TooFastStringBenchmark.someInt                        avgt   10    15.586 ±   0.639   ns/op
[info] TooFastStringBenchmark.someInt:·gc.alloc.rate.norm    avgt   10    40.000 ±   0.001    B/op


```