### PR TITLE
Enable all syntax in io.finch.syntax.scala._

### DIFF
--- a/core/src/main/scala/io/finch/syntax/ToTwitterFuture.scala
+++ b/core/src/main/scala/io/finch/syntax/ToTwitterFuture.scala
@@ -3,18 +3,14 @@ package io.finch.syntax
 import com.twitter.util.Future
 
 /**
-  * Type class for conversion of some HKT (i.e. `scala.concurrent.Future`) to `com.twitter.util.Future`
-  */
+ * Type class for conversion of some HKT (i.e. `scala.concurrent.Future`) to `com.twitter.util.Future`
+ */
 trait ToTwitterFuture[F[_]] {
-
   def apply[A](f: F[A]): Future[A]
 }
 
 object ToTwitterFuture {
-
   implicit val identity: ToTwitterFuture[Future] = new ToTwitterFuture[Future] {
-
     def apply[A](f: Future[A]): Future[A] = f
   }
-
 }

--- a/core/src/main/scala/io/finch/syntax/scala/ScalaToTwitterFuture.scala
+++ b/core/src/main/scala/io/finch/syntax/scala/ScalaToTwitterFuture.scala
@@ -7,10 +7,8 @@ import com.twitter.util.{Future, Promise}
 import io.finch.syntax.ToTwitterFuture
 
 trait ScalaToTwitterFuture {
-
-  implicit def scalaToTwitterFuture(implicit ec: ExecutionContext): ToTwitterFuture[ScalaFuture] = {
+  implicit def scalaToTwitterFuture(implicit ec: ExecutionContext): ToTwitterFuture[ScalaFuture] =
     new ToTwitterFuture[ScalaFuture] {
-
       def apply[A](f: ScalaFuture[A]): Future[A] = {
         val p = Promise[A]
         f.onComplete {
@@ -19,8 +17,5 @@ trait ScalaToTwitterFuture {
         }
         p
       }
-
     }
-  }
-
 }

--- a/core/src/main/scala/io/finch/syntax/scala/package.scala
+++ b/core/src/main/scala/io/finch/syntax/scala/package.scala
@@ -1,3 +1,3 @@
 package io.finch.syntax
 
-package object scala extends ScalaToTwitterFuture
+package object scala extends EndpointMappers with ScalaToTwitterFuture


### PR DESCRIPTION
This allows to enable all syntax (including methods `get`, `post`, etc) by just importing `io.finch.syntax.scala._` (no need for `io.finch.syntax._` import).

@ImLiar Please, take a look.