### PR TITLE
fix a wrong attribute name in user-guide.md

### DIFF
--- a/docs/src/main/tut/user-guide.md
+++ b/docs/src/main/tut/user-guide.md
@@ -224,7 +224,7 @@ Similar to the rest of predefined endpoints, these come in pairs required/option
 
 Non-chunked bodies:
 
-- `bodyString(Option)` - required/optional, non-chunked (only matches non-chunked requests) body
+- `stringBody(Option)` - required/optional, non-chunked (only matches non-chunked requests) body
    represented as a UTF-8 string.
 - `binaryBody(Option)` - required/optional, non-chunked (only matches non-chunked requests) body
    represented as a byte array.


### PR DESCRIPTION
modify bodyString to stringBody

I was very confused because of bodyString.
I could find stringBody instead of bodyString in io.finch.endpoint.Bodies.
