### PR TITLE
Support 415

### DIFF
--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -30,21 +30,31 @@ import shapeless._
  * - `enableMethodNotAllowed` (default: `false`): whether or not to enable 405 MethodNotAllowed HTTP
  *   response (see RFC2616, section 10.4.6)
  *
+ * - `enableUnsupportedMediaType` (default: `false`) whether or not to enable 415
+ *   UnsupportedMediaType HTTP response (see RFC7231, section 6.5.13)
+ *
  * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
  * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec12.html
  * @see https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+ * @see https://tools.ietf.org/html/rfc7231#section-6.5.13
  */
 class Bootstrap[ES <: HList, CTS <: HList](
     val endpoints: ES,
     val includeDateHeader: Boolean = true,
     val includeServerHeader: Boolean = true,
     val negotiateContentType: Boolean = false,
-    val enableMethodNotAllowed: Boolean = false) { self =>
+    val enableMethodNotAllowed: Boolean = false,
+    val enableUnsupportedMediaType: Boolean = false) { self =>
 
   class Serve[CT] {
     def apply[E](e: Endpoint[E]): Bootstrap[Endpoint[E] :: ES, CT :: CTS] =
       new Bootstrap[Endpoint[E] :: ES, CT :: CTS](
-        e :: self.endpoints, includeDateHeader, includeServerHeader, negotiateContentType, enableMethodNotAllowed
+        e :: self.endpoints,
+        includeDateHeader,
+        includeServerHeader,
+        negotiateContentType,
+        enableMethodNotAllowed,
+        enableUnsupportedMediaType
       )
     }
 
@@ -52,30 +62,41 @@ class Bootstrap[ES <: HList, CTS <: HList](
     includeDateHeader: Boolean = self.includeDateHeader,
     includeServerHeader: Boolean = self.includeServerHeader,
     negotiateContentType: Boolean = self.negotiateContentType,
-    enableMethodNotAllowed: Boolean = self.enableMethodNotAllowed
+    enableMethodNotAllowed: Boolean = self.enableMethodNotAllowed,
+    enableUnsupportedMediaType: Boolean = self.enableUnsupportedMediaType
   ): Bootstrap[ES, CTS] = new Bootstrap[ES, CTS](
     endpoints,
     includeDateHeader,
     includeServerHeader,
     negotiateContentType,
-    enableMethodNotAllowed
+    enableMethodNotAllowed,
+    enableUnsupportedMediaType
   )
 
   def serve[CT]: Serve[CT] = new Serve[CT]
 
-  def toService(implicit ts: ToService[ES, CTS]): Service[Request, Response] = ts(
-    endpoints,
-    ToService.Options(includeDateHeader, includeServerHeader, negotiateContentType, enableMethodNotAllowed),
-    ToService.Context()
-  )
+  def toService(implicit ts: ToService[ES, CTS]): Service[Request, Response] = {
+    val opts = ToService.Options(
+      includeDateHeader,
+      includeServerHeader,
+      negotiateContentType,
+      enableMethodNotAllowed,
+      enableUnsupportedMediaType
+    )
+
+    val ctx = ToService.Context()
+
+    ts(endpoints, opts, ctx)
+  }
 
   final override def toString: String = s"Bootstrap($endpoints)"
 }
 
 object Bootstrap extends Bootstrap[HNil, HNil](
-    endpoints = HNil,
-    includeDateHeader = true,
-    includeServerHeader = true,
-    negotiateContentType = false,
-    enableMethodNotAllowed = false
+  endpoints = HNil,
+  includeDateHeader = true,
+  includeServerHeader = true,
+  negotiateContentType = false,
+  enableMethodNotAllowed = false,
+  enableUnsupportedMediaType = false
 )

--- a/core/src/main/scala/io/finch/Decode.scala
+++ b/core/src/main/scala/io/finch/Decode.scala
@@ -53,13 +53,13 @@ object Decode {
    * value.
    */
   trait Dispatchable[A, CT] {
-    def apply(ct: Option[String], b: Buf, cs: Charset): Try[A]
+    def apply(ct: String, b: Buf, cs: Charset): Try[A]
   }
 
   object Dispatchable {
 
     implicit def cnilToDispatchable[A]: Dispatchable[A, CNil] = new Dispatchable[A, CNil] {
-      def apply(ct: Option[String], b: Buf, cs: Charset): Try[A] =
+      def apply(ct: String, b: Buf, cs: Charset): Try[A] =
         Throw(Decode.UnsupportedMediaTypeException)
     }
 
@@ -68,8 +68,8 @@ object Decode {
       witness: Witness.Aux[CTH],
       tail: Dispatchable[A, CTT]
     ): Dispatchable[A, CTH :+: CTT] = new Dispatchable[A, CTH :+: CTT] {
-      def apply(ct: Option[String], b: Buf, cs: Charset): Try[A] =
-        if (ct.exists(_.equalsIgnoreCase(witness.value))) decode(b, cs)
+      def apply(ct: String, b: Buf, cs: Charset): Try[A] =
+        if (ct.equalsIgnoreCase(witness.value)) decode(b, cs)
         else tail(ct, b, cs)
     }
 

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 private abstract class FullBody[A] extends Endpoint[A] {
 
   protected def missing: Future[Output[A]]
-  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[A]]
+  protected def present(contentType: String, content: Buf, cs: Charset): Future[Output[A]]
 
   final def apply(input: Input): Endpoint.Result[A] =
     if (input.request.isChunked) EndpointResult.NotMatched
@@ -21,7 +21,11 @@ private abstract class FullBody[A] extends Endpoint[A] {
       val output = Rerunnable.fromFuture {
         val contentLength = input.request.contentLengthOrNull
         if (contentLength == null || contentLength == "0") missing
-        else present(input.request.contentType, input.request.content, input.request.charsetOrUtf8)
+        else present(
+          input.request.mediaTypeOrEmpty,
+          input.request.content,
+          input.request.charsetOrUtf8
+        )
       }
 
       EndpointResult.Matched(input, Trace.empty, output)
@@ -63,7 +67,7 @@ private abstract class Body[A, B, CT](ad: Decode.Dispatchable[A, CT], ct: ClassT
     case Throw(t) => Throw(Error.NotParsed(items.BodyItem, ct, t))
   }
 
-  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[B]] =
+  protected def present(contentType: String, content: Buf, cs: Charset): Future[Output[B]] =
     Future.const(ad(contentType, content, cs).transform(this))
 
   final override def toString: String = "body"
@@ -72,14 +76,14 @@ private abstract class Body[A, B, CT](ad: Decode.Dispatchable[A, CT], ct: ClassT
 private abstract class BinaryBody[A]
     extends FullBody[A] with FullBody.PreparedBody[Array[Byte], A] {
 
-  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[A]] =
+  protected def present(contentType: String, content: Buf, cs: Charset): Future[Output[A]] =
     Future.value(Output.payload(prepare(content.asByteArray)))
 
   final override def toString: String = "binaryBody"
 }
 
 private abstract class StringBody[A] extends FullBody[A] with FullBody.PreparedBody[String, A] {
-  protected def present(contentType: Option[String], content: Buf, cs: Charset): Future[Output[A]] =
+  protected def present(contentType: String, content: Buf, cs: Charset): Future[Output[A]] =
     Future.value(Output.payload(prepare(content.asString(cs))))
 
   final override def toString: String = "stringBody"

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -64,6 +64,17 @@ package object internal {
     // Returns message's content length or null.
     def contentLengthOrNull: String = self.headerMap.getOrNull(Fields.ContentLength)
 
+    // Returns message's media type or empty string.
+    def mediaTypeOrEmpty: String = {
+      val ct = self.headerMap.getOrNull(Fields.ContentType)
+      if (ct == null) ""
+      else {
+        val semi = ct.indexOf(';')
+        if (semi == -1) ct
+        else ct.substring(0, semi)
+      }
+    }
+
     // Returns message's charset or UTF-8 if it's not defined.
     def charsetOrUtf8: Charset = {
 

--- a/core/src/test/scala/io/finch/data/Foo.scala
+++ b/core/src/test/scala/io/finch/data/Foo.scala
@@ -10,8 +10,7 @@ import org.scalacheck.{Arbitrary, Gen}
 case class Foo(s: String)
 
 object Foo {
-  implicit val showFoo: Show[Foo] =
-    Show.show(_.s)
+  implicit val showFoo: Show[Foo] = Show.show(_.s)
 
   implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals
 

--- a/core/src/test/scala/io/finch/internal/HttpMessageSpec.scala
+++ b/core/src/test/scala/io/finch/internal/HttpMessageSpec.scala
@@ -22,4 +22,14 @@ class HttpMessageSpec extends FinchSpec {
 
     assert(Request().charsetOrUtf8 == StandardCharsets.UTF_8)
   }
+
+  it should "mediaTypeOrEmpty" in {
+    check { cs: Option[Charset] =>
+      val req = Request()
+      req.contentType = "application/json"
+      cs.foreach(c => req.charset = c.displayName())
+
+      req.mediaTypeOrEmpty === "application/json"
+    }
+  }
 }

--- a/examples/src/test/scala/io/finch/todo/TodoSpec.scala
+++ b/examples/src/test/scala/io/finch/todo/TodoSpec.scala
@@ -27,18 +27,18 @@ class TodoSpec extends FlatSpec with Matchers with Checkers {
   implicit def arbitraryTodoWithoutId: Arbitrary[TodoWithoutId] = Arbitrary(genTodoWithoutId)
 
   it should "create a todo" in {
-    check { (todoWithoutId: TodoWithoutId) =>
+    check { todoWithoutId: TodoWithoutId =>
       val input = Input.post("/todos")
         .withBody[Application.Json](todoWithoutId, Some(StandardCharsets.UTF_8))
 
       val res = postTodo(input)
-      res.awaitOutputUnsafe().map(_.status) === Some(Status.Created)
-      res.awaitValueUnsafe().isDefined === true
-      val Some(todo) = res.awaitValueUnsafe()
-      todo.completed === todoWithoutId.completed
-      todo.title === todoWithoutId.title
-      todo.order === todoWithoutId.order
-      Todo.get(todo.id).isDefined === true
+      val Some(todo) = res.awaitOutputUnsafe()
+
+      todo.status === Status.Created &&
+      todo.value.completed === todoWithoutId.completed &&
+      todo.value.title === todoWithoutId.title &&
+      todo.value.order === todoWithoutId.order &&
+      Todo.get(todo.value.id).isDefined
     }
   }
 


### PR DESCRIPTION
This is addressing #967.

The easiest way of supporting 415 (UnsupportedMediaType) is to return a special (singleton) exception from `Decode.Dispatchable[CT, CNil]` (the very last decoder in the list) so we can later match on that within a derived service.

Here is the proposed behavior:

 - By default (a standard `Bootstrap`), a body endpoint that sees an unknown media type will resolve into `Throw(Error.NotParsed)` (fail-fast) with an underlying cause of `Decode.UnsupportedMediaType`.
 - A `Bootstrap` option `enableUnsupportedMediaType` (false by default), would turn those errors into 415 responses. Note the default response remains 400.

I'm not entirely in love with encoding this logic in a special exception but it seems a very natural way to implement it.  I'm eager to hear what people think about this.

As a bonus, this PR fixes a bug with dispatchable decoders where content-type also contains a charset (i.e., `application/json;charset=utf-8`). The new logic only relies on media-type when dispatching to a decoder (as it should).