### PR TITLE
set charset in the Content-Type header for chunked responses

### DIFF
--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -210,7 +210,7 @@ object Output {
       o.headers.foreach { case (k, v) => rep.headerMap.set(k, v) }
       o.cookies.foreach(rep.cookies.add)
       o.charset.foreach { c =>
-        if (!rep.content.isEmpty) {
+        if (!rep.content.isEmpty || rep.isChunked) {
           rep.charset = c.displayName.toLowerCase
         }
       }


### PR DESCRIPTION
Chunked plain text reponses would not include the `charset` part of the `Content-Type` header.
```
  val dummy: Endpoint[AsyncStream[String]] = get("dummy"){
    Ok( AsyncStream.of("Hello / Привет")).withCharset(StandardCharsets.UTF_8)
  }
``` 
The response of this endpoint would be correctly encoded in UTF-8, but the browsers would interpret it wrongly becuase of the missing charset part in the response header.