### PR TITLE
Optimize charsetOrUtf8

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future, Try}
 import io.circe.generic.auto._
 import io.finch.circe._
 import io.finch.data.Foo
-import java.nio.charset.StandardCharsets
+import java.nio.charset.{Charset, StandardCharsets}
 import java.util.concurrent.{ThreadLocalRandom, TimeUnit}
 import org.openjdk.jmh.annotations._
 import shapeless._
@@ -226,4 +226,22 @@ class TooFastStringBenchmark extends FinchBenchmark {
 
   @Benchmark
   def someLong: Option[Long] = "12345678".tooLong
+}
+
+@State(Scope.Benchmark)
+class HttpMessageBenchmark extends FinchBenchmark {
+
+  import io.finch.internal.HttpMessage
+
+  val req = Request()
+  req.contentType = "application/json;charset=utf-8"
+
+  @Benchmark
+  def fastChartset: Charset = req.charsetOrUtf8
+
+  @Benchmark
+  def slowCharset: Charset = req.charset match {
+    case Some(cs) => Charset.forName(cs)
+    case None => StandardCharsets.UTF_8
+  }
 }

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -1,7 +1,6 @@
 package io.finch.endpoint
 
 import com.twitter.concurrent.AsyncStream
-import com.twitter.finagle.http.Fields
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Return, Throw, Try}
 import io.catbird.util.Rerunnable
@@ -20,7 +19,7 @@ private abstract class FullBody[A] extends Endpoint[A] {
     if (input.request.isChunked) EndpointResult.NotMatched
     else {
       val output = Rerunnable.fromFuture {
-        val contentLength = input.request.headerMap.getOrNull(Fields.ContentLength)
+        val contentLength = input.request.contentLengthOrNull
         if (contentLength == null || contentLength == "0") missing
         else present(input.request.content, input.request.charsetOrUtf8)
       }

--- a/core/src/test/scala/io/finch/internal/HttpMessageSpec.scala
+++ b/core/src/test/scala/io/finch/internal/HttpMessageSpec.scala
@@ -1,0 +1,25 @@
+package io.finch.internal
+
+import com.twitter.finagle.http.Request
+import io.finch.FinchSpec
+import java.nio.charset.{Charset, StandardCharsets}
+
+class HttpMessageSpec extends FinchSpec {
+
+  def slowCharset(req: Request): Charset = req.charset match {
+    case Some(cs) => Charset.forName(cs)
+    case None => StandardCharsets.UTF_8
+  }
+
+  "HttpMessage" should "charsetOrUtf8" in {
+    check { cs: Charset =>
+      val req = Request()
+      req.contentType = "application/json"
+      req.charset = cs.displayName()
+
+      req.charsetOrUtf8 === slowCharset(req)
+    }
+
+    assert(Request().charsetOrUtf8 == StandardCharsets.UTF_8)
+  }
+}


### PR DESCRIPTION
This little method is being called on each `body` decode and it's now 4x faster.

```
Benchmark                                                        Mode  Cnt    Score     Error   Units
HttpMessageBenchmark.fastChartset                                avgt   10   79.129 ±   5.363   ns/op
HttpMessageBenchmark.fastChartset:·gc.alloc.rate.norm            avgt   10   72.000 ±   0.001    B/op
HttpMessageBenchmark.slowCharset                                 avgt   10  290.393 ± 125.117   ns/op
HttpMessageBenchmark.slowCharset:·gc.alloc.rate.norm             avgt   10  372.000 ±  19.124    B/op
```