### PR TITLE
Rework Mapper as type class, introduce ToTwitterFuture type class

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -18,6 +18,7 @@ import shapeless._
 abstract class FinchBenchmark {
   val postPayload: Input = Input.post("/").withBody[Text.Plain](Buf.Utf8("x" * 1024))
   val getRoot: Input = Input.get("/")
+  val getOne: Input = Input.get("/1")
   val getFooBarBaz: Input = Input.get("/foo/bar/baz")
   val getTenTwenty: Input = Input.get("/10/20")
   val getTrueFalse: Input = Input.get("/true/false")
@@ -157,6 +158,63 @@ class JsonBenchmark extends FinchBenchmark {
 
   @Benchmark
   def encode: Buf = encodeFoo(foo, StandardCharsets.UTF_8)
+}
+
+@State(Scope.Benchmark)
+class ApplyBenchmark extends FinchBenchmark {
+
+  val responseEndpoint: Endpoint[Response] = get("/")(Response())
+  val outputEndpoint: Endpoint[String] = get("/")(Ok("foo"))
+  val futureResponseEndpoint: Endpoint[Response] = get("/")(Future.value(Response()))
+  val futureOutputEndpoint: Endpoint[String] = get("/")(Future.value(Ok("foo")))
+
+  val function1ResponseEndpoint: Endpoint[Response] = get(int)((_: Int) => Response())
+  val function1OutputEndpoint: Endpoint[String] = get(int)((_: Int) => Ok("foo"))
+  val function1FutureResponseEndpoint: Endpoint[Response] = get(int)((_: Int) => Future.value(Response()))
+  val function1FutureOutputEndpoint: Endpoint[String] = get(int)((_: Int) => Future.value(Ok("foo")))
+
+  val functionNResponseEndpoint: Endpoint[Response] = get(int :: int)((_: Int, _: Int) => Response())
+  val functionNOutputEndpoint: Endpoint[String] = get(int :: int)((_: Int, _: Int) => Ok("foo"))
+  val functionNFutureResponseEndpoint: Endpoint[Response] = get(int :: int)((_: Int, _: Int) =>
+    Future.value(Response())
+  )
+  val functionNFutureOutputEndpoint: Endpoint[String] = get(int :: int)((_: Int, _: Int) => Future.value(Ok("foo")))
+
+  @Benchmark
+  def response: Endpoint.Result[Response] = responseEndpoint(getRoot)
+
+  @Benchmark
+  def output: Endpoint.Result[String] = outputEndpoint(getRoot)
+
+  @Benchmark
+  def futureResponse: Endpoint.Result[Response] = futureResponseEndpoint(getRoot)
+
+  @Benchmark
+  def futureOutput: Endpoint.Result[String] = futureOutputEndpoint(getRoot)
+
+  @Benchmark
+  def function1Response: Endpoint.Result[Response] = function1ResponseEndpoint(getOne)
+
+  @Benchmark
+  def function1Output: Endpoint.Result[String] = function1OutputEndpoint(getOne)
+
+  @Benchmark
+  def function1FutureResponse: Endpoint.Result[Response] = function1FutureResponseEndpoint(getOne)
+
+  @Benchmark
+  def function1FutureOutput: Endpoint.Result[String] = function1FutureOutputEndpoint(getOne)
+
+  @Benchmark
+  def functionNResponse: Endpoint.Result[Response] = functionNResponseEndpoint(getTenTwenty)
+
+  @Benchmark
+  def functionNOutput: Endpoint.Result[String] = functionNOutputEndpoint(getOne)
+
+  @Benchmark
+  def functionNFutureResponse: Endpoint.Result[Response] = functionNFutureResponseEndpoint(getOne)
+
+  @Benchmark
+  def functionNFutureOutput: Endpoint.Result[String] = functionNFutureOutputEndpoint(getOne)
 }
 
 @State(Scope.Benchmark)

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -8,7 +8,7 @@ class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
   /**
    * Maps this endpoint to either `A => Output[B]` or `A => Future[Output[B]]`.
    */
-  final def apply[F](f: F)(implicit mapper: Mapper[F, A]): Endpoint[mapper.Out] = mapper(f, self)
+  final def apply[F](f: => F)(implicit mapper: Mapper[F, A]): Endpoint[mapper.Out] = mapper(f, self)
 
   final def apply(input: Input): Endpoint.Result[A] =
     if (input.request.method == m) e(input)

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -2,7 +2,6 @@ package io.finch.syntax
 
 import com.twitter.finagle.http.Method
 import io.finch._
-import shapeless.Lazy
 
 class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
 

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -2,6 +2,7 @@ package io.finch.syntax
 
 import com.twitter.finagle.http.Method
 import io.finch._
+import shapeless.Lazy
 
 class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
 

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -8,7 +8,7 @@ class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
   /**
    * Maps this endpoint to either `A => Output[B]` or `A => Future[Output[B]]`.
    */
-  final def apply(mapper: Mapper[A]): Endpoint[mapper.Out] = mapper(self)
+  final def apply[F](f: F)(implicit mapper: Mapper[F, A]): Endpoint[mapper.Out] = mapper(f, self)
 
   final def apply(input: Input): Endpoint.Result[A] =
     if (input.request.method == m) e(input)

--- a/core/src/main/scala/io/finch/syntax/Mapper.scala
+++ b/core/src/main/scala/io/finch/syntax/Mapper.scala
@@ -57,8 +57,8 @@ private[finch] trait LowPriorityMapperConversions {
     * @group LowPriorityMapper
     */
   implicit def mapperFromHOutputFunction[F[_], A, B](implicit
-                                                     ttf: ToTwitterFuture[F]
-                                                    ): Mapper.Aux[A => F[Output[B]], A, B] =
+    ttf: ToTwitterFuture[F]
+  ): Mapper.Aux[A => F[Output[B]], A, B] =
     instance((e, f) => e.mapOutputAsync(f.andThen(ttf.apply)))
 
   /**
@@ -128,7 +128,7 @@ object Mapper extends HighPriorityMapperConversions {
     ttf: ToTwitterFuture[F]
   ): Mapper.Aux[FN, A, B] = instance((e, f) => e.mapOutputAsync(value => ttf(ev(ftp(f)(value)))))
 
-  implicit def mapperFromHResponseHFunction[F[_], A, FN, FR](f: FN)(implicit
+  implicit def mapperFromHResponseHFunction[F[_], A, FN, FR](implicit
     ftp: FnToProduct.Aux[FN, A => FR],
     ev: FR <:< F[Response],
     ttf: ToTwitterFuture[F]

--- a/core/src/main/scala/io/finch/syntax/Mapper.scala
+++ b/core/src/main/scala/io/finch/syntax/Mapper.scala
@@ -16,16 +16,16 @@ import shapeless.ops.function.FnToProduct
 trait Mapper[F, A] {
   type Out
 
-  def apply(f: F, e: Endpoint[A]): Endpoint[Out]
+  def apply(f: => F, e: Endpoint[A]): Endpoint[Out]
 }
 
 private[finch] trait LowPriorityMapperConversions {
   type Aux[F, A, B] = Mapper[F, A] { type Out = B }
 
-  def instance[F, A, B](fn: (Endpoint[A], F) => Endpoint[B]): Mapper.Aux[F, A, B] = new Mapper[F, A] {
+  def instance[F, A, B](fn: (Endpoint[A], => F) => Endpoint[B]): Mapper.Aux[F, A, B] = new Mapper[F, A] {
     type Out = B
 
-    override def apply(f: F, e: Endpoint[A]): Endpoint[B] = fn(e, f)
+    override def apply(f: => F, e: Endpoint[A]): Endpoint[B] = fn(e, f)
   }
 
   /**

--- a/core/src/main/scala/io/finch/syntax/ToTwitterFuture.scala
+++ b/core/src/main/scala/io/finch/syntax/ToTwitterFuture.scala
@@ -2,6 +2,9 @@ package io.finch.syntax
 
 import com.twitter.util.Future
 
+/**
+  * Type class for conversion of some HKT (i.e. scala.concurrent.Future) to twitter future
+  */
 trait ToTwitterFuture[F[_]] {
 
   def apply[A](f: F[A]): Future[A]
@@ -11,7 +14,7 @@ trait ToTwitterFuture[F[_]] {
 object ToTwitterFuture {
 
   implicit val identity: ToTwitterFuture[Future] = new ToTwitterFuture[Future] {
-    override def apply[A](f: Future[A]): Future[A] = f
+    def apply[A](f: Future[A]): Future[A] = f
   }
 
 }

--- a/core/src/main/scala/io/finch/syntax/ToTwitterFuture.scala
+++ b/core/src/main/scala/io/finch/syntax/ToTwitterFuture.scala
@@ -1,0 +1,17 @@
+package io.finch.syntax
+
+import com.twitter.util.Future
+
+trait ToTwitterFuture[F[_]] {
+
+  def apply[A](f: F[A]): Future[A]
+
+}
+
+object ToTwitterFuture {
+
+  implicit val identity: ToTwitterFuture[Future] = new ToTwitterFuture[Future] {
+    override def apply[A](f: Future[A]): Future[A] = f
+  }
+
+}

--- a/core/src/main/scala/io/finch/syntax/scala/ScalaToTwitterFuture.scala
+++ b/core/src/main/scala/io/finch/syntax/scala/ScalaToTwitterFuture.scala
@@ -1,0 +1,24 @@
+package io.finch.syntax.scala
+
+import scala.concurrent.{ExecutionContext, Future => ScalaFuture}
+import scala.util.{Failure, Success}
+
+import com.twitter.util.{Future, Promise}
+import io.finch.syntax.ToTwitterFuture
+
+trait ScalaToTwitterFuture {
+
+  implicit def scalaToTwitterFuture(implicit ec: ExecutionContext): ToTwitterFuture[ScalaFuture] = {
+    new ToTwitterFuture[ScalaFuture] {
+      def apply[A](f: ScalaFuture[A]): Future[A] = {
+        val p = Promise[A]
+        f.onComplete {
+          case Success(a) => p.setValue(a)
+          case Failure(t) => p.setException(t)
+        }
+        p
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/io/finch/syntax/scala/package.scala
+++ b/core/src/main/scala/io/finch/syntax/scala/package.scala
@@ -1,0 +1,3 @@
+package io.finch.syntax
+
+package object scala extends ScalaToTwitterFuture


### PR DESCRIPTION
Mapper now is not a magnet pattern, but a type class. Signature of `EndpointMapper.apply` has changed a little, but it's backward compatible. Strictly speaking, from API point of view nothing was changed, except that IDE should stop whining about "wrong" arguments: https://github.com/finagle/finch/issues/631

At the same time, added `ToTwitterFuture` type class to support different async mechanisms. There is an identity for twitter future and scala futures support in different package. Inspired by https://github.com/finagle/finch/pull/815

Potentially, this PR could open a way to support monix and scalaz tasks as parts of different subprojects: https://github.com/finagle/finch/pull/815#issuecomment-318662893

It's a working code, but without specs. If it's valid from "ideological" PoV I could write proper tests for Mapper.