### PR TITLE
Add finch-refined module with refined types support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -286,7 +286,7 @@ lazy val refined = project
   .settings(
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined" % refinedVersion,
-      "eu.timepit" %% "refined-cats" % refinedVersion,
+      "eu.timepit" %% "refined-cats" % refinedVersion % "test",
       "eu.timepit" %% "refined-scalacheck" % refinedVersion % "test"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val argonautVersion = "6.2.1"
 lazy val json4sVersion = "3.5.3"
 lazy val iterateeVersion = "0.17.0"
 lazy val iterateeTwitterVersion = "18.5.0"
+lazy val refinedVersion = "0.9.0"
 
 lazy val compilerOptions = Seq(
   "-deprecation",
@@ -106,7 +107,7 @@ lazy val publishSettings = Seq(
         <url>https://twitter.com/ryan_plessner</url>
       </developer>
       <developer>
-        <id>ImLiar</id>
+        <id>sergeykolbasov</id>
         <name>Sergey Kolbasov</name>
         <url>https://twitter.com/sergey_kolbasov</url>
       </developer>
@@ -278,6 +279,18 @@ lazy val sse = project
   .settings(moduleName := "finch-sse")
   .settings(allSettings)
   .dependsOn(core)
+
+lazy val refined = project
+  .settings(moduleName := "finch-refined")
+  .settings(allSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "eu.timepit" %% "refined" % refinedVersion,
+      "eu.timepit" %% "refined-cats" % refinedVersion,
+      "eu.timepit" %% "refined-scalacheck" % refinedVersion % "test"
+    )
+  )
+  .dependsOn(core % "test->test;compile->compile")
 
 lazy val docs = project
   .settings(moduleName := "finch-docs")

--- a/docs/src/main/tut/user-guide.md
+++ b/docs/src/main/tut/user-guide.md
@@ -886,6 +886,31 @@ val bufEnumerator =
   }
 ```
 
+The `finch-refined` module provides support for [refined][refined] types in path segments, query parameters and
+other request entities. This approach enables validation of API on type level:
+
+```tut
+import java.net.URL
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric._
+import eu.timepit.refined.string._
+import io.finch._
+import io.finch.syntax._
+
+val e: Endpoint[Int] = get("foo" :: param[Int Refined Positive]("int")) { (i: Int Refined Positive) =>
+  Ok(i.value)
+}
+
+val u: Endpoint[URL] = get("foo" :: param[String Refined Url]("url")) { (s: String Refined Url) =>
+  Ok(new URL(s.value))
+}
+
+//Throw(io.finch.Error.NotParsed: param 'int' cannot be converted to Refined: Predicate failed: (-1 > 0)..)
+e(Input.get("/foo?int=-1")).awaitValue().get
+```
+
+
 **Encoding**
 
 Beside decoding of input stream, it's possible to make output stream with enumerator serving
@@ -1008,4 +1033,5 @@ val s = Bootstrap.configure(includeServerHeader = false).
 [circe-jackson]: https://github.com/circe/circe-jackson
 [circe-jackson-performance]: https://github.com/circe/circe-jackson#jackson-vs-jawn
 [playjson]: https://www.playframework.com/documentation/2.6.x/ScalaJson
+[refined]: https://github.com/fthomas/refined
 [spray-json]: https://github.com/spray/spray-json

--- a/refined/src/main/scala/io/finch/refined/PredicateFailed.scala
+++ b/refined/src/main/scala/io/finch/refined/PredicateFailed.scala
@@ -1,0 +1,9 @@
+package io.finch.refined
+
+import scala.util.control.NoStackTrace
+
+case class PredicateFailed(error: String) extends Exception with NoStackTrace {
+
+    override def getMessage: String = error
+
+}

--- a/refined/src/main/scala/io/finch/refined/package.scala
+++ b/refined/src/main/scala/io/finch/refined/package.scala
@@ -1,16 +1,22 @@
 package io.finch
 
 import com.twitter.util.{Return, Throw}
-import eu.timepit.refined._
-import eu.timepit.refined.api.{Refined, Validate}
+import eu.timepit.refined.api.{RefType, Validate}
 
 package object refined {
 
-  implicit def decodePathRefined[A, B](implicit ad: DecodePath[A], v: Validate[A, B]): DecodePath[A Refined B] =
-    DecodePath.instance(s => ad(s).flatMap(p => refineV[B](p).toOption))
+  implicit def decodePathRefined[F[_, _], A, B](implicit
+    ad: DecodePath[A],
+    v: Validate[A, B],
+    rt: RefType[F]
+  ): DecodePath[F[A, B]] = DecodePath.instance(s => ad(s).flatMap(p => rt.refine[B](p).toOption))
 
-  implicit def decodeEntityRefined[A, B](implicit ad: DecodeEntity[A], v: Validate[A, B]): DecodeEntity[A Refined B] =
-    DecodeEntity.instance(s => ad(s).flatMap(e => refineV[B](e) match {
+  implicit def decodeEntityRefined[F[_, _], A, B](implicit
+    ad: DecodeEntity[A],
+    v: Validate[A, B],
+    rt: RefType[F]
+  ): DecodeEntity[F[A, B]] =
+    DecodeEntity.instance(s => ad(s).flatMap(e => rt.refine[B](e) match {
       case Left(error) => Throw(PredicateFailed(error))
       case Right(ref) => Return(ref)
     }))

--- a/refined/src/main/scala/io/finch/refined/package.scala
+++ b/refined/src/main/scala/io/finch/refined/package.scala
@@ -1,0 +1,18 @@
+package io.finch
+
+import com.twitter.util.{Return, Throw}
+import eu.timepit.refined._
+import eu.timepit.refined.api.{Refined, Validate}
+
+package object refined {
+
+  implicit def decodePathRefined[A, B](implicit ad: DecodePath[A], v: Validate[A, B]): DecodePath[A Refined B] =
+    DecodePath.instance(s => ad(s).flatMap(p => refineV[B](p).toOption))
+
+  implicit def decodeEntityRefined[A, B](implicit ad: DecodeEntity[A], v: Validate[A, B]): DecodeEntity[A Refined B] =
+    DecodeEntity.instance(s => ad(s).flatMap(e => refineV[B](e) match {
+      case Left(error) => Throw(PredicateFailed(error))
+      case Right(ref) => Return(ref)
+    }))
+
+}

--- a/refined/src/test/scala/io/finch/refined/DecodeEntityRefinedSpec.scala
+++ b/refined/src/test/scala/io/finch/refined/DecodeEntityRefinedSpec.scala
@@ -1,0 +1,16 @@
+package io.finch.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.cats._
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.scalacheck.all._
+import io.finch.{DecodeEntityLaws, FinchSpec}
+
+class DecodeEntityRefinedSpec extends FinchSpec {
+
+  checkAll("DecodeEntity[Int Refined Positive]", DecodeEntityLaws[Int Refined Positive].all)
+  checkAll("DecodeEntity[String Refined NonEmpty]", DecodeEntityLaws[String Refined NonEmpty].all)
+
+
+}

--- a/refined/src/test/scala/io/finch/refined/DecodePathRefinedSpec.scala
+++ b/refined/src/test/scala/io/finch/refined/DecodePathRefinedSpec.scala
@@ -1,0 +1,15 @@
+package io.finch.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.cats._
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.scalacheck.all._
+import io.finch.{DecodePathLaws, FinchSpec}
+
+class DecodePathRefinedSpec extends FinchSpec {
+
+  checkAll("DecodePath[Int Refined Positive]", DecodePathLaws[Int Refined Positive].all)
+  checkAll("DecodePath[String Refined NonEmpty]", DecodePathLaws[String Refined NonEmpty].all)
+
+}

--- a/refined/src/test/scala/io/finch/refined/PredicateFailedSpec.scala
+++ b/refined/src/test/scala/io/finch/refined/PredicateFailedSpec.scala
@@ -1,0 +1,24 @@
+package io.finch.refined
+
+import com.twitter.util.Throw
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric._
+import io.finch._
+import io.finch.FinchSpec
+import io.finch.syntax._
+
+class PredicateFailedSpec extends FinchSpec {
+
+  it should "return error with predicate failure information" in {
+
+    val endpoint = get(param[Int Refined Positive]("int")) { (i: Int Refined Positive) =>
+      Ok(i.value)
+    }
+
+    val Some(Throw(result)) = endpoint(Input.get("/?int=-1")).awaitValue()
+
+    result.getCause shouldBe a[PredicateFailed]
+
+  }
+
+}


### PR DESCRIPTION
This PR enables support for [refined](https://github.com/fthomas/refined) types in query parameters, path segments, and other request entities.

Personally, I find it very handy for validation on the type level. This library is also supported by 
circe, so users are able to use refined types in DTOs along with JSON decoders, but it's optional.

- [x] Decoders
- [x] Specs
- [x] Documentation