### PR TITLE
Fix example for the match verbs section of the documentation

### DIFF
--- a/docs/src/main/tut/user-guide.md
+++ b/docs/src/main/tut/user-guide.md
@@ -177,13 +177,16 @@ For every HTTP verb, there is a function `Endpoint[A] => Endpoint[A]` that takes
 an arbitrary type and enriches it with an additional check/match of the HTTP method/verb.
 
 ```tut
-import io.finch._, com.twitter.finagle.http.{Request, Method}
+
+import io.finch._
 
 val e = path("foo")
 
-e(Input.get("/foo")).isMatched
+val a = get(e)
 
-e(Input.get("/bar")).isMatched
+a(Input.get("/foo")).isMatched
+
+a(Input.post("/foo")).isMatched
 ```
 
 #### Params


### PR DESCRIPTION
Reading the documentation, I stumbled upon a strange example in the Match Verb section. To be precise, It didn't give any examples of matching verbs.

This PR reflects the way I understand what should be there, but I'm not sure if this is exactly what author wanted to show.