### PR TITLE
Experiment with cats Validated

### DIFF
--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -35,6 +35,10 @@ case class Errors(errors: NonEmptyList[Error]) extends Exception with NoStackTra
       errors.map(_.getMessage).toList.mkString(EOL + "  ", EOL + "  ","")
 }
 
+object Errors {
+  def of(head: Error, tail: Error*): Errors = Errors(NonEmptyList.of(head, tail: _*))
+}
+
 object Error {
 
   implicit val eq: Eq[Error] = Eq.instance[Error] { (error1, error2) =>


### PR DESCRIPTION
I was dealing with some heavy use of cats Validated recently and was reminded of #513. This PR adds a `validate` method to `Endpoint` that uses Cats' `Validated` to validate the data of an endpoint. I did not remove `ValidationRule`, `should`, and `shouldNot` because I think we should let users decide which they like better. We should let users experiment and provide feedback on it.

In addition, I add an `Errors.of` method that mimics `NonEmptyList.of` to make constructing `Errors` involve slightly less typing. 

I also implemented `should` and `shouldNot` in terms of `validate`. After @vkostyukov's last PR I'm suddenly very aware of allocations and am willing to undo this if we think the extra allocation of a `Validated` isn't ok.