### PR TITLE
Add docs for bootstrap

### DIFF
--- a/core/src/main/scala/io/finch/Accept.scala
+++ b/core/src/main/scala/io/finch/Accept.scala
@@ -1,22 +1,26 @@
 package io.finch
 
-import cats.Eq
 import javax.activation.MimeType
 import scala.util.control.NonFatal
 
-case class Accept(primary: String, subtype: String)
+/**
+ * Models an HTTP Accept header (see RFC2616, 14.1).
+ *
+ * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+ */
+final case class Accept(primary: String, sub: String) {
+  def matches(that: Accept): Boolean =
+    (this.primary == that.primary || this.primary == "*") &&
+      (this.sub == that.sub || this.sub == "*")
+}
 
 object Accept {
 
-  def apply(s: String): Option[Accept] = try {
+  /**
+   * Parses an [[Accept]] instance from a given string. Returns `null` when not able to parse.
+   */
+  def fromString(s: String): Accept = try {
     val mt = new MimeType(s)
-    Some(Accept(mt.getPrimaryType, mt.getSubType))
-  } catch {
-    case NonFatal(_) => None
-  }
-
-  implicit val eq: Eq[Accept] = Eq.instance((a, b) => {
-    (a.primary == b.primary || a.primary == "*") &&
-      (a.subtype == b.subtype || a.subtype == "*")
-  })
+    Accept(mt.getPrimaryType, mt.getSubType)
+  } catch { case NonFatal(_) => null }
 }

--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -14,7 +14,18 @@ import shapeless._
  *  .toService
  * }}}
  *
- * @note This API is experimental/unstable. Use with caution.
+ *
+ * == Supported Configuration Options ==
+ *
+ * - `includeDateHeader` (default: `true`): whether or not to include the Date header into
+ *   each response (see RFC2616, section 14.18)
+ * - `includeServerHeader` (default: `true`): whether or not to include the Server header into
+ *   each response (see RFC2616, section 14.38)
+ * - `negotiateContentType` (default: `false`): whether or not to enable server-driven content type
+ *   negotiation (see RFC2616, section 12.1)
+ *
+ * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+ * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec12.html
  */
 class Bootstrap[ES <: HList, CTS <: HList](
     val endpoints: ES,

--- a/core/src/main/scala/io/finch/NegotiateToResponse.scala
+++ b/core/src/main/scala/io/finch/NegotiateToResponse.scala
@@ -1,6 +1,5 @@
 package io.finch
 
-import cats.syntax.eq._
 import shapeless._
 
 /**
@@ -28,8 +27,8 @@ object NegotiateToResponse {
     t: NegotiateToResponse[A, CTT],
     w: Witness.Aux[CTH]
   ): NegotiateToResponse[A, CTH :+: CTT] = instance { accept =>
-    Accept(w.value) match {
-      case Some(ct) if accept.exists(_ === ct) =>
+    Accept.fromString(w.value) match {
+      case ct if (ct ne null) && accept.exists(_.matches(ct)) =>
         h.asInstanceOf[ToResponse.Aux[A, CTH :+: CTT]]
       case _ =>
         t(accept).asInstanceOf[ToResponse.Aux[A, CTH :+: CTT]]

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -103,7 +103,9 @@ object ToService {
 
       def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
         case EndpointResult.Matched(rem, out) if rem.route.isEmpty =>
-          val accept = if (negotiateContentType) req.accept.flatMap(a => Accept(a)) else Seq.empty
+          val accept =
+            if (negotiateContentType) req.accept.flatMap(a => Option(Accept.fromString(a))) else Nil
+
           out.map(oa => conformHttp(
             oa.toResponse(ntrA(accept), ntrE(accept)),
             req.version,

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -137,8 +137,6 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
     genPayloadOutput[A], genFailureOutput, genEmptyOutput
   )
 
-
-
   def genAccept: Gen[Accept] = {
     def witness[T <: String](implicit w: Witness.Aux[T]): String = w.value
     Gen.oneOf(
@@ -154,7 +152,7 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
       witness[Text.Plain],
       witness[Text.Html],
       witness[Text.EventStream]
-    ).map(s => Accept(s).get)
+    ).map(s => Accept.fromString(s))
   }
 
   def genMethod: Gen[Method] = Gen.oneOf(
@@ -193,7 +191,7 @@ trait FinchSpec extends FlatSpec with Matchers with Checkers with AllInstances
       r.content = b
       r.contentLength = b.length.toLong
       r.charset = "utf-8"
-      r.accept = s"${a.primary}/${a.subtype}"
+      r.accept = s"${a.primary}/${a.sub}"
       r
     }
   )

--- a/core/src/test/scala/io/finch/NegotiateToResponseSpec.scala
+++ b/core/src/test/scala/io/finch/NegotiateToResponseSpec.scala
@@ -56,7 +56,7 @@ class NegotiateToResponseSpec extends FinchSpec {
 
   it should "ignore order of values in Accept header and use first appropriate encoder in coproduct" in {
     check { (req: Request, accept: Accept) =>
-      val a = s"${accept.primary}/${accept.subtype}"
+      val a = s"${accept.primary}/${accept.sub}"
       req.accept = a +: req.accept
 
       val s = Bootstrap.serve[AllContentTypes](*).configure(negotiateContentType = true).toService


### PR DESCRIPTION
To follow up on #905. This PR 
 - adds some sacladoc for `Bootstrap`
 - Rebrands `Eq[Accept]` instance to just `Accept.matches` method
 - Renames `Accept.apply` to `Accept.fromString` and gives up on options