### PR TITLE
adjusts stack size to address OOM error when running tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,9 @@ val baseSettings = Seq(
   scalacOptions in (Compile, console) ~= {
     _.filterNot(Set("-Ywarn-unused-import"))
   },
-  scalacOptions in (Compile, console) += "-Yrepl-class-based"
+  scalacOptions in (Compile, console) += "-Yrepl-class-based",
+  fork in Test := true,
+  javaOptions in ThisBuild ++= Seq("-Xss2048K")
 )
 
 lazy val publishSettings = Seq(


### PR DESCRIPTION
adjusts `javaOptions` by bumping stack size to `2048K`

fixes #993 