### PR TITLE
Add path decoding for path[String]

### DIFF
--- a/core/src/test/scala/io/finch/ExtractPathLaws.scala
+++ b/core/src/test/scala/io/finch/ExtractPathLaws.scala
@@ -1,6 +1,7 @@
 package io.finch
 
 import cats.instances.AllInstances
+import io.netty.handler.codec.http.QueryStringEncoder
 import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
 import scala.reflect.ClassTag
@@ -14,6 +15,7 @@ trait ExtractPathLaws[A]  extends Laws with MissingInstances with AllInstances {
     name = "all",
     parent = None,
     "extractOne" -> Prop.forAll { i: Input =>
+      val encodedInput = i.withRoute(i.route.map(s => new QueryStringEncoder(s).toString))
       val o = one(i)
       val v = i.route.headOption.flatMap(s => decode(s))
 


### PR DESCRIPTION
Addresses https://github.com/finagle/finch/issues/902

Though I suppose that use of a netty-provided solution in a long-run might be not the best pick, it solves the problem and does it _very_ efficiently.
See https://github.com/netty/netty/blob/d672a5a483d0c919279dc9d9724011b6d9dcfd9f/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java#L290)