### PR TITLE
Unify ToService and Bootstrap benchmarks

### DIFF
--- a/benchmarks/src/main/scala/io/finch/data/Foo.scala
+++ b/benchmarks/src/main/scala/io/finch/data/Foo.scala
@@ -11,9 +11,12 @@ object Foo {
   implicit val decodeEntityFoo: DecodeEntity[Foo] =
     DecodeEntity.instance(s => Return(Foo(s)))
 
-  implicit def decodeFoo[CT <: String]: Decode.Aux[Foo, CT] =
-    Decode.instance((b, cs) => Return(Foo(b.asString(cs))))
+  implicit val decodeFoo: Decode.Text[Foo] =
+    Decode.text((b, cs) => Return(Foo(b.asString(cs))))
 
-  implicit def encodeFoo[CT <: String]: Encode.Aux[Foo, CT] =
-    Encode.instance((f, cs) => Buf.ByteArray.Owned(f.s.getBytes(cs.name)))
+  implicit val encodeFoo: Encode.Text[Foo] =
+    Encode.text((f, cs) => Buf.ByteArray.Owned(f.s.getBytes(cs.name)))
+
+  implicit def encodeList(implicit e: Encode.Text[Foo]): Encode.Text[List[Foo]] =
+    Encode.text((fs, cs) => fs.map(f => e(f, cs)).reduce(_ concat _))
 }


### PR DESCRIPTION
We don't really need a separate benchmark for ToService as it still delegates to `Bootstrap`. Here is the initial results:

```
[info] JsonAndTextNegotiatedBootstrapBenchmark.foos                                thrpt   10   29488.779 ±  2146.953   ops/s
[info] JsonAndTextNegotiatedBootstrapBenchmark.foos:·gc.alloc.rate.norm            thrpt   10   80254.923 ±   270.207    B/op

[info] JsonBootstrapBenchmark.foos                                                 thrpt   10   22546.634 ±   980.536   ops/s
[info] JsonBootstrapBenchmark.foos:·gc.alloc.rate.norm                             thrpt   10  110968.068 ±  2435.075    B/op

[info] JsonNegotiatedBootstrapBenchmark.foos                                       thrpt   10   21366.940 ±  1125.327   ops/s
[info] JsonNegotiatedBootstrapBenchmark.foos:·gc.alloc.rate.norm                   thrpt   10  111040.072 ±  2422.331    B/op

[info] TextBootstrapBenchmark.foos                                                 thrpt   10   67144.142 ±  1851.120   ops/s
[info] TextBootstrapBenchmark.foos:·gc.alloc.rate.norm                             thrpt   10   48568.023 ±    12.749    B/op

[info] TextNegotiatedBootstrapBenchmark.foos                                       thrpt   10   66333.709 ±   848.695   ops/s
[info] TextNegotiatedBootstrapBenchmark.foos:·gc.alloc.rate.norm                   thrpt   10   48624.024 ±     0.008    B/op
```

Looks like enabling negotiation flag on `Bootstrap` (when a single content-type is supplied) degrades its throughput by ~5%. It's likely due to `Accept.fromString` and headers query. As it's only 5%, it's not the end of the world, we can look into that later (actually, I gave it a shot in #909).