### PR TITLE
Update to iteratee.io 0.15.0 and Cats 1.0.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 sudo: false
 scala:
   - 2.11.11
-  - 2.12.3
+  - 2.12.4
 jdk:
   - oraclejdk8
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -3,23 +3,24 @@ import microsites.ExtraMdFileConfig
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   version := "0.16.0-M3",
-  scalaVersion := "2.12.3",
-  crossScalaVersions := Seq("2.11.11", "2.12.3")
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.11.11", "2.12.4")
 )
 
 lazy val finagleVersion = "17.10.0"
 lazy val twitterServerVersion = "17.10.0"
-lazy val circeVersion = "0.9.0-M1"
-lazy val circeJacksonVersion = "0.9.0-M1"
-lazy val catbirdVersion = "0.19.0"
+lazy val circeVersion = "0.9.0-M2"
+lazy val circeIterateeVersion = "0.9.0-M3"
+lazy val circeJacksonVersion = "0.9.0-M2"
+lazy val catbirdVersion = "0.20.0"
 lazy val shapelessVersion = "2.3.2"
-lazy val catsVersion = "1.0.0-MF"
+lazy val catsVersion = "1.0.0-RC1"
 lazy val sprayVersion = "1.3.3"
 lazy val playVersion = "2.6.6"
 lazy val jacksonVersion = "2.8.8"
 lazy val argonautVersion = "6.2"
 lazy val json4sVersion = "3.5.2"
-lazy val iterateeVersion = "0.14.0"
+lazy val iterateeVersion = "0.15.0"
 
 lazy val compilerOptions = Seq(
   "-deprecation",
@@ -216,7 +217,7 @@ lazy val jsonTest = project.in(file("json-test"))
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-jawn" % circeVersion,
-      "io.circe" %% "circe-streaming" % circeVersion
+      "io.circe" %% "circe-iteratee" % circeIterateeVersion
     ) ++ testDependencies
   )
   .dependsOn(core, iteratee)
@@ -253,7 +254,7 @@ lazy val circe = project
   .settings(
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
-      "io.circe" %% "circe-streaming" % circeVersion,
+      "io.circe" %% "circe-iteratee" % circeIterateeVersion,
       "io.circe" %% "circe-jawn" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion % "test",
       "io.circe" %% "circe-jackson28" % circeJacksonVersion

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -3,8 +3,8 @@ package io.finch.circe
 import com.twitter.util.{Future, Return, Throw, Try}
 import io.catbird.util._
 import io.circe.Decoder
+import io.circe.iteratee._
 import io.circe.jawn._
-import io.circe.streaming._
 import io.finch.{Application, Decode}
 import io.finch.internal.HttpContent
 import io.finch.iteratee.Enumerate

--- a/docs/src/main/tut/user-guide.md
+++ b/docs/src/main/tut/user-guide.md
@@ -808,7 +808,7 @@ that will return an empty content body.
 ### Streaming
 
 The `finch-iteratee` module enables high-level support of chunked request and response streaming using
-[iteratee.io](https://github.com/travisbrown/iteratee) and `circe-streaming` libraries. It allows encoding and decoding
+[iteratee.io](https://github.com/travisbrown/iteratee) and `circe-iteratee` libraries. It allows encoding and decoding
 newline delimited JSON streams, but also supports binary and text streaming.  
 Concept of [iteratee](https://en.wikipedia.org/wiki/Iteratee) could be complicated for understanding, but
 proves itself very powerful and useful abstraction over processing sequential data. The API of `iteratee.io` library 
@@ -823,7 +823,7 @@ Main points:
 **Decoding**
 
 Currently JSON decoding is supported only in `finch-circe` module and implemented
-using `circe-streaming` library.
+using `circe-iteratee` library.
 
 Finch plugs in iteratee-powered decoding support via the `io.finch.iteratee.Enumerate` type-class:
 

--- a/json-test/src/main/scala/io/finch/test/JsonLaws.scala
+++ b/json-test/src/main/scala/io/finch/test/JsonLaws.scala
@@ -9,8 +9,8 @@ import cats.laws.discipline._
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.circe.{Decoder, Encoder}
+import io.circe.iteratee._
 import io.circe.jawn
-import io.circe.streaming._
 import io.finch._
 import io.finch.internal.HttpContent
 import io.finch.iteratee.Enumerate


### PR DESCRIPTION
This gets us on Cats 1.0.0-RC1 with the newly published [iteratee.io 0.15.0](https://github.com/travisbrown/iteratee/releases/tag/v0.15.0).