### PR TITLE
Deprecate implicit syntax

### DIFF
--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -9,7 +9,7 @@ import shapeless.Witness
 package object finch extends Endpoints
     with Outputs
     with ValidationRules
-    with io.finch.syntax.EndpointMappers {
+    with io.finch.syntax.DeprecatedEndpointMappers {
 
   object items {
     sealed abstract class RequestItem(val kind: String, val nameOption:Option[String] = None) {

--- a/core/src/main/scala/io/finch/syntax/DeprecatedEndpointMappers.scala
+++ b/core/src/main/scala/io/finch/syntax/DeprecatedEndpointMappers.scala
@@ -1,0 +1,78 @@
+package io.finch.syntax
+
+import com.twitter.finagle.http.Method
+import io.finch._
+
+private[finch] trait DeprecatedEndpointMappers {
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `GET` and the underlying
+   * endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def get[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Get, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `POST` and the underlying
+   * endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def post[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Post, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `PATCH` and the underlying
+   * endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def patch[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Patch, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `DELETE` and the
+   * underlying endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def delete[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Delete, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `HEAD` and the underlying
+   * endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def head[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Head, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `OPTIONS` and the
+   * underlying endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def options[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Options, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `PUT` and the underlying
+   * endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def put[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Put, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `CONNECT` and the
+   * underlying endpoint succeeds on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def connect[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Connect, e)
+
+  /**
+   * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The
+   * resulting [[Endpoint]] succeeds on the request only if its method is `TRACE` and the underlying
+   * router endpoint on it.
+   */
+  @deprecated("Enable syntax explicitly: import io.finch.syntax._", "0.16")
+  def trace[A](e: Endpoint[A]): EndpointMapper[A] = new EndpointMapper[A](Method.Trace, e)
+}


### PR DESCRIPTION
Addressing #833.

Opinions on other ways to achieve this are more than welcome!

```scala
scala> import io.finch._
import io.finch._

scala> val p = get(/) { Ok("foo") }
val p = get(/) { Ok("foo") }
<console>:14: warning: method get in trait DeprecatedEndpointMappers is deprecated (since 0.16): Enable syntax explicitly: import io.finch.syntax._
       val p = get(/) { Ok("foo") }
               ^
p: io.finch.Endpoint[String] = GET /

scala> import io.finch.syntax._
import io.finch.syntax._

scala> val p = get(/) { Ok("foo") }
val p = get(/) { Ok("foo") }
p: io.finch.Endpoint[String] = GET /
```