### PR TITLE
Remove '-Ywarn-unused-import' from docs project's scalacOptions 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ lazy val docSettings = allSettings ++ Seq(
     "-doc-root-content", (resourceDirectory.in(Compile).value / "rootdoc.txt").getAbsolutePath
   ),
   scalacOptions ~= {
-    _.filterNot(Set("-Yno-predef", "-Xlint"))
+    _.filterNot(Set("-Yno-predef", "-Xlint", "-Ywarn-unused-import"))
   },
   git.remoteRepo := "git@github.com:finagle/finch.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(benchmarks, jsonTest),


### PR DESCRIPTION
Right now the code fences in the docs are filled with `warning: Unused import`. This due to how tut uses the REPL to evaluate code. For now we can filter out `-Ywarn-unused-import` in the docs project. One downside is that we won't get these errors now for the docs, but I think we'll just have to live with it. We'll also need to republish the docs after this.