### PR TITLE
Introduce ResolveDecodeEntity

### DIFF
--- a/core/src/main/scala/io/finch/internal/ResolveDecodeEntity.scala
+++ b/core/src/main/scala/io/finch/internal/ResolveDecodeEntity.scala
@@ -1,0 +1,46 @@
+package io.finch.internal
+
+import io.finch.DecodeEntity
+import scala.reflect.ClassTag
+
+/**
+ * A temporary type-class supporting an API migration from
+ *
+ * ```
+ * param("foo").as[Int]
+ * ```
+ *
+ * to
+ *
+ * ```
+ * param[Int]("foo")
+ * ```
+ *
+ * , while also resolving a very basic `param("foo")` case as expected.
+ *
+ * @note This class will be removed after the 0.16 release.
+ */
+trait ResolveDecodeEntity[-A] {
+  type Out
+
+  def classTag: ClassTag[Out]
+  def decodeEntity: DecodeEntity[Out]
+}
+
+object ResolveDecodeEntity {
+  type Aux[A, B] = ResolveDecodeEntity[A] { type Out = B }
+
+  implicit val nothing: Aux[Nothing, String] =
+    new ResolveDecodeEntity[Nothing] {
+      type Out = String
+      def classTag: ClassTag[String] = implicitly[ClassTag[String]]
+      def decodeEntity: DecodeEntity[String] = DecodeEntity.decodeString
+    }
+
+  implicit def something[A](implicit de: DecodeEntity[A], ct: ClassTag[A]): Aux[A, A] =
+    new ResolveDecodeEntity[A] {
+      type Out = A
+      def classTag: ClassTag[A] = ct
+      def decodeEntity: DecodeEntity[A] = de
+    }
+}

--- a/core/src/main/scala/io/finch/internal/Rs.scala
+++ b/core/src/main/scala/io/finch/internal/Rs.scala
@@ -3,6 +3,7 @@ package io.finch.internal
 import com.twitter.util.Future
 import io.catbird.util.Rerunnable
 import io.finch._
+import scala.reflect.ClassTag
 import shapeless.HNil
 
 /**
@@ -47,6 +48,9 @@ private[finch] object Rs {
 
   final def paramNotPresent[A](name: String): Rerunnable[Output[A]] =
     exception(Error.NotPresent(items.ParamItem(name)))
+
+  final def paramNotParsed[A](name: String, ct: ClassTag[_], t: Throwable): Rerunnable[Output[A]] =
+    exception(Error.NotParsed(items.ParamItem(name), ct, t))
 
   final def headerNotPresent[A](name: String): Rerunnable[Output[A]] =
     exception(Error.NotPresent(items.HeaderItem(name)))

--- a/generic/src/main/scala/io/finch/generic/FromParams.scala
+++ b/generic/src/main/scala/io/finch/generic/FromParams.scala
@@ -38,7 +38,7 @@ private[generic] object Extractor extends Poly1 {
     dh: DecodeEntity[V],
     ct: ClassTag[V]
   ): Case.Aux[String, Endpoint[Option[V]]] = at[String] { key =>
-    paramOption(key).as(dh, ct)
+    paramOption[V](key)
   }
 
   implicit def seqExtractor[V](implicit
@@ -59,6 +59,6 @@ private[generic] object Extractor extends Poly1 {
     dh: DecodeEntity[V],
     ct: ClassTag[V]
   ): Case.Aux[String, Endpoint[V]] = at[String] { key =>
-    param(key).as(dh, ct)
+    param[V](key)
   }
 }


### PR DESCRIPTION
I've been playing with this idea of supporting an API migration from `param("foo").as[Int]` to `param[Int]("foo")`. What makes it complicated is that we have to maintain a support for just `param("foo")` and have it resolved into `Endpont[String]`. See #786.

This PR introduces a new, temporary type-class `ResolveDecodeEntity` that maps a given type parameter (`Nothing` in the case of `param("foo")` onto a `DecodeEntity` instance). Here is how it works:

```scala
scala> import io.finch._
import io.finch._

scala> param("foo")
res0: io.finch.Endpoint[io.finch.internal.ResolveDecodeEntity.nothing.Out] = param(foo)

scala> param[Int]("foo")
res1: io.finch.Endpoint[Int] = param(foo)

scala> param("foo").as[Int]
res2: io.finch.Endpoint[Int] = param(foo)

scala> param("foo"): Endpoint[String]
res3: io.finch.Endpoint[String] = param(foo)
```

Note: `res0` type looks rather confusing but it's perfectly convertible into `String` (as shown in `res3`). I don't believe this should be a problem for any application's code.

I'd appreciate any feedback people may have about this.