### PR TITLE
Change `toString` of an Endpoint coproduct

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -198,7 +198,7 @@ trait Endpoint[A] { self =>
       final def apply(input: Input): Endpoint.Result[pa.Out] = inner(input)
 
       override def item = items.MultipleItems
-      final override def toString: String = s"${other.toString} :: ${self.toString}"
+      final override def toString: String = s"${other.toString}/${self.toString}"
     }
 
   /**

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -164,7 +164,7 @@ class EndpointSpec extends FinchSpec {
 
     check { (s: String, i: Int) => path(s).map(_ => i).toString === s }
     check { (s: String, t: String) => (path(s) :+: path(t)).toString === s"($s :+: $t)" }
-    check { (s: String, t: String) => (path(s) :: path(t)).toString === s"$s :: $t" }
+    check { (s: String, t: String) => (path(s) :: path(t)).toString === s"$s/$t" }
     check { s: String => path(s).product[String](*.map(_ => "foo")).toString === s }
     check { (s: String, t: String) => path(s).mapAsync(_ => Future.value(t)).toString === s }
 


### PR DESCRIPTION
Proposing to use `/` instead of ` :: ` as character in endpoint string concatenation when dealing with a coproduct.

I don't know of any use cases for coproduct toString() method other than logging purposes, and using "/" instead of " :: " doesn't take anything away from that. But it adds the URL-like property to it, so it can e.g. be directly put in the Location header upon 201 response. The way things are now, I have to do:

```
val root = "foo" :: "bar" :: "baz"

Created(someEntity)
  .withHeader(`Location` -> s"/${root.toString.replace(" :: ", "/")}/${someEntity.id}")
```
where `${root.toString.replace(" :: ", "/")}` could have been simply `$root`.

URL path is unlikely to change, and HTTP endpoints will be using forward slashes for a long time to come, but I can't say the same for `::` which seems to be an arbitrary choice following a 3rd party library convention.

If this is not acceptable, perhaps ` :: ` could at least be defined as a constant, something along the lines of `Endpoint.coproductStringDelimiter`,  so that I can use that in my replace function and not care should the symbol for coproduct suddenly change tomorrow. 