### PR TITLE
Add support for content-type-based decoding of request body

### DIFF
--- a/core/src/main/scala/io/finch/Decode.scala
+++ b/core/src/main/scala/io/finch/Decode.scala
@@ -58,21 +58,20 @@ object Decode {
       instance((_, b, cs) => decode(b, cs))
 
     implicit def mkCons[A, CTH <: String, CTT <: Coproduct](implicit
-                                                            decode: Decode.Aux[A, CTH],
-                                                            witness: Witness.Aux[CTH],
-                                                            tail: Dispatchable[A, CTT]
-                                                           ): Dispatchable[A, CTH :+: CTT] =
-      instance((contentType, b, cs) => {
-        if (contentType.exists(ct => ct.equalsIgnoreCase(witness.value))) {
-          decode(b, cs)
-        } else {
-          tail(contentType, b, cs)
-        }
-      })
+      decode: Decode.Aux[A, CTH],
+      witness: Witness.Aux[CTH],
+      tail: Dispatchable[A, CTT]
+    ): Dispatchable[A, CTH :+: CTT] = instance((contentType, b, cs) => {
+      if (contentType.exists(ct => ct.equalsIgnoreCase(witness.value))) {
+        decode(b, cs)
+      } else {
+        tail(contentType, b, cs)
+      }
+    })
 
     implicit def mkSingle[A, CT <: String](implicit
-                                           decode: Decode.Aux[A, CT]
-                                          ): Dispatchable[A, CT] = instance((_, b, cs) => decode(b, cs))
+      decode: Decode.Aux[A, CT]
+    ): Dispatchable[A, CT] = instance((_, b, cs) => decode(b, cs))
 
   }
 

--- a/core/src/main/scala/io/finch/Decode.scala
+++ b/core/src/main/scala/io/finch/Decode.scala
@@ -3,20 +3,21 @@ package io.finch
 import com.twitter.io.Buf
 import com.twitter.util.Try
 import java.nio.charset.Charset
+import shapeless.{:+:, CNil, Coproduct, Witness}
 
 /**
  * Decodes an HTTP payload represented as [[Buf]] (encoded with [[Charset]]) into
  * an arbitrary type `A`.
  */
 trait Decode[A] {
-  type ContentType <: String
+  type ContentType
 
   def apply(b: Buf, cs: Charset): Try[A]
 }
 
 object Decode {
 
-  type Aux[A, CT <: String] = Decode[A] { type ContentType = CT }
+  type Aux[A, CT] = Decode[A] { type ContentType = CT }
 
   type Json[A] = Aux[A, Application.Json]
   type Text[A] = Aux[A, Text.Plain]
@@ -39,4 +40,37 @@ object Decode {
    * Returns a [[Decode]] instance for a given type (with required content type).
    */
   @inline def apply[A, CT <: String](implicit d: Aux[A, CT]): Aux[A, CT] = d
+}
+
+trait AdaptableDecode[A, CT] {
+
+  def apply(contentType: Option[String]): Decode.Aux[A, CT]
+
+}
+
+object AdaptableDecode {
+
+  def instance[A, CT](fn: Option[String] => Decode.Aux[A, CT]):  AdaptableDecode[A, CT] = new AdaptableDecode[A, CT] {
+    def apply(contentType: Option[String]): Decode.Aux[A, CT] = fn(contentType)
+  }
+
+  implicit def mkCnil[A, CTH <: String](implicit decode: Decode.Aux[A, CTH]): AdaptableDecode[A, CTH :+: CNil] =
+    instance(_ => decode.asInstanceOf[Decode.Aux[A, CTH :+: CNil]])
+
+  implicit def mkCons[A, CTH <: String, CTT <: Coproduct](implicit
+    decode: Decode.Aux[A, CTH],
+    witness: Witness.Aux[CTH],
+    tail: AdaptableDecode[A, CTT]
+  ): AdaptableDecode[A, CTH :+: CTT] = instance(contentType => {
+    if (contentType.exists(ct => ct.equalsIgnoreCase(witness.value))) {
+      decode.asInstanceOf[Decode.Aux[A, CTH :+: CTT]]
+    } else {
+      tail(contentType).asInstanceOf[Decode.Aux[A, CTH :+: CTT]]
+    }
+  })
+
+  implicit def mkSingle[A, CT <: String](implicit
+    decode: Decode.Aux[A, CT]
+  ): AdaptableDecode[A, CT] = instance(_ => decode)
+
 }

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -55,10 +55,8 @@ private object FullBody {
   }
 }
 
-private abstract class Body[A, B, CT](
-                                       ad: Decode.Dispatchable[A, CT],
-                                       ct: ClassTag[A]
-) extends FullBody[B] with FullBody.PreparedBody[A, B] with (Try[A] => Try[Output[B]]) {
+private abstract class Body[A, B, CT](ad: Decode.Dispatchable[A, CT], ct: ClassTag[A])
+  extends FullBody[B] with FullBody.PreparedBody[A, B] with (Try[A] => Try[Output[B]]) {
 
   final def apply(ta: Try[A]): Try[Output[B]] = ta match {
     case Return(r) => Return(Output.payload(prepare(r)))

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 private abstract class FullBody[A] extends Endpoint[A] {
 
   protected def missing: Future[Output[A]]
-  protected def present(content: Buf, cs: Charset): Future[Output[A]]
+  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[A]]
 
   final def apply(input: Input): Endpoint.Result[A] =
     if (input.request.isChunked) EndpointResult.NotMatched
@@ -21,7 +21,7 @@ private abstract class FullBody[A] extends Endpoint[A] {
       val output = Rerunnable.fromFuture {
         val contentLength = input.request.contentLengthOrNull
         if (contentLength == null || contentLength == "0") missing
-        else present(input.request.content, input.request.charsetOrUtf8)
+        else present(input.request.contentType, input.request.content, input.request.charsetOrUtf8)
       }
 
       EndpointResult.Matched(input, Trace.empty, output)
@@ -55,8 +55,8 @@ private object FullBody {
   }
 }
 
-private abstract class Body[A, B, CT <: String](
-  d: Decode.Aux[A, CT],
+private abstract class Body[A, B, CT](
+  ad: AdaptableDecode[A, CT],
   ct: ClassTag[A]
 ) extends FullBody[B] with FullBody.PreparedBody[A, B] with (Try[A] => Try[Output[B]]) {
 
@@ -65,8 +65,8 @@ private abstract class Body[A, B, CT <: String](
     case Throw(t) => Throw(Error.NotParsed(items.BodyItem, ct, t))
   }
 
-  protected def present(content: Buf, cs: Charset): Future[Output[B]] =
-    Future.const(d(content, cs).transform(this))
+  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[B]] =
+    Future.const(ad(contentType)(content, cs).transform(this))
 
   final override def toString: String = "body"
 }
@@ -74,14 +74,14 @@ private abstract class Body[A, B, CT <: String](
 private abstract class BinaryBody[A]
     extends FullBody[A] with FullBody.PreparedBody[Array[Byte], A] {
 
-  protected def present(content: Buf, cs: Charset): Future[Output[A]] =
+  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[A]] =
     Future.value(Output.payload(prepare(content.asByteArray)))
 
   final override def toString: String = "binaryBody"
 }
 
 private abstract class StringBody[A] extends FullBody[A] with FullBody.PreparedBody[String, A] {
-  protected def present(content: Buf, cs: Charset): Future[Output[A]] =
+  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[A]] =
     Future.value(Output.payload(prepare(content.asString(cs))))
 
   final override def toString: String = "stringBody"
@@ -125,7 +125,7 @@ private[finch] trait Bodies {
    * (non-streamed) requests.
    */
   def bodyOption[A, CT <: String](implicit
-    d: Decode.Aux[A, CT], ct: ClassTag[A]
+    d: AdaptableDecode[A, CT], ct: ClassTag[A]
   ): Endpoint[Option[A]] = new Body[A, Option[A], CT](d, ct) with FullBody.Optional[A]
 
   /**
@@ -133,7 +133,7 @@ private[finch] trait Bodies {
    * interpreted as `A`, or throws an [[Error.NotPresent]] exception. The returned [[Endpoint]]
    * only matches non-chunked (non-streamed) requests.
    */
-  def body[A, CT <: String](implicit d: Decode.Aux[A, CT], ct: ClassTag[A]): Endpoint[A] =
+  def body[A, CT](implicit d: AdaptableDecode[A, CT], ct: ClassTag[A]): Endpoint[A] =
     new Body[A, A, CT](d, ct) with FullBody.Required[A]
 
   /**

--- a/core/src/test/scala/io/finch/data/Foo.scala
+++ b/core/src/test/scala/io/finch/data/Foo.scala
@@ -1,8 +1,9 @@
 package io.finch.data
 
 import cats.{Eq, Show}
+import com.twitter.io.Buf
 import com.twitter.util.Return
-import io.finch.Decode
+import io.finch.{Application, Decode, Encode}
 import io.finch.internal.HttpContent
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -16,6 +17,19 @@ object Foo {
 
   implicit val decodeTextFoo: Decode.Text[Foo] =
     Decode.text((b, cs) => Return(Foo(b.asString(cs))))
+
+  implicit val decodeCsvFoo: Decode.Aux[Foo, Application.Csv] =
+    Decode.instance((b, cs) =>
+      Return(Foo(b.asString(cs).split("\n").last))
+    )
+
+  implicit val encodeCsvFoo: Encode.Aux[Foo, Application.Csv] =
+    Encode.instance((a, cs) =>
+      Buf.ByteArray.Owned(
+      s"""|column
+          |${a.s}""".stripMargin.getBytes(cs)
+      )
+    )
 
   implicit val arbitraryFoo: Arbitrary[Foo] =
     Arbitrary(Gen.alphaStr.suchThat(_.nonEmpty).map(Foo.apply))


### PR DESCRIPTION
https://github.com/finagle/finch/issues/958

- Add new abstraction `AdaptableDecode` that is used only for `body` and all the related endpoints. This abstraction enables coproduct support for `Content-Type`:
```scala
body[A, Application.Json :+: Application.Csv :+: CNil]
```
Backward-compatibility is there with a very small overhead of one more instance per call.

- Add specs and related documentation 