### PR TITLE
Metrics interface and its calls in ToService.apply

### DIFF
--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -117,7 +117,7 @@ object ToService {
             val now = Stopwatch.timeMillis().toFloat
             metrics.countSuccess(path, response.statusCode)
             metrics.successTime(path, response.statusCode, now - start)
-            metrics.size(path, response.content.length.toFloat)
+            metrics.size(path, response.statusCode, response.content.length.toFloat)
           }).onFailure(e => {
             val now = Stopwatch.timeMillis().toFloat
             metrics.countFailure(path, e)

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -1,10 +1,12 @@
 package io.finch
 
+import scala.annotation.implicitNotFound
+
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status, Version}
-import com.twitter.util.Future
+import com.twitter.util.{Future, Stopwatch}
 import io.finch.internal.currentTime
-import scala.annotation.implicitNotFound
+import io.finch.metrics.Metrics
 import shapeless._
 
 /**
@@ -35,7 +37,8 @@ trait ToService[ES <: HList, CTS <: HList] {
   def apply(
     endpoints: ES,
     includeDateHeader: Boolean,
-    includeServerHeader: Boolean
+    includeServerHeader: Boolean,
+    metrics: Metrics
   ): Service[Request, Response]
 }
 
@@ -78,7 +81,8 @@ object ToService {
     def apply(
         endpoints: HNil,
         includeDateHeader: Boolean,
-        includeServerHeader: Boolean): Service[Request, Response] = new Service[Request, Response] {
+        includeServerHeader: Boolean,
+        metrics: Metrics): Service[Request, Response] = new Service[Request, Response] {
 
       def apply(req: Request): Future[Response] = Future.value(
         conformHttp(Response(Status.NotFound), req.version, includeDateHeader, includeServerHeader)
@@ -94,19 +98,33 @@ object ToService {
     def apply(
         endpoints: Endpoint[A] :: ET,
         includeDateHeader: Boolean,
-        includeServerHeader: Boolean): Service[Request, Response] = new Service[Request, Response] {
+        includeServerHeader: Boolean,
+        metrics: Metrics): Service[Request, Response] = new Service[Request, Response] {
 
       private[this] val underlying = endpoints.head.handle(respond400OnErrors)
 
       def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
-        case EndpointResult.Matched(rem, out) if rem.route.isEmpty => out.map(oa => conformHttp(
-          oa.toResponse(trA, trE),
-          req.version,
-          includeDateHeader,
-          includeServerHeader
-        )).run
+        case EndpointResult.Matched(rem, out) if rem.route.isEmpty =>
+          val path = underlying.toString
+          val start = Stopwatch.timeMillis().toFloat
+          metrics.countCall(path)
+          out.map(oa => conformHttp(
+            oa.toResponse(trA, trE),
+            req.version,
+            includeDateHeader,
+            includeServerHeader
+          )).run.onSuccess(response => {
+            val now = Stopwatch.timeMillis().toFloat
+            metrics.countSuccess(path, response.statusCode)
+            metrics.successTime(path, response.statusCode, now - start)
+            metrics.size(path, response.content.length.toFloat)
+          }).onFailure(e => {
+            val now = Stopwatch.timeMillis().toFloat
+            metrics.countFailure(path, e)
+            metrics.failureTime(path, e, now - start)
+          })
 
-        case _ => tsT(endpoints.tail, includeDateHeader, includeServerHeader)(req)
+        case _ => tsT(endpoints.tail, includeDateHeader, includeServerHeader, metrics)(req)
       }
     }
   }

--- a/core/src/main/scala/io/finch/metrics/Metrics.scala
+++ b/core/src/main/scala/io/finch/metrics/Metrics.scala
@@ -30,7 +30,7 @@ trait Metrics {
   /**
     * Count size of a response
     */
-  def size(path: String, s: Float): Unit
+  def size(path: String, code: Int, s: Float): Unit
 
 }
 
@@ -43,7 +43,7 @@ object Metrics {
 
     def failureTime(path: String, e: Throwable, duration: Float): Unit = ()
 
-    def size(path: String, s: Float): Unit = ()
+    def size(path: String, code: Int, s: Float): Unit = ()
 
     def countSuccess(path: String, code: Int): Unit = ()
 

--- a/core/src/main/scala/io/finch/metrics/Metrics.scala
+++ b/core/src/main/scala/io/finch/metrics/Metrics.scala
@@ -1,0 +1,53 @@
+package io.finch.metrics
+
+trait Metrics {
+
+  /**
+    * Count a call to endpoint by path and method
+    */
+  def countCall(path: String): Unit
+
+  /**
+    * Count failure if exception was thrown during processing request to an endpoint
+    */
+  def countFailure(path: String, e: Throwable): Unit
+
+  /**
+    * Count time that was required to process failed request
+    */
+  def failureTime(path: String, e: Throwable, duration: Float): Unit
+
+  /**
+    * Count success if request was processed without exceptions
+    */
+  def countSuccess(path: String, code: Int): Unit
+
+  /**
+    * Count
+    */
+  def successTime(path: String, code: Int, duration: Float): Unit
+
+  /**
+    * Count size of response
+    */
+  def size(path: String, s: Float): Unit
+
+}
+
+object Metrics {
+
+  val Null: Metrics = new Metrics {
+    def countCall(path: String): Unit = ()
+
+    def countFailure(path: String, e: Throwable): Unit = ()
+
+    def failureTime(path: String, e: Throwable, duration: Float): Unit = ()
+
+    def size(path: String, s: Float): Unit = ()
+
+    def countSuccess(path: String, code: Int): Unit = ()
+
+    def successTime(path: String, code: Int, duration: Float): Unit = ()
+  }
+
+}

--- a/core/src/main/scala/io/finch/metrics/Metrics.scala
+++ b/core/src/main/scala/io/finch/metrics/Metrics.scala
@@ -3,32 +3,32 @@ package io.finch.metrics
 trait Metrics {
 
   /**
-    * Count a call to endpoint by path and method
+    * Count call to endpoint by the path and method
     */
   def countCall(path: String): Unit
 
   /**
-    * Count failure if exception was thrown during processing request to an endpoint
+    * Count failure if exception was thrown during processing a request to an endpoint
     */
   def countFailure(path: String, e: Throwable): Unit
 
   /**
-    * Count time that was required to process failed request
+    * Count time that was required to process a failed request
     */
   def failureTime(path: String, e: Throwable, duration: Float): Unit
 
   /**
-    * Count success if request was processed without exceptions
+    * Count success if a request was processed without exceptions
     */
   def countSuccess(path: String, code: Int): Unit
 
   /**
-    * Count
+    * Count time that was required to process a successful request
     */
   def successTime(path: String, code: Int, duration: Float): Unit
 
   /**
-    * Count size of response
+    * Count size of a response
     */
   def size(path: String, s: Float): Unit
 


### PR DESCRIPTION
Here I'm again with #781 

After some good points in review of PR #835, I decided to try it in another way.

- Metrics interface and its default `Null` implementation
- Users could prove their own implementation through `Bootstrap`
- Default finagle-stats based implementation could be used by the user with `finch-metrics` module (different PR)

@vkostyukov @rpless @spockz take a look please

I still in doubts about how to properly count failures since `Output.failure` is encoded as successful `Future[Response]`.
Also `path: String` will be replaced when `Endpoint.Meta` introduced, giving even more flexibility.