### PR TITLE
Update third-party dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 sudo: false
 scala:
   - 2.11.11
-  - 2.12.2
+  - 2.12.3
 jdk:
   - oraclejdk8
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import microsites.ExtraMdFileConfig
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   version := "0.16.0-M3",
-  scalaVersion := "2.12.2",
-  crossScalaVersions := Seq("2.11.11", "2.12.2")
+  scalaVersion := "2.12.3",
+  crossScalaVersions := Seq("2.11.11", "2.12.3")
 )
 
 lazy val finagleVersion = "7.1.0"
@@ -15,7 +15,7 @@ lazy val catbirdVersion = "0.18.0"
 lazy val shapelessVersion = "2.3.2"
 lazy val catsVersion = "1.0.0-MF"
 lazy val sprayVersion = "1.3.3"
-lazy val playVersion = "2.6.3"
+lazy val playVersion = "2.6.6"
 lazy val jacksonVersion = "2.8.8"
 lazy val argonautVersion = "6.2"
 lazy val json4sVersion = "3.5.2"
@@ -38,9 +38,9 @@ lazy val compilerOptions = Seq(
 
 val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.13.5",
-  "org.scalatest" %% "scalatest" % "3.0.3",
+  "org.scalatest" %% "scalatest" % "3.0.4",
   "org.typelevel" %% "cats-laws" % catsVersion,
-  "org.typelevel" %% "discipline" % "0.7.3"
+  "org.typelevel" %% "discipline" % "0.8"
 )
 
 val baseSettings = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16


### PR DESCRIPTION
- Use sbt 0.13.16 (https://github.com/sbt/sbt/releases/tag/v0.13.16)
- Compile against scala 2.12.3 and update travis-ci accordingly
- scalatest 3.0.3 -> 3.0.4 (http://www.scalatest.org/release_notes/3.0.4)
- play 2.6.3 -> 2.6.6 (https://www.playframework.com/changelog)
- discipline 0.7.3 -> 0.8 (compiled against 2.12.2 instead of 2.12.0-RC1, https://github.com/typelevel/discipline/compare/v0.7...v0.8)