### PR TITLE
Support MethodNotAllowed via new EndpointResult

### DIFF
--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -17,7 +17,7 @@ private abstract class FullBody[A] extends Endpoint[A] {
   protected def present(content: Buf, cs: Charset): Rerunnable[Output[A]]
 
   final def apply(input: Input): Endpoint.Result[A] =
-    if (input.request.isChunked) EndpointResult.Skipped
+    if (input.request.isChunked) EndpointResult.NotMatched
     else {
       val contentLength = input.request.headerMap.getOrNull(Fields.ContentLength)
       val output =
@@ -147,7 +147,7 @@ private[finch] trait Bodies {
    */
   val asyncBody: Endpoint[AsyncStream[Buf]] = new Endpoint[AsyncStream[Buf]] {
     final def apply(input: Input): Endpoint.Result[AsyncStream[Buf]] =
-      if (!input.request.isChunked) EndpointResult.Skipped
+      if (!input.request.isChunked) EndpointResult.NotMatched
       else EndpointResult.Matched(input,
         Rerunnable(Output.payload(AsyncStream.fromReader(input.request.reader))))
 

--- a/core/src/main/scala/io/finch/endpoint/header.scala
+++ b/core/src/main/scala/io/finch/endpoint/header.scala
@@ -46,7 +46,7 @@ private object Header {
 
   trait Exists[A] { _: Header[Id, A] =>
     protected def missing(input: Input, name: String): Endpoint.Result[A] =
-      EndpointResult.Skipped
+      EndpointResult.NotMatched
 
     protected def present(input: Input, value: A): Endpoint.Result[A] =
       EndpointResult.Matched(input, Rs.payload(value))

--- a/core/src/main/scala/io/finch/endpoint/multipart.scala
+++ b/core/src/main/scala/io/finch/endpoint/multipart.scala
@@ -33,7 +33,7 @@ private abstract class Attribute[F[_], A](val name: String, val d: DecodeEntity[
   }
 
   final def apply(input: Input): Endpoint.Result[F[A]] = {
-    if (input.request.isChunked) EndpointResult.Skipped
+    if (input.request.isChunked) EndpointResult.NotMatched
     else {
       all(input) match {
         case None => EndpointResult.Matched(input, missing(name))
@@ -108,7 +108,7 @@ private abstract class FileUpload[F[_]](name: String) extends Endpoint[F[Finagle
     } yield nel
 
   final def apply(input: Input): Endpoint.Result[F[FinagleFileUpload]] =
-    if (input.request.isChunked) EndpointResult.Skipped
+    if (input.request.isChunked) EndpointResult.NotMatched
     else {
       all(input) match {
         case Some(nel) => EndpointResult.Matched(input, present(nel))

--- a/core/src/main/scala/io/finch/endpoint/param.scala
+++ b/core/src/main/scala/io/finch/endpoint/param.scala
@@ -49,7 +49,7 @@ private object Param {
 
   trait Exists[A] { _: Param[Id, A] =>
     protected def missing(input: Input, name: String): Endpoint.Result[A] =
-      EndpointResult.Skipped
+      EndpointResult.NotMatched
 
     protected def present(input: Input, value: A): Endpoint.Result[A] =
       EndpointResult.Matched(input, Rs.payload(value))

--- a/core/src/main/scala/io/finch/endpoint/path.scala
+++ b/core/src/main/scala/io/finch/endpoint/path.scala
@@ -10,7 +10,7 @@ import shapeless.HNil
 private class MatchPath(s: String) extends Endpoint[HNil] {
   final def apply(input: Input): Endpoint.Result[HNil] = input.route match {
     case `s` +: rest => EndpointResult.Matched(input.withRoute(rest), Rs.OutputHNil)
-    case _ => EndpointResult.Skipped
+    case _ => EndpointResult.NotMatched
   }
 
   final override def toString: String = s
@@ -22,9 +22,9 @@ private class ExtractPath[A](implicit d: DecodePath[A], ct: ClassTag[A]) extends
       case Some(a) =>
         EndpointResult.Matched(input.withRoute(rest), Rerunnable.const(Output.payload(a)))
       case _ =>
-        EndpointResult.Skipped
+        EndpointResult.NotMatched
     }
-    case _ => EndpointResult.Skipped
+    case _ => EndpointResult.NotMatched
   }
 
   final override def toString: String = s":${ct.runtimeClass.getSimpleName.toLowerCase}"

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -11,8 +11,11 @@ class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
   final def apply(mapper: Mapper[A]): Endpoint[mapper.Out] = mapper(self)
 
   final def apply(input: Input): Endpoint.Result[A] =
-    if (input.request.method == m) e(input)
-    else EndpointResult.Skipped
+      if (input.request.method == m) e(input)
+      else e(input) match {
+        case EndpointResult.Matched(_, _) => EndpointResult.NotMatched.MethodNotAllowed(m :: Nil)
+        case skipped => skipped
+      }
 
   final override def toString: String = s"${ m.toString.toUpperCase } /${ e.toString }"
 }

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -311,6 +311,19 @@ class EndpointSpec extends FinchSpec {
     }
   }
 
+  it should "accumulate EndpointResult.NotMatched in its | compositor" in {
+    val a = get("foo")
+    val b = post("foo")
+    val ab = a.coproduct(b)
+
+    ab(Input.get("/foo")).isMatched shouldBe true
+    ab(Input.post("/foo")).isMatched shouldBe true
+
+    val put = ab(Input.put("/foo"))
+    put.isMatched shouldBe false
+    put.asInstanceOf[EndpointResult.NotMatched.MethodNotAllowed].allowed.toSet shouldBe Set(Method.Post, Method.Get)
+  }
+
   it should "support the as[A] method on Endpoint[Seq[String]]" in {
     val foos = params[Foo]("testEndpoint")
     foos(Input.get("/index", "testEndpoint" -> "a")).awaitValueUnsafe() shouldBe Some(Seq(Foo("a")))

--- a/iteratee/src/main/scala/io/finch/iteratee/package.scala
+++ b/iteratee/src/main/scala/io/finch/iteratee/package.scala
@@ -35,9 +35,8 @@ package object iteratee extends IterateeInstances {
   def enumeratorBody[A, CT <: String](implicit decode: Enumerate.Aux[A, CT]): Endpoint[Enumerator[Future, A]] = {
     new Endpoint[Enumerator[Future, A]] {
       final def apply(input: Input): Endpoint.Result[Enumerator[Future, A]] = {
-        if (!input.request.isChunked) {
-          EndpointResult.Skipped
-        } else {
+        if (!input.request.isChunked) EndpointResult.NotMatched
+        else {
           val req = input.request
           EndpointResult.Matched(
             input,

--- a/iteratee/src/test/scala/io/finch/iteratee/EnumerateEndpointSpec.scala
+++ b/iteratee/src/test/scala/io/finch/iteratee/EnumerateEndpointSpec.scala
@@ -33,7 +33,7 @@ class EnumerateEndpointSpec extends FinchSpec with GeneratorDrivenPropertyChecks
   }
 
   "enumeratorBody" should "skip matching if request is not chunked" in {
-    enumeratorBody[Buf, Application.OctetStream].apply(Input.fromRequest(Request())) shouldBe EndpointResult.Skipped
+    enumeratorBody[Buf, Application.OctetStream].apply(Input.fromRequest(Request())) shouldBe EndpointResult.NotMatched
   }
 
   "enumeratorJsonBody" should "enumerate input stream if required Enumerate instance is presented" in {


### PR DESCRIPTION
This is essentially an iteration on #883 that instead of capturing a matched method as part of `Input`, introduces a new `EndpointResult` case. I like this approach better because:

 - It's compliant with https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html (10.4.6)
 - It's more efficient (`Input` remains skinner)
 - It keeps a reasonable semantic for `Endpoint.apply(Input)` for endpoint-mappers so REPL/test environments will return "not-matched" when HTTP verb is different.

Example:

```scala
scala> val a = get("foo") { Ok("foo") }
a: io.finch.Endpoint[String] = GET /foo

scala> val b = post("foo") { Ok("post foo") }
b: io.finch.Endpoint[String] = POST /foo

scala> val c = put("foo") { Ok("put foo") }
c: io.finch.Endpoint[String] = PUT /foo

scala> val s = Bootstrap.configure(enabledMethodNotAllowed = true).serve[Text.Plain](a :+: b).serve[Text.Plain](c).toService
s: com.twitter.finagle.Service[com.twitter.finagle.http.Request,com.twitter.finagle.http.Response] = <function1>

scala> Http.server.serve(":8081", s)
```

And then:

```
[tw-mbp-vkostyukov finch (vk/match-wo-method)]$ http :8081/bar
HTTP/1.1 404 Not Found
Content-Length: 0
Date: Fri, 16 Mar 2018 20:59:30 GMT
Server: Finch



[tw-mbp-vkostyukov finch (vk/match-wo-method)]$ http POST :8081/foo
HTTP/1.1 200 OK
Content-Type: text/plain
Date: Fri, 16 Mar 2018 20:59:37 GMT
Server: Finch
content-encoding: gzip
content-length: 34

post foo

[tw-mbp-vkostyukov finch (vk/match-wo-method)]$ http PUT :8081/foo
HTTP/1.1 200 OK
Content-Type: text/plain
Date: Fri, 16 Mar 2018 20:59:48 GMT
Server: Finch
content-encoding: gzip
content-length: 33

put foo

[tw-mbp-vkostyukov finch (vk/match-wo-method)]$ http DELETE :8081/foo
HTTP/1.1 405 Method Not Allowed
Allow: PUT,GET,POST
Content-Length: 0
Date: Fri, 16 Mar 2018 20:59:56 GMT
Server: Finch
```