### PR TITLE
Export Endpoint.toString in a Response.Schema.Record

### DIFF
--- a/core/src/main/scala/io/finch/FinchContext.scala
+++ b/core/src/main/scala/io/finch/FinchContext.scala
@@ -1,0 +1,13 @@
+package io.finch
+
+import com.twitter.finagle.http.Response
+
+/** [[FinchContext]] provides `Response.Schema.Field`s that Finch uses to export internal
+ * information.
+ */
+object FinchContext {
+
+  /** [[PathField]] exports the [[Endpoint toString]] of the endpoint that is matched.
+    */
+  val PathField: Response.Schema.Field[String] = Response.Schema.newField[String]()
+}

--- a/core/src/main/scala/io/finch/FinchContext.scala
+++ b/core/src/main/scala/io/finch/FinchContext.scala
@@ -1,5 +1,6 @@
 package io.finch
 
+import com.twitter.finagle.http.Request
 import com.twitter.finagle.http.Response
 
 /** [[FinchContext]] provides `Response.Schema.Field`s that Finch uses to export internal
@@ -7,7 +8,9 @@ import com.twitter.finagle.http.Response
  */
 object FinchContext {
 
-  /** [[PathField]] exports the [[Endpoint toString]] of the endpoint that is matched.
-    */
-  val PathField: Response.Schema.Field[String] = Response.Schema.newField[String]()
+  /** [[RequestPathField]] exports the [[Endpoint toString]] of the endpoint that is matched. */
+  val RequestPathField: Request.Schema.Field[String] = Request.Schema.newField[String]()
+
+  /** [[ResponsePathField]] exports the [[Endpoint toString]] of the endpoint that is matched. */
+  val ResponsePathField: Response.Schema.Field[String] = Response.Schema.newField[String]()
 }

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -2,8 +2,9 @@ package io.finch
 
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status, Version}
-import com.twitter.util.Future
+import com.twitter.util.{Future, Return, Throw}
 import io.finch.internal.currentTime
+
 import scala.annotation.implicitNotFound
 import shapeless._
 
@@ -74,8 +75,9 @@ object ToService {
     rep
   }
 
-  private def withPathContext(e: Endpoint[_])(rep: Response): Response = {
-    rep.ctx.updateAndLock(FinchContext.PathField, e.toString)
+  private def withPathContext(e: Endpoint[_], req: Request)(rep: Response): Response = {
+    req.ctx.updateAndLock(FinchContext.RequestPathField, e.toString)
+    rep.ctx.updateAndLock(FinchContext.ResponsePathField, e.toString)
     rep
   }
 
@@ -109,7 +111,10 @@ object ToService {
           req.version,
           includeDateHeader,
           includeServerHeader
-        )).run.onSuccess(withPathContext(underlying))
+        )).run.respond({
+          case Return(rep) => withPathContext(underlying, req)(rep)
+          case Throw(_) => req.ctx.updateAndLock(FinchContext.RequestPathField, underlying.toString)
+        })
 
         case _ => tsT(endpoints.tail, includeDateHeader, includeServerHeader)(req)
       }

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -74,6 +74,11 @@ object ToService {
     rep
   }
 
+  private def withPathContext(e: Endpoint[_])(rep: Response): Response = {
+    rep.ctx.updateAndLock(FinchContext.PathField, e.toString)
+    rep
+  }
+
   implicit val hnilTS: ToService[HNil, HNil] = new ToService[HNil, HNil] {
     def apply(
         endpoints: HNil,
@@ -104,7 +109,7 @@ object ToService {
           req.version,
           includeDateHeader,
           includeServerHeader
-        )).run
+        )).run.onSuccess(withPathContext(underlying))
 
         case _ => tsT(endpoints.tail, includeDateHeader, includeServerHeader)(req)
       }

--- a/core/src/test/scala/io/finch/ToServiceSpec.scala
+++ b/core/src/test/scala/io/finch/ToServiceSpec.scala
@@ -1,0 +1,33 @@
+package io.finch
+
+import com.twitter.finagle.http.Response
+import com.twitter.util.Await
+
+class ToServiceSpec extends FinchSpec {
+
+  behavior of "ToService"
+
+  it should "set FinchContext.PathField on the Request.ctx and the Response.ctx" in {
+    val passingEndpoint: Endpoint[Response] = get(/).map(_ => Response())
+    val service = passingEndpoint.toServiceAs[Text.Plain]
+
+    val request = Input.get("/").request
+    val response = Await.result(service(request))
+
+    request.ctx[String](FinchContext.RequestPathField) shouldBe passingEndpoint.toString
+    response.ctx(FinchContext.ResponsePathField) shouldBe passingEndpoint.toString
+  }
+
+  it should "set FinchContext.PathField correctly with multiple" in {
+    val passingEndpoint: Endpoint[Response] =
+      get(/).map(_ => Response()) coproduct
+      get(/ :: path[String]).map(_ => Response())
+    val service = passingEndpoint.toServiceAs[Text.Plain]
+
+    val request = Input.get("/").request
+    val response = Await.result(service(request))
+
+    request.ctx[String](FinchContext.RequestPathField) shouldBe "GET /"
+    response.ctx(FinchContext.ResponsePathField) shouldBe "GET /"
+  }
+}

--- a/docs/src/main/tut/best-practices.md
+++ b/docs/src/main/tut/best-practices.md
@@ -207,6 +207,31 @@ object Main extends TwitterServer {
 Both Finagle and user-defined stats are available via the TwitterServer's HTTP admin interface or
 through the `/admin/metrics.json` HTTP endpoint.
 
+#### Monitoring Individual Endpoints
+While it is possible to use a `SimpleFilter` and the `Request`'s path to monitor each endpoint from 
+a filter, this can be detrimental to some metrics systems if the path has dynamic values in it. To 
+support per-endpoint monitoring, Finch exports the Endpoint's `toString` in the `Response`'s `ctx`.
+
+As an example, using `FinchContext` it is possible to define a `Filter` that counts the number of 
+times an `Endpoint` returns a particular status code:
+```tut
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.util.Future
+import io.finch.FinchContext
+
+class MetricFilter(statsReceiver: StatsReceiver) extends SimpleFilter[Request, Response] {
+
+  def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    service(request).onSuccess({ resp =>
+      val path: String = resp.ctx[String](FinchContext.PathField)
+      statsReceiver.counter(path.replace("/","_"), resp.statusCode.toString).incr()
+    })
+  }
+}
+```
+
 ### Picking HTTP statuses for responses
 
 There is no one-size-fits-all answer on what HTTP status code to use for a particular response, but


### PR DESCRIPTION
A possible way to handle #781 that takes a similar approach to what @spockz described [here](https://github.com/finagle/finch/issues/781#issuecomment-304957583). The only difference is that instead of explicitly calling a method to include the path, we always have it available if the endpoint matches.

I'm suspicious of a couple things with this initial sketch, but wanted to solicit feedback on both the general approach and the following:
1. I don't think we want to re-evaluate `toString` on every endpoint call, so maybe pre-computing it is in order
2. I'm unsure if I'm using `StatsReceiver` correctly in the docs, as I use Dropwizard metrics at work and am unfamiliar with the gotchas of `StatsReceiver`.
3. Calling `apply` on the Record can yield a `IllegalStateException` if the endpoint didn't match will raise an exception

I would be interested in hearing what others think about this approach.