### PR TITLE
Add Circe's predict size support

### DIFF
--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -5,7 +5,6 @@ import io.circe.{Json, Printer}
 import java.nio.charset.{Charset, StandardCharsets}
 
 package object circe extends Encoders with Decoders {
-
   protected def print(json: Json, cs: Charset): Buf =
     Buf.ByteBuffer.Owned(Printer.noSpaces.prettyByteBuffer(json, cs))
 
@@ -27,5 +26,15 @@ package object circe extends Encoders with Decoders {
         Buf.ByteBuffer.Owned(io.circe.jackson.jacksonPrintByteBuffer(json))
       else
         Buf.ByteArray.Owned(io.circe.jackson.jacksonPrint(json).getBytes(cs.name))
+  }
+
+  /**
+   * Provides a [[Printer]] that uses a simple form of feedback-controller to predict the
+   * size of the printed message.
+   */
+  object predictSize extends Encoders with Decoders {
+    private[this] val printer: Printer = Printer.noSpaces.copy(predictSize = true)
+    protected def print(json: Json, cs: Charset): Buf =
+      Buf.ByteBuffer.Owned(printer.prettyByteBuffer(json, cs))
   }
 }

--- a/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
@@ -18,3 +18,8 @@ class CirceDropNullKeysSpec extends AbstractJsonSpec {
   import io.finch.circe.dropNullValues._
   checkJson("circe-dropNullKeys")
 }
+
+class CircePredictSizeSpec extends AbstractJsonSpec {
+  import io.finch.circe.predictSize._
+  checkJson("circe-predictSize")
+}


### PR DESCRIPTION
See details in the Circe's PR: https://github.com/circe/circe/pull/739

Our `ToService` benchmark looks pretty great yet I'm unable to reproduce the numbers in the wrk. Let's consider this an experimental until we know more about the performance improvements.

```
PREDICT SIZE DISABLED:

[info] Benchmark                                               Mode  Cnt       Score       Error   Units
[info] ToServiceBenchmark.foos                                thrpt   10   13876.850 ±  9207.359   ops/s
[info] ToServiceBenchmark.foos:·gc.alloc.rate.norm            thrpt   10  111100.167 ±  2415.956    B/op
[info] ToServiceBenchmark.ints                                thrpt   10   76738.704 ±  4821.128   ops/s
[info] ToServiceBenchmark.ints:·gc.alloc.rate.norm            thrpt   10   23449.304 ±    56.644    B/op

PREDICT SIZE ENABLED:

[info] Benchmark                                               Mode  Cnt       Score       Error   Units
[info] ToServiceBenchmark.foos                                thrpt   10   22147.146 ±  1240.016   ops/s
[info] ToServiceBenchmark.foos:·gc.alloc.rate.norm            thrpt   10  111040.073 ±  2435.077    B/op
[info] ToServiceBenchmark.ints                                thrpt   10   80175.133 ±  2721.351   ops/s
[info] ToServiceBenchmark.ints:·gc.alloc.rate.norm            thrpt   10   20821.181 ±  2428.086    B/op
```