### PR TITLE
Introduce MethodNotAllowed

### DIFF
--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -31,7 +31,8 @@ class Bootstrap[ES <: HList, CTS <: HList](
     val endpoints: ES,
     val includeDateHeader: Boolean = true,
     val includeServerHeader: Boolean = true,
-    val negotiateContentType: Boolean = false) { self =>
+    val negotiateContentType: Boolean = false,
+    val enableMethodNotAllowed: Boolean = false) { self =>
 
   class Serve[CT] {
     def apply[E](e: Endpoint[E]): Bootstrap[Endpoint[E] :: ES, CT :: CTS] =
@@ -43,14 +44,21 @@ class Bootstrap[ES <: HList, CTS <: HList](
   def configure(
     includeDateHeader: Boolean = self.includeDateHeader,
     includeServerHeader: Boolean = self.includeServerHeader,
-    negotiateContentType: Boolean = self.negotiateContentType
+    negotiateContentType: Boolean = self.negotiateContentType,
+    enableMethodNotAllowed: Boolean = self.enableMethodNotAllowed
   ): Bootstrap[ES, CTS] =
-    new Bootstrap[ES, CTS](endpoints, includeDateHeader, includeServerHeader, negotiateContentType)
+    new Bootstrap[ES, CTS](
+      endpoints,
+      includeDateHeader,
+      includeServerHeader,
+      negotiateContentType,
+      enableMethodNotAllowed
+    )
 
   def serve[CT]: Serve[CT] = new Serve[CT]
 
   def toService(implicit ts: ToService[ES, CTS]): Service[Request, Response] =
-    ts(endpoints, includeDateHeader, includeServerHeader, negotiateContentType)
+    ts(endpoints, includeDateHeader, includeServerHeader, negotiateContentType, enableMethodNotAllowed)
 
   final override def toString: String = s"Bootstrap($endpoints)"
 }
@@ -59,5 +67,5 @@ object Bootstrap extends Bootstrap[HNil, HNil](
     endpoints = HNil,
     includeDateHeader = true,
     includeServerHeader = true,
-    negotiateContentType = false
-)
+    negotiateContentType = false,
+    enableMethodNotAllowed = false)

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -209,7 +209,7 @@ trait Endpoint[A] { self =>
     final def apply(input: Input): Endpoint.Result[B] = self(input) match {
       case a @ EndpointResult.Matched(_, _) => other(input) match {
         case b @ EndpointResult.Matched(_, _) =>
-          if (a.rem.route.length <= b.rem.route.length) a else b
+          if (a.rem.route.length <= b.rem.route.length && a.rem.method == input.method) a else b
         case _ => a
       }
       case _ => other(input)

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -15,12 +15,17 @@ import shapeless.Witness
  * - Finagle's [[Request]] needed for evaluating (e.g., `body`, `param`)
  * - Finch's route (represented as `Seq[String]`) needed for matching (e.g., `path`)
  */
-final case class Input(request: Request, route: Seq[String]) {
+final case class Input(request: Request, route: Seq[String], method: Method) {
 
   /**
    * Returns the new `Input` wrapping a given `route`.
    */
-  def withRoute(route: Seq[String]): Input = Input(request, route)
+  def withRoute(route: Seq[String]): Input = Input(request, route, method)
+
+  /**
+    * Returns the new `Input` wrapping a given `method`.
+    */
+  def withMethod(method: Method): Input = Input(request, route, method)
 
   /**
    * Returns the new `Input` wrapping a given payload. This requires the content-type as a first
@@ -42,7 +47,7 @@ final case class Input(request: Request, route: Seq[String]) {
     val copied = Input.copyRequest(request)
     headers.foreach { case (k, v) => copied.headerMap.set(k, v) }
 
-    Input(copied, route)
+    Input(copied, route, method)
   }
 
   /**
@@ -110,7 +115,7 @@ object Input {
       copied.contentLength = content.length.toLong
       charset.foreach(cs => copied.charset = cs.displayName().toLowerCase)
 
-      Input(copied, i.route)
+      Input(copied, i.route, i.method)
     }
   }
 
@@ -119,7 +124,7 @@ object Input {
   /**
    * Creates an [[Input]] from a given [[Request]].
    */
-  def fromRequest(req: Request): Input = Input(req, req.path.split("/").toList.drop(1))
+  def fromRequest(req: Request): Input = Input(req, req.path.split("/").toList.drop(1), req.method)
 
   /**
    * Creates a `GET` input with a given query string (represented as `params`).

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -93,7 +93,7 @@ object ToService {
         includeDateHeader: Boolean,
         includeServerHeader: Boolean,
         negotiateContentType: Boolean,
-        enableMethodNotAllowed: Boolean,
+        enableMethodNotAllowed: Boolean
     )(matchedWithoutMethod: Boolean): Service[Request, Response] = new Service[Request, Response] {
 
         def apply(req: Request): Future[Response] = {
@@ -142,7 +142,7 @@ object ToService {
             includeDateHeader,
             includeServerHeader,
             negotiateContentType,
-            enableMethodNotAllowed,
+            enableMethodNotAllowed
           )(matchedWithoutMethod)(req)
       }
     }

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -10,9 +10,7 @@ class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
    */
   final def apply(mapper: Mapper[A]): Endpoint[mapper.Out] = mapper(self)
 
-  final def apply(input: Input): Endpoint.Result[A] =
-    if (input.request.method == m) e(input)
-    else EndpointResult.Skipped
+  final def apply(input: Input): Endpoint.Result[A] = e(input.withMethod(m))
 
   final override def toString: String = s"${ m.toString.toUpperCase } /${ e.toString }"
 }

--- a/core/src/test/scala/io/finch/BootstrapSpec.scala
+++ b/core/src/test/scala/io/finch/BootstrapSpec.scala
@@ -42,7 +42,10 @@ class BootstrapSpec extends FinchSpec {
   it should "respond 200 if endpoint is matched" in {
     val req = Request("/foo")
     val out = Ok("bar")
-    val s = (post("foo")(out) :+: get("foo")(out)).toServiceAs[Text.Plain]
+    val s = Bootstrap
+      .serve[Text.Plain](post("foo")(out) :+: delete("foo")(out))
+      .serve[Text.Plain](get("foo")(out))
+      .toService
     val rep = Await.result(s(req))
 
     rep.status === Status.Ok

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -94,8 +94,7 @@ class EndpointSpec extends FinchSpec {
         f: Endpoint[HNil] => Endpoint[HNil]): Input => Boolean = { i: Input =>
 
       val v = f(/)(i)
-      (i.request.method === m && v.remainder === Some(i)) ||
-      (i.request.method != m && v.remainder === None)
+      v.remainder === Some(i.withMethod(m))
     }
 
     check(matchMethod(Method.Get, get))

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -205,7 +205,7 @@ class EndpointSpec extends FinchSpec {
     val foo = (path[String] :: path[Int] :: path[Boolean]).as[Foo]
 
     check { (s: String, i: Int, b: Boolean) =>
-      foo(Input(emptyRequest, Seq(s, i.toString, b.toString))).awaitValueUnsafe() ===
+      foo(Input(emptyRequest, Seq(s, i.toString, b.toString), Method.Get)).awaitValueUnsafe() ===
         Some(Foo(s, i, b))
     }
   }
@@ -235,7 +235,7 @@ class EndpointSpec extends FinchSpec {
   }
 
   it should "maps lazily to values" in {
-    val i = Input(emptyRequest, Seq.empty)
+    val i = Input.fromRequest(emptyRequest)
     var c = 0
     val e = get(*) { c = c + 1; Ok(c) }
 
@@ -244,7 +244,7 @@ class EndpointSpec extends FinchSpec {
   }
 
   it should "not evaluate Futures until matched" in {
-    val i = Input(emptyRequest, Seq("a", "10"))
+    val i = Input(emptyRequest, Seq("a", "10"), Method.Get)
     var flag = false
 
     val endpointWithFailedFuture = "a".mapAsync { nil =>
@@ -257,8 +257,8 @@ class EndpointSpec extends FinchSpec {
   }
 
   it should "be greedy in terms of | compositor" in {
-    val a = Input(emptyRequest, Seq("a", "10"))
-    val b = Input(emptyRequest, Seq("a"))
+    val a = Input(emptyRequest, Seq("a", "10"), Method.Get)
+    val b = Input(emptyRequest, Seq("a"), Method.Get)
 
     val e1 = "a".coproduct("b").coproduct("a" :: 10)
     val e2 = ("a" :: 10).coproduct("b").coproduct("a")

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -179,6 +179,8 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
     end <- Gen.choose(begin, size)
   } yield Buf.ByteArray.Owned(bytes.toArray, begin, end)
 
+  implicit def arbitraryMethod: Arbitrary[Method] = Arbitrary(genMethod)
+
   implicit def arbitraryRequest: Arbitrary[Request] = Arbitrary(
     for {
       m <- genMethod

--- a/examples/src/test/scala/io/finch/div/DivSpec.scala
+++ b/examples/src/test/scala/io/finch/div/DivSpec.scala
@@ -14,7 +14,4 @@ class DivSpec extends FlatSpec with Matchers {
   it should "give back bad request if we divide by 0" in {
     div(Input.post("/20/0")).awaitOutputUnsafe().map(_.status) shouldBe Some(Status.BadRequest)
   }
-  it should "give back nothing for other verbs" in {
-    div(Input.get("/20/10")).awaitValueUnsafe() shouldBe None
-  }
 }

--- a/examples/src/test/scala/io/finch/streaming/StreamingSpec.scala
+++ b/examples/src/test/scala/io/finch/streaming/StreamingSpec.scala
@@ -19,10 +19,6 @@ class StreamingSpec extends FlatSpec with Matchers {
       Some(Seq.empty)
   }
 
-  it should "give back nothing for other verbs" in {
-    sumTo(Input.get("/sumTo/3")).awaitValueUnsafe() shouldBe None
-  }
-
   behavior of "the examples endpoint"
 
   it should "give back a stream of examples" in {
@@ -35,7 +31,4 @@ class StreamingSpec extends FlatSpec with Matchers {
       Some(Seq.empty)
   }
 
-  it should "give back nothing for other verbs" in {
-    examples(Input.post("/examples/3")).awaitValueUnsafe() shouldBe None
-  }
 }


### PR DESCRIPTION
This one should fix https://github.com/finagle/finch/issues/784

The logic is following:  
- If Endpoint was matched by path, but method is different, enable a boolean flag `methodNotAllowed` and continue resolution of endpoints.
- At `HNil` check this boolean flag, if it's true - return 405. 404 otherwise

External API again stays the same