### PR TITLE
Cheaper Accept

### DIFF
--- a/core/src/main/scala/io/finch/Accept.scala
+++ b/core/src/main/scala/io/finch/Accept.scala
@@ -1,26 +1,72 @@
 package io.finch
 
-import javax.activation.MimeType
-import scala.util.control.NonFatal
+import java.util.Locale
+
+import shapeless.Witness
 
 /**
  * Models an HTTP Accept header (see RFC2616, 14.1).
  *
+ * @note This API doesn't validate the input primary/sub types.
+ *
  * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
  */
-final case class Accept(primary: String, sub: String) {
-  def matches(that: Accept): Boolean =
-    (this.primary == that.primary || this.primary == "*") &&
-      (this.sub == that.sub || this.sub == "*")
+abstract class Accept {
+  def primary: String
+  def sub: String
+  def matches[CT <: String](implicit m: Accept.Matcher[CT]): Boolean = m(this)
+
+  override def toString: String = s"Accept: $primary/$sub"
 }
 
 object Accept {
 
+  private object Empty extends Accept {
+    def primary: String = ""
+    def sub: String = ""
+    override def matches[CT <: String](implicit m: Matcher[CT]): Boolean = false
+  }
+
+  abstract class Matcher[CT <: String] {
+    def apply(a: Accept): Boolean
+  }
+
+  object Matcher {
+
+    private object Empty extends Matcher[Nothing] {
+      def apply(a: Accept): Boolean = false
+    }
+
+    implicit val json: Matcher[Application.Json] = fromWitness[Application.Json]
+    implicit val xml: Matcher[Application.Xml] = fromWitness[Application.Xml]
+    implicit val text: Matcher[Text.Plain] = fromWitness[Text.Plain]
+    implicit val html: Matcher[Text.Html] = fromWitness[Text.Html]
+
+    implicit def fromWitness[CT <: String](implicit w: Witness.Aux[CT]): Matcher[CT] = {
+      val slashIndex = w.value.indexOf(47)
+      if (slashIndex == 0 || slashIndex == w.value.length) Empty.asInstanceOf[Matcher[CT]]
+      else new Matcher[CT] {
+        private val primary: String = w.value.substring(0, slashIndex).trim.toLowerCase(Locale.ENGLISH)
+        private val sub: String = w.value.substring(slashIndex + 1, w.value.length).trim.toLowerCase(Locale.ENGLISH)
+        def apply(a: Accept): Boolean =
+          (a.primary == "*" && a.sub == "*") || (a.primary == primary && (a.sub == sub || a.sub == "*"))
+      }
+    }
+  }
+
   /**
    * Parses an [[Accept]] instance from a given string. Returns `null` when not able to parse.
    */
-  def fromString(s: String): Accept = try {
-    val mt = new MimeType(s)
-    Accept(mt.getPrimaryType, mt.getSubType)
-  } catch { case NonFatal(_) => null }
+  def fromString(s: String): Accept = {
+    // Adopted from Java's MimeType's API.
+    val slashIndex = s.indexOf(47)
+    val semIndex = s.indexOf(59)
+    val length = if (semIndex < 0) s.length else semIndex
+
+    if (slashIndex < 0 || slashIndex >= length) Empty
+    else new Accept {
+      val primary: String = s.substring(0, slashIndex).trim.toLowerCase(Locale.ENGLISH)
+      val sub: String = s.substring(slashIndex + 1, length).trim.toLowerCase(Locale.ENGLISH)
+    }
+  }
 }

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -103,8 +103,7 @@ object ToService {
 
       def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
         case EndpointResult.Matched(rem, out) if rem.route.isEmpty =>
-          val accept =
-            if (negotiateContentType) req.accept.flatMap(a => Option(Accept.fromString(a))) else Nil
+          val accept = if (negotiateContentType) req.accept.map(a => Accept.fromString(a)) else Nil
 
           out.map(oa => conformHttp(
             oa.toResponse(ntrA(accept), ntrE(accept)),


### PR DESCRIPTION
Several things going on here:

 - `Accept.fromString` now parses string directly (w/o use of the `MimeType` API)
 - New type-class `Accept.Matcher` allows mapping existing content-types (i.e., JSON, text) onto corresponding `Accept` instances so we don't have to create/allocate those for each part of a coproduct.
 - This new type-class surely complicates things a bit but I think it models the matching more fairly as we shouldn't be parsing Accept headers from content-type values in the first place. Now there is a distinction.

@ImLiar @rpless Mind taking a quick look?