### PR TITLE
Optimize Scala Future -> Twitter Future conversion

### DIFF
--- a/core/src/main/scala/io/finch/syntax/scala/CallingThreadExecutionContext.scala
+++ b/core/src/main/scala/io/finch/syntax/scala/CallingThreadExecutionContext.scala
@@ -1,0 +1,9 @@
+package io.finch.syntax.scala
+
+import scala.concurrent.ExecutionContext
+
+private[scala] object CallingThreadExecutionContext extends ExecutionContext {
+  def execute(runnable: Runnable): Unit = runnable.run()
+
+  def reportFailure(throwable: Throwable): Unit = throwable.printStackTrace()
+}

--- a/core/src/main/scala/io/finch/syntax/scala/ScalaToTwitterFuture.scala
+++ b/core/src/main/scala/io/finch/syntax/scala/ScalaToTwitterFuture.scala
@@ -1,20 +1,22 @@
 package io.finch.syntax.scala
 
-import scala.concurrent.{ExecutionContext, Future => ScalaFuture}
+import scala.concurrent.{Future => ScalaFuture}
 import scala.util.{Failure, Success}
 
 import com.twitter.util.{Future, Promise}
 import io.finch.syntax.ToTwitterFuture
 
 trait ScalaToTwitterFuture {
-  implicit def scalaToTwitterFuture(implicit ec: ExecutionContext): ToTwitterFuture[ScalaFuture] =
+  implicit val scalaToTwitterFuture: ToTwitterFuture[ScalaFuture] =
     new ToTwitterFuture[ScalaFuture] {
       def apply[A](f: ScalaFuture[A]): Future[A] = {
-        val p = Promise[A]
+        val p = Promise[A]()
+
         f.onComplete {
           case Success(a) => p.setValue(a)
           case Failure(t) => p.setException(t)
-        }
+        }(CallingThreadExecutionContext)
+
         p
       }
     }


### PR DESCRIPTION
By using a custom CallingThreadExecutionContext we can save a trip through the thread pool and two context switches.

This is an optimization that Twitter Future does by default, but for Scala Future this needs to be done manually (where appropriate).

I've also made ScalaToTwitterFuture a lazy val instead of a def, for a decrease in garbage creation and increase in performance.
(I've noticed that there seem to be quite a few other places in Finch where this might make sense.)

This leads to a significant increase in performance in a simple benchmark of an Endpoint returning `scala.concurrent.Future.successful { Ok() }` :
```
scala.concurrent.ExecutionContext.Implicits.global:
Running 30s test @ http://127.0.0.1:8080/health
  6 threads and 6 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   276.31us    1.29ms  67.06ms   97.69%
    Req/Sec     7.83k     2.53k   14.01k    68.91%
  1403466 requests in 30.10s, 120.46MB read
Requests/sec:  46627.27
Transfer/sec:      4.00MB

CallingThreadExecutionContext (def):
Running 30s test @ http://127.0.0.1:8080/health
  6 threads and 6 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   223.08us    0.96ms  28.54ms   97.22%
    Req/Sec    10.53k     3.10k   17.74k    65.24%
  1886399 requests in 30.10s, 161.91MB read
Requests/sec:  62671.91
Transfer/sec:      5.38MB

CallingThreadExecutionContext (lazy val):
Running 30s test @ http://127.0.0.1:8080/health
  6 threads and 6 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   208.32us    0.91ms  22.86ms   97.38%
    Req/Sec    11.01k     3.17k   17.78k    67.68%
  1977729 requests in 30.10s, 169.75MB read
Requests/sec:  65705.25
Transfer/sec:      5.64MB
```