### PR TITLE
Fix Bootstrap.copy() bug

### DIFF
--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -16,8 +16,8 @@ import shapeless._
  * - copy requests's HTTP version onto a response
  * - respond with 404 when en endpoint is not matched
 
- * - include the date header on each response (if enabled)
- * - include the server header on each reponse (if enabled)
+ * - include the date header on each response (unless disabled)
+ * - include the server header on each response (unless disabled)
  */
 @implicitNotFound(
 """An Endpoint you're trying to convert into a Finagle service is missing one or more encoders.

--- a/core/src/test/scala/io/finch/ToResponseSpec.scala
+++ b/core/src/test/scala/io/finch/ToResponseSpec.scala
@@ -1,9 +1,8 @@
-package io.finch.internal
+package io.finch
 
 import com.twitter.concurrent.AsyncStream
 import com.twitter.io.Buf
 import com.twitter.util.Await
-import io.finch._
 import java.nio.charset.StandardCharsets
 
 class ToResponseSpec extends FinchSpec {


### PR DESCRIPTION
The `copy` method generated for a case class isn't necessarily what we need. It makes it much easier to drop the `CTS <: HNil` type given it doesn't have a corresponding argument. I downgraded  `Bootstrap` to a regular class and supplied our own copy (`configure` in that case). This way we distinct two copy operations on the `Bootstrap`:

- modifying endpoints via `serve` (takes care of types)
- modifying one of the configuration params via `configure`(doesn't care about types)