### PR TITLE
Optimize Endpoint and Output

### DIFF
--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -10,124 +10,121 @@ import java.nio.charset.{Charset, StandardCharsets}
  */
 sealed trait Output[+A] { self =>
 
-  protected def meta: Output.Meta
-  protected def withMeta(meta: Output.Meta): Output[A]
-
   /**
    * The status code of this [[Output]].
    */
-  def status: Status = meta.status
+  def status: Status
 
   /**
    * The header map of this [[Output]].
    */
-  def headers: Map[String, String] = meta.headers
+  def headers: Map[String, String]
 
   /**
    * The cookie list of this [[Output]].
    */
-  def cookies: Seq[Cookie] = meta.cookies
+  def cookies: Seq[Cookie]
 
   /**
    * The charset of this [[Output]].
    */
-  def charset: Option[Charset] = meta.charset
+  def charset: Option[Charset]
 
   /**
    * Returns the payload value of this [[Output]] or throws an exception.
    */
   def value: A
 
-  def map[B](fn: A => B): Output[B] = this match {
-    case Output.Payload(v, m) => Output.Payload(fn(v), m)
-    case f @ Output.Failure(_, _) => f
-    case e @ Output.Empty(_) => e
+  final def map[B](fn: A => B): Output[B] = this match {
+    case p: Output.Payload[A] => p.withValue(fn(p.value))
+    case f: Output.Failure => f
+    case e: Output.Empty => e
   }
 
-  def flatMap[B](fn: A => Output[B]): Output[B] = this match {
-    case p @ Output.Payload(v, _) =>
-      val ob = fn(v)
-      ob.withMeta(ob.meta.copy(
-        headers = ob.headers ++ p.headers,
-        cookies = ob.cookies ++ p.cookies
-      ))
-
-    case f @ Output.Failure(_, _) => f
-    case e @ Output.Empty(_) => e
+  final def flatMap[B](fn: A => Output[B]): Output[B] = this match {
+    case p: Output.Payload[A] => fn(p.value).withCookies(p.cookies).withHeaders(p.headers)
+    case f: Output.Failure => f
+    case e: Output.Empty => e
   }
 
-  def flatten[B](implicit ev: A <:< Output[B]): Output[B] = this match {
-    case Output.Payload(v, _) => v
-    case f @ Output.Failure(_, _) => f
-    case e @ Output.Empty(_) => e
+  final def traverse[B](fn: A => Future[B]): Future[Output[B]] = this match {
+    case p: Output.Payload[A] => fn(p.value).map(b => p.withValue(b))
+    case f: Output.Failure => Future.value(f)
+    case e: Output.Empty => Future.value(e)
   }
 
-  def traverse[B](fn: A => Future[B]): Future[Output[B]] = this match {
-    case p @ Output.Payload(v, _) => fn(v).map(b => p.copy(value = b))
-    case f @ Output.Failure(_, _) => Future.value(f)
-    case e @ Output.Empty(_) => Future.value(e)
+  final def traverseFlatten[B](fn: A => Future[Output[B]]): Future[Output[B]] = this match {
+    case p: Output.Payload[A] =>
+      fn(p.value).map(ob => ob.withHeaders(self.headers).withCookies(self.cookies))
+    case f: Output.Failure => Future.value(f)
+    case e: Output.Empty => Future.value(e)
   }
 
   /**
    * Overrides `charset` of this [[Output]].
    */
-  def withCharset(charset: Charset): Output[A] =
-    withMeta(meta.copy(charset = Some(charset)))
+  final def withCharset(charset: Charset): Output[A] =
+    copy(charset = Some(charset))
 
   /**
    * Overrides the `status` code of this [[Output]].
    */
-  def withStatus(status: Status): Output[A] =
-    withMeta(meta.copy(status = status))
+  final def withStatus(status: Status): Output[A] =
+    copy(status = status)
+
+  /**
+   * Adds given `headers` to this [[Output]].
+   */
+  final def withHeaders(headers: Map[String, String]): Output[A] =
+    if (headers.isEmpty) this
+    else copy(headers = self.headers ++ headers)
+
+  /**
+   * Adds given `cookies` to this [[Output]].
+   */
+  final def withCookies(cookies: Seq[Cookie]): Output[A] =
+    if (cookies.isEmpty) this
+    else copy(cookies = self.cookies ++ cookies)
 
   /**
    * Adds a given `header` to this [[Output]].
    */
-  def withHeader(header: (String, String)): Output[A] =
-    withMeta(meta.copy(headers = headers + header))
+  final def withHeader(header: (String, String)): Output[A] = withHeaders(Map(header))
 
   /**
    * Adds a given `cookie` to this [[Output]].
    */
-  def withCookie(cookie: Cookie): Output[A] =
-    withMeta(meta.copy(cookies = cookies :+ cookie))
+  final def withCookie(cookie: Cookie): Output[A] = withCookies(Seq(cookie))
+
+  protected def copy(status: Status = self.status,
+    charset: Option[Charset] = self.charset,
+    headers: Map[String, String] = self.headers,
+    cookies: Seq[Cookie] = self.cookies): Output[A]
 }
 
 object Output {
 
   /**
-   * A data type representing an HTTP response metadata shared between different types of
-   * [[Output]]s.
-   */
-  private[finch] case class Meta(
-    status: Status = Status.Ok,
-    charset: Option[Charset] = Option.empty,
-    headers: Map[String, String] = Map.empty[String, String],
-    cookies: Seq[Cookie] = Seq.empty[Cookie]
-  )
-
-  /**
    * Creates a successful [[Output]] that wraps a payload `value` with given `status`.
    */
   final def payload[A](value: A, status: Status = Status.Ok): Output[A] =
-    Payload(value, Meta(status = status))
+    Payload(value, status)
 
   /**
    * Creates a failure [[Output]] that wraps an exception `cause` causing this.
    */
   final def failure[A](cause: Exception, status: Status = Status.BadRequest): Output[A] =
-    Failure(cause, Meta(status = status))
+    Failure(cause, status)
 
   /**
    * Creates an empty [[Output]] of given `status`.
    */
-  final def empty[A](status: Status): Output[A] =
-    Empty(Meta(status = status))
+  final def empty[A](status: Status): Output[A] = Empty(status)
 
   /**
    * Creates a unit/empty [[Output]] (i.e., `Output[Unit]`) of given `status`.
    */
-  final def unit(status: Status): Output[Unit] = Empty(Meta(status = status))
+  final def unit(status: Status): Output[Unit] = empty(status)
 
   /**
    * An [[Output]] with `None` as payload.
@@ -137,33 +134,61 @@ object Output {
   /**
    * A successful [[Output]] that captures a payload `value`.
    */
-  private[finch] final case class Payload[A](value: A, meta: Meta) extends Output[A] {
-    override protected def withMeta(meta: Meta): Output[A] = copy(meta = meta)
+  private[finch] final case class Payload[A](
+      value: A,
+      status: Status = Status.Ok,
+      charset: Option[Charset] = Option.empty,
+      headers: Map[String, String] = Map.empty[String, String],
+      cookies: Seq[Cookie] = Seq.empty[Cookie]) extends  Output[A] { self =>
+
+    def withValue[B](value: B): Payload[B] = Payload(value, status, charset, headers, cookies)
+
+    protected def copy(
+        status: Status,
+        charset: Option[Charset],
+        headers: Map[String, String],
+        cookies: Seq[Cookie]): Output[A] = Payload(value, status, charset, headers, cookies)
   }
 
   /**
    * A failure [[Output]] that captures an  [[Exception]] explaining why it's not a payload
    * or an empty response.
    */
-  private[finch] final case class Failure(cause: Exception, meta: Meta) extends Output[Nothing] {
-    override protected def withMeta(meta: Meta): Output[Nothing] = copy(meta = meta)
-    override def value: Nothing = throw cause
+  private[finch] final case class Failure(
+      cause: Exception,
+      status: Status = Status.BadRequest,
+      charset: Option[Charset] = Option.empty,
+      headers: Map[String, String] = Map.empty[String, String],
+      cookies: Seq[Cookie] = Seq.empty[Cookie]) extends Output[Nothing] {
+
+    def value: Nothing = throw cause
+
+    protected def copy(
+        status: Status,
+        charset: Option[Charset],
+        headers: Map[String, String],
+        cookies: Seq[Cookie]): Output[Nothing] = Failure(cause, status, charset, headers, cookies)
   }
 
   /**
    * An empty [[Output]] that does not capture any payload.
    */
-  private[finch] final case class Empty(meta: Meta) extends Output[Nothing] {
-    override protected def withMeta(meta: Meta): Output[Nothing] = copy(meta = meta)
-    override def value: Nothing = throw new IllegalStateException("empty output")
+  private[finch] final case class Empty(
+      status: Status,
+      charset: Option[Charset] = Option.empty,
+      headers: Map[String, String] = Map.empty[String, String],
+      cookies: Seq[Cookie] = Seq.empty[Cookie]) extends Output[Nothing] {
+
+    def value: Nothing = throw new IllegalStateException("empty output")
+
+    protected def copy(
+        status: Status,
+        charset: Option[Charset],
+        headers: Map[String, String],
+        cookies: Seq[Cookie]): Output[Nothing] = Empty(status, charset, headers, cookies)
   }
 
-  implicit def outputEq[A](implicit A: Eq[A]): Eq[Output[A]] = Eq.instance {
-    case (Payload(av, am), Payload(bv, bm)) => A.eqv(av, bv) && am == bm
-    case (Failure(ac, am), Failure(bc, bm)) => ac == bc && am == bm
-    case (Empty(am), Empty(bm)) => am == bm
-    case (_, _) => false
-  }
+  implicit def outputEq[A]: Eq[Output[A]] = Eq.fromUniversalEquals
 
   implicit class OutputOps[A](val o: Output[A]) extends AnyVal {
 
@@ -175,9 +200,9 @@ object Output {
       tre: ToResponse.Aux[Exception, CT]
     ): Response = {
       val rep = o match {
-        case Output.Payload(v, m) => tr(v, m.charset.getOrElse(StandardCharsets.UTF_8))
-        case Output.Failure(x, m) => tre(x, m.charset.getOrElse(StandardCharsets.UTF_8))
-        case Output.Empty(_) => Response()
+        case p: Output.Payload[A] => tr(p.value, p.charset.getOrElse(StandardCharsets.UTF_8))
+        case f: Output.Failure => tre(f.cause, f.charset.getOrElse(StandardCharsets.UTF_8))
+        case e: Output.Empty => Response()
       }
 
       rep.status = o.status

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -115,22 +115,22 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
     StandardCharsets.UTF_16, StandardCharsets.UTF_16BE, StandardCharsets.UTF_16LE
   )
 
-  def genOutputMeta: Gen[Output.Meta] =
-    genStatus.map(s => Output.Meta(s, Option.empty, Map.empty[String, String], Seq.empty[Cookie]))
+  def genOutputMeta: Gen[(Status, Option[Charset], Map[String, String], Seq[Cookie])] =
+    genStatus.map(s => (s, Option.empty, Map.empty[String, String], Seq.empty[Cookie]))
 
   def genEmptyOutput: Gen[Output.Empty] = for {
-    m <- genOutputMeta
-  } yield Output.Empty(m)
+    (st, cs, hs, c) <- genOutputMeta
+  } yield Output.Empty(st, cs, hs, c)
 
   def genFailureOutput: Gen[Output.Failure] = for {
-    m <- genOutputMeta
+    (st, cs, hs, c) <- genOutputMeta
     s <- Gen.alphaStr
-  } yield Output.Failure(new Exception(s), m)
+  } yield Output.Failure(new Exception(s), st, cs, hs, c)
 
   def genPayloadOutput[A: Arbitrary]: Gen[Output.Payload[A]] = for {
-    m <- genOutputMeta
+    (st, cs, hs, c) <- genOutputMeta
     a <- Arbitrary.arbitrary[A]
-  } yield Output.Payload(a, m)
+  } yield Output.Payload(a, st, cs, hs, c)
 
   def genOutput[A: Arbitrary]: Gen[Output[A]] = Gen.oneOf(
     genPayloadOutput[A], genFailureOutput, genEmptyOutput

--- a/core/src/test/scala/io/finch/OutputSpec.scala
+++ b/core/src/test/scala/io/finch/OutputSpec.scala
@@ -137,9 +137,7 @@ class OutputSpec extends FinchSpec {
 
   it should "traverse arbitrary outputs" in {
     check { oa: Output[String] =>
-        val traversedOutput = oa.traverse[String](_ => Future.value(oa.value))
-
-        Await.result(traversedOutput) === oa
+      Await.result(oa.traverse[String](_ => Future.value(oa.value))) === oa
     }
   }
 }


### PR DESCRIPTION
Applying some technics I learned from @fwbrasil.

The biggest thing is to avoid closure allocations by embedding a `Funciton1` or `Function2` into an enclosing scope/object. This played really nicely in the `Endpoint` (see performance results bellow).

In addition to that optimization I also restructured the `Output` type a bit:

- Got rid of `Meta` and merged its members into each object
- Added `traverseFlatten` (a specialised and cheap version of `traverse().flatten`)
- Added `withHeaders` and `withCookies` that allow copying all things in one shot (no need to allocate an intermediate `Output` for each header).

In a nutshell
- `map*` operations are now up to **40% faster** (400 bytes fewer allocations on each call)
- `::` is now up to **5% faster** (120 bytes fewer allocations on each call)

Running time:

```
NEW:

MapBenchmark.map                             avgt   10   633.837 ±  14.613   ns/op
MapBenchmark.mapAsync                        avgt   10   624.249 ±  22.426   ns/op
MapBenchmark.mapOutput                       avgt   10   734.677 ±  30.215   ns/op
MapBenchmark.mapOutputAsync                  avgt   10   737.170 ±  29.808   ns/op
ProductBenchmark.bothMatched                 avgt   10  1175.716 ±  44.236   ns/op
ProductBenchmark.leftMatched                 avgt   10    26.510 ±   2.335   ns/op
ProductBenchmark.rightMatched                avgt   10     5.081 ±   0.112   ns/op

OLD:

MapBenchmark.map                             avgt   10   624.174 ±  28.621   ns/op
MapBenchmark.mapAsync                        avgt   10   647.369 ±  30.775   ns/op
MapBenchmark.mapOutput                       avgt   10  1221.053 ±  39.319   ns/op
MapBenchmark.mapOutputAsync                  avgt   10  1202.541 ±  44.432   ns/op
ProductBenchmark.bothMatched                 avgt   10  1224.278 ±  49.114   ns/op
ProductBenchmark.leftMatched                 avgt   10    29.856 ±   0.709   ns/op
ProductBenchmark.rightMatched                avgt   10     5.209 ±   0.112   ns/op
```

Allocations:

```
NEW: 

MapBenchmark.map:·gc.alloc.rate.norm                 avgt   10   664.000 ±   0.001    B/op
MapBenchmark.mapAsync:·gc.alloc.rate.norm            avgt   10   664.000 ±   0.001    B/op
MapBenchmark.mapOutput:·gc.alloc.rate.norm           avgt   10   832.000 ±   0.001    B/op
MapBenchmark.mapOutputAsync:·gc.alloc.rate.norm      avgt   10   832.000 ±   0.001    B/op
ProductBenchmark.bothMatched:·gc.alloc.rate.norm     avgt   10  1400.001 ±   0.001    B/op
ProductBenchmark.leftMatched:·gc.alloc.rate.norm     avgt   10    80.000 ±   0.001    B/op
ProductBenchmark.rightMatched:·gc.alloc.rate.norm    avgt   10    ≈ 10⁻⁶              B/op

OLD:

MapBenchmark.map:·gc.alloc.rate.norm                 avgt   10   696.000 ±   0.001    B/op
MapBenchmark.mapAsync:·gc.alloc.rate.norm            avgt   10   696.000 ±   0.001    B/op
MapBenchmark.mapOutput:·gc.alloc.rate.norm           avgt   10  1232.001 ±   0.001    B/op
MapBenchmark.mapOutputAsync:·gc.alloc.rate.norm      avgt   10  1232.001 ±   0.001    B/op
ProductBenchmark.bothMatched:·gc.alloc.rate.norm     avgt   10  1520.001 ±   0.001    B/op
ProductBenchmark.leftMatched:·gc.alloc.rate.norm     avgt   10   104.000 ±   0.001    B/op
ProductBenchmark.rightMatched:·gc.alloc.rate.norm    avgt   10    ≈ 10⁻⁶              B/op
```

/cc @travisbrown @rpless 