### PR TITLE
Faster route parsing

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -26,6 +26,18 @@ abstract class FinchBenchmark {
 }
 
 @State(Scope.Benchmark)
+class InputBenchmark extends FinchBenchmark {
+  val foo = Request()
+  val bar = Request("/foo/bar/baz/que/quz")
+
+  @Benchmark
+  def fromEmptyPath: Input = Input.fromRequest(foo)
+
+  @Benchmark
+  def fromPath: Input = Input.fromRequest(bar)
+}
+
+@State(Scope.Benchmark)
 class BodyBenchmark extends FinchBenchmark {
 
   val fooOptionAsText: Endpoint[Option[Foo]] = bodyOption[Foo, Text.Plain]

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -7,6 +7,7 @@ import com.twitter.io.Buf
 import java.nio.charset.{Charset, StandardCharsets}
 import org.jboss.netty.handler.codec.http.{DefaultHttpRequest, HttpMethod, HttpVersion}
 import org.jboss.netty.handler.codec.http.multipart.{DefaultHttpDataFactory, HttpPostRequestEncoder}
+import scala.collection.mutable.ListBuffer
 import shapeless.Witness
 
 /**
@@ -119,7 +120,30 @@ object Input {
   /**
    * Creates an [[Input]] from a given [[Request]].
    */
-  def fromRequest(req: Request): Input = Input(req, req.path.split("/").toList.drop(1))
+  def fromRequest(req: Request): Input = {
+    val p = req.path
+
+    if (p.length == 1) Input(req, Nil)
+    else {
+      val route = new ListBuffer[String]
+      var i, j = 1 // drop the first slash
+
+      while (j < p.length) {
+        if (p.charAt(j) == '/') {
+          route += p.substring(i, j)
+          i = j + 1
+        }
+
+        j += 1
+      }
+
+      if (j > i) {
+        route += p.substring(i, j)
+      }
+
+      Input(req, route.toList)
+    }
+  }
 
   /**
    * Creates a `GET` input with a given query string (represented as `params`).

--- a/core/src/test/scala/io/finch/InputSpec.scala
+++ b/core/src/test/scala/io/finch/InputSpec.scala
@@ -70,4 +70,10 @@ class InputSpec extends FinchSpec {
       }
     }
   }
+
+  it should "parse route correctly" in {
+    check { i: Input =>
+      i.route === i.request.path.split("/").toList.drop(1)
+    }
+  }
 }


### PR DESCRIPTION
Addresses #942.

Benchmark results look promising:

```
BEFORE:

[info] Benchmark                                                   Mode  Cnt     Score     Error   Units
[info] InputBenchmark.fromEmptyPath                                avgt   10   165.508 ±  12.205   ns/op
[info] InputBenchmark.fromEmptyPath:·gc.alloc.rate.norm            avgt   10   280.000 ±   0.001    B/op
[info] InputBenchmark.fromPath                                     avgt   10   418.471 ±  10.846   ns/op
[info] InputBenchmark.fromPath:·gc.alloc.rate.norm                 avgt   10   664.000 ±   0.001    B/op

AFTER:

[info] Benchmark                                                   Mode  Cnt     Score     Error   Units
[info] InputBenchmark.fromEmptyPath                                avgt   10    14.236 ±   0.297   ns/op
[info] InputBenchmark.fromEmptyPath:·gc.alloc.rate.norm            avgt   10    24.000 ±   0.001    B/op
[info] InputBenchmark.fromPath                                     avgt   10   148.513 ±   6.581   ns/op
[info] InputBenchmark.fromPath:·gc.alloc.rate.norm                 avgt   10   384.000 ±   0.001    B/op
```