### PR TITLE
Deprecated Circe's jackson serializer

### DIFF
--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -18,6 +18,7 @@ package object circe extends Encoders with Decoders {
   /**
    * Provides Jackson Serializer.
    */
+  @deprecated("Use standard Circe serializer - it works great!", "0.17")
   object jacksonSerializer extends Encoders with Decoders {
     override protected def print(json: Json, cs: Charset): Buf =
       if (cs == StandardCharsets.UTF_8)


### PR DESCRIPTION
Let's deprecate it and remove it in 0.18 (see #891).