### PR TITLE
Fix docs build outputting 'unused import' for every import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,7 @@ lazy val docSettings = allSettings ++ Seq(
     "-doc-root-content", (resourceDirectory.in(Compile).value / "rootdoc.txt").getAbsolutePath
   ),
   scalacOptions ~= {
-    _.filterNot(Set("-Yno-predef"))
+    _.filterNot(Set("-Yno-predef", "-Xlint"))
   },
   git.remoteRepo := "git@github.com:finagle/finch.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(benchmarks, jsonTest),
@@ -291,7 +291,7 @@ lazy val docs = project
     )
   )
   .enablePlugins(MicrositesPlugin, ScalaUnidocPlugin)
-  .dependsOn(core, circe, jackson, sse, argonaut, json4s, playjson)
+  .dependsOn(core, circe, jackson, sse, argonaut, json4s, playjson, iteratee)
 
 
 lazy val examples = project


### PR DESCRIPTION
Under Scala 2.12 `-Xlint` brings in some features of `-Xwarn-unused-imports` and this causes Tut to output these warnings in the docs. This removes `-Xlint` from the docs build only and fixes the #827. We may want to try to re-enable the other features of `-Xlint` at some point. 

Also fixed a couple compilation issues in the Enumerator docs.

Also @vkostyukov do you just run `sbt publishMicrosite` to push the docs to github pages or do you have another work flow?