### PR TITLE
Multiple file uploads

### DIFF
--- a/core/src/test/scala/io/finch/MultipartSpec.scala
+++ b/core/src/test/scala/io/finch/MultipartSpec.scala
@@ -27,9 +27,13 @@ class MultipartSpec extends FinchSpec {
       val i = withFileUpload("foo", b)
       val fu = multipartFileUpload("foo")(i).awaitValueUnsafe()
       val fuo = multipartFileUploadOption("foo")(i).awaitValueUnsafe().flatten
+      val fus = multipartFileUploads("foo")(i).awaitValueUnsafe()
+      val fun = multipartFileUploadsNel("foo")(i).awaitValueUnsafe()
 
       fu.map(_.asInstanceOf[Multipart.InMemoryFileUpload].content) === Some(b) &&
-      fuo.map(_.asInstanceOf[Multipart.InMemoryFileUpload].content) === Some(b)
+      fuo.map(_.asInstanceOf[Multipart.InMemoryFileUpload].content) === Some(b) //&&
+      fus.exists(_.forall(_.asInstanceOf[Multipart.InMemoryFileUpload].content === b)) &&
+      fun.exists(_.forall(_.asInstanceOf[Multipart.InMemoryFileUpload].content === b))
     }
   }
 

--- a/docs/src/main/tut/user-guide.md
+++ b/docs/src/main/tut/user-guide.md
@@ -246,13 +246,13 @@ Chunked bodies:
 
 #### File Uploads
 
-Finch supports reading file uploads from the `multipart/form-data` HTTP bodies with the help of two
+Finch supports reading file uploads from the `multipart/form-data` HTTP bodies with the help of four
 instances (evaluating endpoints that also only match non-chunked requests).
 
-- `fileUpload("foo")` - required, non-chunked (only matches non-chunked requests) file upload with
-  name "foo"
-- `fileUploadOption("foo")` - optional, non-chunked (only matches non-chunked requests) file upload
-  with name "foo"
+- `multipartFileUpload("foo")` - required, non-chunked file upload with name "foo"
+- `multipartFileUploadOption("foo")` - optional, non-chunked file upload with name "foo"
+- `multipartFileUploads("foo")` - optional, non-chunked multiple file uploads with name "foo"
+- `multipartFileUploadsNel("foo")` - required at least one, non-chunked multiple file upload with name "foo"
 
 #### Cookies
 


### PR DESCRIPTION
Adds an endpoint fileUploads(paramName). As mentioned in gitter, this is useful for us.

A suggestion would be to maintain only APIs for multiple file uploads, essentially replacing fileUpload and fileUploadOption (one FileUpload) with fileUploads and fileUploadsOption (Seq[FileUpload]) as the latter also represent the former. If you want I can do this.