### PR TITLE
Call /hello endpoint in cookbook example 5

### DIFF
--- a/docs/src/main/tut/cookbook.md
+++ b/docs/src/main/tut/cookbook.md
@@ -332,7 +332,7 @@ val headers = get("hello" :: headersAll) {headers: Map[String, String] =>
   Ok(s"Headers: $headers")
 }
 
-headers(Input.get("/").withHeaders("foo" -> "bar")).awaitValueUnsafe()
+headers(Input.get("/hello").withHeaders("foo" -> "bar")).awaitValueUnsafe()
 ```
 
 ### CORS in Finch


### PR DESCRIPTION
Example 5 in the Finch cookbook (https://finagle.github.io/finch/cookbook.html) shows how to extract headers from a request, but the Input doesn't call the set-up endpoint, which results in
```
res31: Option[String] = None
```
The desired behaviour is to show that the headers are indeed extracted.
```scala
res1: Option[String] = Some(Headers: Map(foo -> bar))
```