### PR TITLE
Introduce Trace (what endpoint was matched) [RFC]

### DIFF
--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -34,7 +34,7 @@ sealed abstract class EndpointResult[+A] {
    *         `None` otherwise.
    */
   final def remainder: Option[Input] = this match {
-    case EndpointResult.Matched(rem, _) => Some(rem)
+    case EndpointResult.Matched(rem, _, _) => Some(rem)
     case _ => None
   }
 
@@ -45,7 +45,18 @@ sealed abstract class EndpointResult[+A] {
    *         `None` otherwise.
    */
   final def output: Option[Future[Output[A]]] = this match {
-    case EndpointResult.Matched(_, out) => Some(out.run)
+    case EndpointResult.Matched(_, _, out) => Some(out.run)
+    case _ => None
+  }
+
+  /**
+   * Returns the [[Trace]] if an [[Endpoint]] is matched.
+   *
+   * @return `Some(trace)` if this endpoint is matched on a given input,
+   *          `None` otherwise.
+   */
+  final def trace: Option[Trace] = this match {
+    case EndpointResult.Matched(_, trc, _) => Some(trc)
     case _ => None
   }
 
@@ -58,7 +69,7 @@ sealed abstract class EndpointResult[+A] {
    * @return `Some(output)` if this endpoint was matched on a given input, `None` otherwise.
    */
   final def awaitOutput(d: Duration = Duration.Top): Option[Try[Output[A]]] = this match {
-    case EndpointResult.Matched(_, out) => Some(Await.result(out.liftToTry.run, d))
+    case EndpointResult.Matched(_, _, out) => Some(Await.result(out.liftToTry.run, d))
     case _ => None
   }
 
@@ -99,7 +110,11 @@ sealed abstract class EndpointResult[+A] {
 
 object EndpointResult {
 
-  final case class Matched[A](rem: Input, out: Rerunnable[Output[A]]) extends EndpointResult[A] {
+  final case class Matched[A](
+    rem: Input,
+    trc: Trace,
+    out: Rerunnable[Output[A]]
+  ) extends EndpointResult[A] {
     def isMatched: Boolean = true
   }
 

--- a/core/src/main/scala/io/finch/Endpoints.scala
+++ b/core/src/main/scala/io/finch/Endpoints.scala
@@ -21,7 +21,7 @@ trait Endpoints extends Bodies
    */
   object * extends Endpoint[HNil] {
     final def apply(input: Input): Endpoint.Result[HNil] =
-      EndpointResult.Matched(input.copy(route = Nil), EmptyOutput)
+      EndpointResult.Matched(input.copy(route = Nil), Trace.empty, EmptyOutput)
 
     final override def toString: String = "*"
   }
@@ -31,7 +31,7 @@ trait Endpoints extends Bodies
    */
   object / extends Endpoint[HNil] {
     final def apply(input: Input): Endpoint.Result[HNil] =
-      EndpointResult.Matched(input, EmptyOutput)
+      EndpointResult.Matched(input, Trace.empty, EmptyOutput)
 
     final override def toString: String = ""
   }
@@ -41,7 +41,7 @@ trait Endpoints extends Bodies
    */
   object root extends Endpoint[Request] {
     final def apply(input: Input): Endpoint.Result[Request] =
-      EndpointResult.Matched(input, Rerunnable(Output.payload(input.request)))
+      EndpointResult.Matched(input, Trace.empty, Rerunnable(Output.payload(input.request)))
 
     final override def toString: String = "root"
   }

--- a/core/src/main/scala/io/finch/Trace.scala
+++ b/core/src/main/scala/io/finch/Trace.scala
@@ -1,0 +1,61 @@
+package io.finch
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Models a trace of a matched [[Endpoint]]. For example, `/hello/:name`.
+ *
+ * @note represented as a linked-list-like structure for efficiency.
+ */
+sealed trait Trace {
+
+  /**
+   * Concatenates this and `that` [[Trace]]s.
+   */
+  final def concat(that: Trace): Trace = {
+    @tailrec
+    def loop(from: Trace, last: Trace.Segment): Unit = from match {
+      case Trace.Empty =>
+        last.next = that
+      case Trace.Segment(p, n) =>
+        val newLast = Trace.Segment(p, Trace.Empty)
+        last.next = newLast
+        loop(n, newLast)
+    }
+
+    this match {
+      case Trace.Empty => that
+      case a @ Trace.Segment(_, _) => that match {
+        case Trace.Empty => a
+        case _ =>
+          val result = Trace.Segment(a.path, Trace.Empty)
+          loop(a.next, result)
+          result
+      }
+    }
+  }
+
+  /**
+   * Converts this [[Trace]] into a linked list of path segments.
+   */
+  final def toList: List[String] = {
+    @tailrec
+    def loop(from: Trace, to: ListBuffer[String]): List[String] = from match {
+      case Trace.Empty => to.toList
+      case Trace.Segment(path, next) => loop(next, to += path)
+    }
+
+    loop(this, ListBuffer.empty)
+  }
+
+  final override def toString: String = toList.mkString("/", "/", "")
+}
+
+object Trace {
+  private case object Empty extends Trace
+  private final case class Segment(path: String, var next: Trace) extends Trace
+
+  def empty: Trace = Empty
+  def segment(s: String): Trace = Segment(s, empty)
+}

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -24,7 +24,7 @@ private abstract class FullBody[A] extends Endpoint[A] {
         else present(input.request.content, input.request.charsetOrUtf8)
       }
 
-      EndpointResult.Matched(input, output)
+      EndpointResult.Matched(input, Trace.empty, output)
     }
 
   final override def item: RequestItem = items.BodyItem
@@ -164,8 +164,12 @@ private[finch] trait Bodies {
   val asyncBody: Endpoint[AsyncStream[Buf]] = new Endpoint[AsyncStream[Buf]] {
     final def apply(input: Input): Endpoint.Result[AsyncStream[Buf]] =
       if (!input.request.isChunked) EndpointResult.NotMatched
-      else EndpointResult.Matched(input,
-        Rerunnable(Output.payload(AsyncStream.fromReader(input.request.reader))))
+      else
+        EndpointResult.Matched(
+          input,
+          Trace.empty,
+          Rerunnable(Output.payload(AsyncStream.fromReader(input.request.reader)))
+        )
 
     final override def item: RequestItem = items.BodyItem
     final override def toString: String = "asyncBody"

--- a/core/src/main/scala/io/finch/endpoint/cookie.scala
+++ b/core/src/main/scala/io/finch/endpoint/cookie.scala
@@ -18,7 +18,7 @@ private abstract class Cookie[A](name: String) extends Endpoint[A] {
       }
     }
 
-    EndpointResult.Matched(input, output)
+    EndpointResult.Matched(input, Trace.empty, output)
   }
 
   final override def item: items.RequestItem = items.CookieItem(name)

--- a/core/src/main/scala/io/finch/endpoint/header.scala
+++ b/core/src/main/scala/io/finch/endpoint/header.scala
@@ -29,7 +29,7 @@ private abstract class Header[F[_], A](
       }
     }
 
-    EndpointResult.Matched(input, output)
+    EndpointResult.Matched(input, Trace.empty, output)
   }
 
   final override def item: RequestItem = items.HeaderItem(name)

--- a/core/src/main/scala/io/finch/endpoint/multipart.scala
+++ b/core/src/main/scala/io/finch/endpoint/multipart.scala
@@ -44,7 +44,7 @@ private abstract class Attribute[F[_], A](val name: String, d: DecodeEntity[A], 
         }
       }
 
-      EndpointResult.Matched(input, output)
+      EndpointResult.Matched(input, Trace.empty, output)
     }
   }
 
@@ -129,7 +129,7 @@ private abstract class FileUpload[F[_]](name: String)
         }
       }
 
-      EndpointResult.Matched(input, output)
+      EndpointResult.Matched(input, Trace.empty, output)
     }
 
   final override def item: RequestItem = ParamItem(name)

--- a/core/src/main/scala/io/finch/endpoint/param.scala
+++ b/core/src/main/scala/io/finch/endpoint/param.scala
@@ -29,7 +29,7 @@ private abstract class Param[F[_], A](
       }
     }
 
-    EndpointResult.Matched(input, output)
+    EndpointResult.Matched(input, Trace.empty, output)
   }
 
   final override def item: items.RequestItem = items.ParamItem(name)
@@ -78,7 +78,7 @@ private abstract class Params[F[_], A](name: String, d: DecodeEntity[A], tag: Cl
       }
     }
 
-    EndpointResult.Matched(input, output)
+    EndpointResult.Matched(input, Trace.empty, output)
   }
 
   final override def item: items.RequestItem = items.ParamItem(name)

--- a/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
+++ b/core/src/main/scala/io/finch/syntax/EndpointMapper.scala
@@ -13,7 +13,7 @@ class EndpointMapper[A](m: Method, e: Endpoint[A]) extends Endpoint[A] { self =>
   final def apply(input: Input): Endpoint.Result[A] =
       if (input.request.method == m) e(input)
       else e(input) match {
-        case EndpointResult.Matched(_, _) => EndpointResult.NotMatched.MethodNotAllowed(m :: Nil)
+        case EndpointResult.Matched(_, _, _) => EndpointResult.NotMatched.MethodNotAllowed(m :: Nil)
         case skipped => skipped
       }
 

--- a/core/src/test/scala/io/finch/TraceSpec.scala
+++ b/core/src/test/scala/io/finch/TraceSpec.scala
@@ -1,0 +1,19 @@
+package io.finch
+
+class TraceSpec extends FinchSpec {
+
+  behavior of "Trace"
+
+  it should "round-trip concat/toList" in {
+    check { l: List[String] =>
+      val trace = l.foldLeft(Trace.empty)((t, s) => t.concat(Trace.segment(s)))
+      trace.toList === l
+    }
+  }
+
+  it should "concat two non-empty segments correctly" in {
+    check { (a: Trace, b: Trace) =>
+      a.concat(b).toList === (a.toList ++ b.toList)
+    }
+  }
+}

--- a/iteratee/src/main/scala/io/finch/iteratee/package.scala
+++ b/iteratee/src/main/scala/io/finch/iteratee/package.scala
@@ -40,6 +40,7 @@ package object iteratee extends IterateeInstances {
           val req = input.request
           EndpointResult.Matched(
             input,
+            Trace.empty,
             Rerunnable(Output.payload(decode(enumeratorFromReader(req.reader), req.charsetOrUtf8)))
           )
         }


### PR DESCRIPTION
We've been talking quite a bit about the ways to provide users with a context of what endpoint was actually matched (see #953 for a top-level issue). This wasn't possible today.

Both of our attempts to built-in metrics/telemetry failed because of that (see #845 and #855) as we didn't have the right tools to implement it.

I've been playing with the idea of including the matched path into an `EndpointResult` so it could be propagated along the request/input path. This way, at the very bottom (in `ToService`) we can extract this matched path and do something useful with that, for example, report metrics.

This PR [RFC] introduces a new concept `io.finch.Trace` that represent a matched path of an endpoint and is optimized for low footprint and fast concat. Right now, we aren't doing anything useful with it in `ToService` as I wanted to make sure we settle on a general idea before I proceed with actually employing the new data.

Let me know what do you think! Here is a quick usage example.

```scala
scala> import io.finch._, io.finch.syntax._
import io.finch._
import io.finch.syntax._

scala> val foo = get("foo" :: "bar" :: path[String]) { s: String => Ok(s) }
foo: io.finch.Endpoint[String] = GET /foo :: bar :: :string

scala> val bar = get("bar" :: "foo" :: path[Int]) { i: Int => Ok(i) }
bar: io.finch.Endpoint[Int] = GET /bar :: foo :: :int

scala> val fooBar = foo :+: bar
fooBar: io.finch.Endpoint[String :+: Int :+: shapeless.CNil] = (GET /foo :: bar :: :string :+: GET /bar :: foo :: :int)

scala> fooBar(Input.get("/foo/bar/baz")).trace
res0: Option[io.finch.Trace] = Some(/foo/bar/:string)

scala> fooBar(Input.get("/bar/foo/10")).trace
res1: Option[io.finch.Trace] = Some(/bar/foo/:int)
```