### PR TITLE
replace twitter.Try[A] with scala.Either[Throwable, A]

### DIFF
--- a/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
+++ b/argonaut/src/main/scala/io/finch/argonaut/Decoders.scala
@@ -3,7 +3,6 @@ package io.finch.argonaut
 import argonaut._
 import argonaut.DecodeJson
 import cats.syntax.either._
-import com.twitter.util.{Return, Throw}
 import io.finch._
 import io.finch.internal.HttpContent
 
@@ -15,8 +14,8 @@ trait Decoders {
   implicit def decodeArgonaut[A](implicit d: DecodeJson[A]): Decode.Json[A] =
     Decode.json { (b, cs) =>
       Parse.parse(b.asString(cs)).flatMap(_.as[A].result.leftMap(_._1)) match {
-        case Right(result) => Return(result)
-        case Left(error) => Throw(new Exception(error))
+        case Right(result) => Right(result)
+        case Left(error) => Left(new Exception(error))
       }
   }
 }

--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.io.Buf
-import com.twitter.util.{Await, Try}
+import com.twitter.util.Await
 import io.circe.generic.auto._
 import io.finch.circe._
 import io.finch.data.Foo
@@ -174,7 +174,7 @@ class JsonBenchmark extends FinchBenchmark {
   val buf: Buf = Buf.Utf8(foo.asJson.noSpaces)
 
   @Benchmark
-  def decode: Try[Foo] = decodeFoo(buf, StandardCharsets.UTF_8)
+  def decode: Either[Throwable, Foo] = decodeFoo(buf, StandardCharsets.UTF_8)
 
   @Benchmark
   def encode: Buf = encodeFoo(foo, StandardCharsets.UTF_8)

--- a/benchmarks/src/main/scala/io/finch/data/Foo.scala
+++ b/benchmarks/src/main/scala/io/finch/data/Foo.scala
@@ -1,7 +1,6 @@
 package io.finch.data
 
 import com.twitter.io.Buf
-import com.twitter.util.Return
 import io.finch.{Decode, DecodeEntity, Encode}
 import io.finch.internal.HttpContent
 
@@ -9,10 +8,10 @@ case class Foo(s: String)
 
 object Foo {
   implicit val decodeEntityFoo: DecodeEntity[Foo] =
-    DecodeEntity.instance(s => Return(Foo(s)))
+    DecodeEntity.instance(s => Right(Foo(s)))
 
   implicit val decodeFoo: Decode.Text[Foo] =
-    Decode.text((b, cs) => Return(Foo(b.asString(cs))))
+    Decode.text((b, cs) => Right(Foo(b.asString(cs))))
 
   implicit val encodeFoo: Encode.Text[Foo] =
     Encode.text((f, cs) => Buf.ByteArray.Owned(f.s.getBytes(cs.name)))

--- a/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
+++ b/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
@@ -4,7 +4,6 @@ import java.nio.charset.StandardCharsets
 
 import cats.MonadError
 import cats.data.Validated
-import com.twitter.util.{Decoder => _, _}
 import io.circe._
 import io.circe.iteratee._
 import io.circe.jawn.{decodeAccumulating, decodeByteBufferAccumulating}
@@ -25,7 +24,7 @@ trait AccumulatingDecoders {
       case _ => decodeAccumulating[A](b.asString(cs))
     }
 
-    attemptJson.fold[Try[A]](nel => Throw(Errors(nel)), Return.apply)
+    attemptJson.fold[Either[Throwable, A]](nel => Left(Errors(nel)), Right.apply)
   }
 
   implicit def enumerateCirce[F[_], A : Decoder](implicit

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -1,7 +1,6 @@
 package io.finch.circe
 
 import cats.MonadError
-import com.twitter.util.{Return, Throw, Try}
 import io.circe.Decoder
 import io.circe.iteratee._
 import io.circe.jawn._
@@ -22,7 +21,7 @@ trait Decoders {
       case _ => decode[A](b.asString(cs))
     }
 
-    attemptJson.fold[Try[A]](Throw.apply, Return.apply)
+    attemptJson.fold[Either[Throwable, A]](Left.apply, Right.apply)
   }
 
   implicit def enumerateCirce[F[_], A : Decoder](implicit

--- a/core/src/main/scala/io/finch/DecodeEntity.scala
+++ b/core/src/main/scala/io/finch/DecodeEntity.scala
@@ -63,5 +63,5 @@ trait LowPriorityDecode {
     gen: Generic.Aux[A, H],
     ev: (E :: HNil) =:= H,
     de: DecodeEntity[E]
-  ): DecodeEntity[A] = instance(s => de(s).map(b => gen.from(b :: HNil)))
+  ): DecodeEntity[A] = instance(s => de(s).right.map(b => gen.from(b :: HNil)))
 }

--- a/core/src/main/scala/io/finch/DecodeEntity.scala
+++ b/core/src/main/scala/io/finch/DecodeEntity.scala
@@ -25,29 +25,26 @@ object DecodeEntity extends HighPriorityDecode {
 
 trait HighPriorityDecode extends LowPriorityDecode {
 
-  implicit val decodeInt: DecodeEntity[Int] = instance(s => toEither(s)(_.toInt))
+  implicit val decodeInt: DecodeEntity[Int] = instance(s =>
+    try { Right(s.toInt)} catch {case e: Throwable => Left(e)})
 
-  implicit val decodeLong: DecodeEntity[Long] = instance(s => toEither(s)(_.toLong))
+  implicit val decodeLong: DecodeEntity[Long] = instance(s =>
+    try { Right(s.toLong)} catch {case e: Throwable => Left(e)})
 
-  implicit val decodeFloat: DecodeEntity[Float] = instance(s => toEither(s)(_.toFloat))
+  implicit val decodeFloat: DecodeEntity[Float] = instance(s =>
+    try { Right(s.toFloat)} catch {case e: Throwable => Left(e)})
 
-  implicit val decodeDouble: DecodeEntity[Double] = instance(s => toEither(s)(_.toDouble))
+  implicit val decodeDouble: DecodeEntity[Double] = instance(s =>
+    try { Right(s.toDouble)} catch {case e: Throwable => Left(e)})
 
-  implicit val decodeBoolean: DecodeEntity[Boolean] = instance(s => toEither(s)(_.toBoolean))
+  implicit val decodeBoolean: DecodeEntity[Boolean] = instance(s =>
+    try { Right(s.toBoolean)} catch {case e: Throwable => Left(e)})
 
   implicit val decodeUUID: DecodeEntity[UUID] = instance(s =>
     if (s.length != 36) Left(new IllegalArgumentException(s"Too long for UUID: ${s.length}"))
-    else toEither(s)(UUID.fromString)
+    else try { Right(UUID.fromString(s))} catch {case e: Throwable => Left(e)}
   )
 
-  private def toEither[A](s: String)(fn: String => A): Either[Throwable, A] = {
-    try {
-      Right(fn.apply(s))
-    } catch {
-      case e: Throwable =>
-        Left(e)
-    }
-  }
 }
 
 trait LowPriorityDecode {

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -14,7 +14,6 @@ import com.twitter.finagle.http.{
 }
 import com.twitter.finagle.http.exp.{Multipart => FinagleMultipart}
 import com.twitter.io.Buf
-import com.twitter.util.{Return, Throw, Try}
 import io.finch.endpoint._
 import io.finch.internal._
 import io.finch.items.RequestItem
@@ -359,15 +358,6 @@ trait Endpoint[F[_], A] { self =>
     */
   final def shouldNot(rule: ValidationRule[A])(implicit F: MonadError[F, Throwable]): Endpoint[F, A] =
     shouldNot(rule.description)(rule.apply)
-
-  /**
-    * Lifts this endpoint into one that always succeeds, with [[Try]] representing both success and
-    * failure cases.
-    */
-  final def liftToTry(implicit F: MonadError[F, Throwable]): Endpoint[F, Try[A]] = attempt.map({
-    case Right(r) => Return(r)
-    case Left(t) => Throw(t)
-  })
 
   /**
     * Lifts this endpoint into one that always succeeds, with [[Either[Throwable, A]] representing both success and

--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -62,7 +62,12 @@ sealed abstract class EndpointResult[F[_], +A] {
   }
 
   def awaitOutputUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Output[A]] =
-    awaitOutput(d).map(toa => toa.right.get)
+    awaitOutput(d).map{toa => {
+      toa match {
+        case Right(r) => r
+        case Left(ex) => throw ex
+      }
+    }}
 
   def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, A]] =
     awaitOutput(d).map(toa => toa.flatMap(oa => Right(oa.value)))

--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -69,8 +69,11 @@ sealed abstract class EndpointResult[F[_], +A] {
       }
     }}
 
-  def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, A]] =
-    awaitOutput(d).map(toa => toa.flatMap(oa => Right(oa.value)))
+  def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, A]]=
+    awaitOutput(d) map {
+      case Right(oa) => Right(oa.value)
+      case Left(ob) => Left(ob)
+    }
 
   def awaitValueUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[A] =
     awaitOutputUnsafe(d).map(oa => oa.value)

--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -48,20 +48,20 @@ sealed abstract class EndpointResult[F[_], +A] {
     case _ => None
   }
 
-  def awaitOutput(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Try[Output[A]]] = this match {
+  def awaitOutput(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, Output[A]]] = this match {
     case EndpointResult.Matched(_, _, out) =>
-      Some(Try(e.toIO(out).unsafeRunTimed(d) match {
-        case Some(a) => a
-        case _ => throw new TimeoutException(s"Output wasn't returned in time: $d")
-      }))
+      e.toIO(out).unsafeRunTimed(d) match {
+        case Some(a) => Some(Right(a))
+        case _ => Some(Left(new TimeoutException(s"Output wasn't returned in time: $d")))
+      }
     case _ => None
   }
 
   def awaitOutputUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Output[A]] =
-    awaitOutput(d).map(toa => toa.get)
+    awaitOutput(d).map(toa => toa.right.get)
 
-  def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Try[A]] =
-    awaitOutput(d).map(toa => toa.flatMap(oa => Try(oa.value)))
+  def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, A]] =
+    awaitOutput(d).map(toa => toa.map(oa => oa.value))
 
   def awaitValueUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[A] =
     awaitOutputUnsafe(d).map(oa => oa.value)

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -2,7 +2,6 @@ package io.finch.endpoint
 
 import cats.effect.Effect
 import com.twitter.io.Buf
-import com.twitter.util.{Return, Throw, Try}
 import io.finch._
 import io.finch.internal._
 import io.finch.items._
@@ -55,17 +54,17 @@ private[finch] abstract class Body[F[_], A, B, CT](implicit
   dd: Decode.Dispatchable[A, CT],
   ct: ClassTag[A],
   protected val F: Effect[F]
-) extends FullBody[F, B] with FullBody.PreparedBody[F, A, B] with (Try[A] => Try[Output[B]]) {
+) extends FullBody[F, B] with FullBody.PreparedBody[F, A, B] with (Either[Throwable, A] => Either[Throwable, Output[B]]) {
 
-  final def apply(ta: Try[A]): Try[Output[B]] = ta match {
-    case Return(r) => Return(Output.payload(prepare(r)))
-    case Throw(t) => Throw(Error.NotParsed(items.BodyItem, ct, t))
+  final def apply(ta: Either[Throwable, A]): Either[Throwable, Output[B]] = ta match {
+    case Right(r) => Right(Output.payload(prepare(r)))
+    case Left(t) => Left(Error.NotParsed(items.BodyItem, ct, t))
   }
 
   protected def present(contentType: String, content: Buf, cs: Charset): F[Output[B]] =
-    dd(contentType, content, cs).transform(this) match {
-      case Return(r) => F.pure(r)
-      case Throw(t) => F.raiseError(t)
+    apply(dd(contentType, content, cs)) match {
+      case Right(r) => F.pure(r)
+      case Left(t) => F.raiseError(t)
     }
 
   final override def toString: String = "body"

--- a/core/src/main/scala/io/finch/endpoint/header.scala
+++ b/core/src/main/scala/io/finch/endpoint/header.scala
@@ -15,11 +15,6 @@ private[finch] abstract class Header[F[_], G[_], A](name: String)(implicit
   protected def missing(name: String): F[Output[G[A]]]
   protected def present(value: A): G[A]
 
-  final def apply(ta: Either[Throwable, A]): Either[Throwable, Output[G[A]]] = ta match {
-    case Right(a) => Right(Output.payload(present(a)))
-    case Left(e) => Left(Error.NotParsed(items.HeaderItem(name), tag, e))
-  }
-
   final def apply(input: Input): EndpointResult[F, G[A]] = {
     val output: F[Output[G[A]]] = F.suspend {
       input.request.headerMap.getOrNull(name) match {

--- a/core/src/main/scala/io/finch/endpoint/multipart.scala
+++ b/core/src/main/scala/io/finch/endpoint/multipart.scala
@@ -6,7 +6,6 @@ import cats.effect.Effect
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.http.exp.{Multipart => FinagleMultipart, MultipartDecoder}
 import com.twitter.finagle.http.exp.Multipart.{FileUpload => FinagleFileUpload}
-import com.twitter.util.Throw
 import io.finch._
 import io.finch.items._
 import scala.reflect.ClassTag
@@ -38,10 +37,10 @@ private[finch] abstract class Attribute[F[_]: Effect, G[_], A](val name: String)
           case None => missing(name)
           case Some(values) =>
             val decoded = values.map(d.apply)
-            val errors = decoded.collect { case Throw(t) => t }
+            val errors = decoded.collect { case Left(t) => t }
 
             NonEmptyList.fromList(errors) match {
-              case None => present(decoded.map(_.get()))
+              case None => present(decoded.map(_.right.get))
               case Some(es) => unparsed(es, tag)
             }
         }

--- a/core/src/main/scala/io/finch/endpoint/param.scala
+++ b/core/src/main/scala/io/finch/endpoint/param.scala
@@ -10,23 +10,18 @@ private[finch] abstract class Param[F[_], G[_], A](name: String)(implicit
   d: DecodeEntity[A],
   tag: ClassTag[A],
   protected val F: Effect[F]
-) extends Endpoint[F, G[A]] with (Either[Throwable, A] => Either[Throwable, Output[G[A]]]) { self =>
+) extends Endpoint[F, G[A]] { self =>
 
   protected def missing(name: String): F[Output[G[A]]]
   protected def present(value: A): G[A]
-
-  final def apply(ta: Either[Throwable, A]): Either[Throwable, Output[G[A]]] = ta match {
-    case Right(r) => Right(Output.payload(present(r)))
-    case Left(e) => Left(Error.NotParsed(items.ParamItem(name), tag, e))
-  }
 
   final def apply(input: Input): EndpointResult[F, G[A]] = {
     val output: F[Output[G[A]]] = F.suspend {
       input.request.params.get(name) match {
         case None => missing(name)
-        case Some(value) => self(d(value)) match {
-          case Right(r) => F.pure(r)
-          case Left(t) => F.raiseError(t)
+        case Some(value) => d(value) match {
+          case Right(s) => F.pure(Output.payload(present(s)))
+          case Left(e) => F.raiseError(Error.NotParsed(items.ParamItem(name), tag, e))
         }
       }
     }

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -83,11 +83,11 @@ class BodySpec extends FinchSpec {
   it should "resolve into NotParsed(Decode.UMTE) if Content-Type does not match" in {
     val i = Input.post("/").withBody[Application.Xml](Buf.Utf8("foo"))
     val b = body[Foo, Text.Plain :+: Application.Csv :+: CNil]
-    val t =  b(i).awaitOutput().get
+    val t =  b(i).awaitOutput()
 
     t match {
-      case Left(error: Error.NotParsed) =>
-        error.getCause shouldBe Some(Decode.UnsupportedMediaTypeException)
+      case Some(Left(error: Error.NotParsed)) =>
+        error.getCause shouldBe Decode.UnsupportedMediaTypeException
     }
   }
 }

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import com.twitter.finagle.http.Request
 import com.twitter.io.Buf
-import com.twitter.util.{Return, Throw, Try}
+import com.twitter.util.{Return, Throw}
 import io.finch.data.Foo
 import java.nio.charset.Charset
 import shapeless.{:+:, CNil}
@@ -14,7 +14,7 @@ class BodySpec extends FinchSpec {
 
     @volatile private var e = false
 
-    def apply(b: Buf, cs: Charset): Try[A] = {
+    def apply(b: Buf, cs: Charset): Either[Throwable, A] = {
       e = true
       d(b, cs)
     }

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -2,7 +2,6 @@ package io.finch
 
 import com.twitter.finagle.http.Request
 import com.twitter.io.Buf
-import com.twitter.util.{Return, Throw}
 import io.finch.data.Foo
 import java.nio.charset.Charset
 import shapeless.{:+:, CNil}
@@ -26,11 +25,11 @@ class BodySpec extends FinchSpec {
 
   it should "respond with NotFound when it's required" in {
     body[Foo, Text.Plain].apply(Input.get("/")).awaitValue() shouldBe
-      Some(Throw(Error.NotPresent(items.BodyItem)))
+      Some(Left(Error.NotPresent(items.BodyItem)))
   }
 
   it should "respond with None when it's optional" in {
-    bodyOption[Foo, Text.Plain].apply(Input.get("/")).awaitValue() shouldBe Some(Return(None))
+    bodyOption[Foo, Text.Plain].apply(Input.get("/")).awaitValue() shouldBe Some(Right(None))
   }
 
   it should "not match on streaming requests" in {

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -83,9 +83,11 @@ class BodySpec extends FinchSpec {
   it should "resolve into NotParsed(Decode.UMTE) if Content-Type does not match" in {
     val i = Input.post("/").withBody[Application.Xml](Buf.Utf8("foo"))
     val b = body[Foo, Text.Plain :+: Application.Csv :+: CNil]
-    val t =  b(i).awaitOutput().get.throwable
+    val t =  b(i).awaitOutput().get
 
-    t shouldBe an[Error.NotParsed]
-    t.getCause shouldBe Decode.UnsupportedMediaTypeException
+    t match {
+      case Left(error: Error.NotParsed) =>
+        error.getCause shouldBe Some(Decode.UnsupportedMediaTypeException)
+    }
   }
 }

--- a/core/src/test/scala/io/finch/DecodeEntityLaws.scala
+++ b/core/src/test/scala/io/finch/DecodeEntityLaws.scala
@@ -4,7 +4,6 @@ import cats.Eq
 import cats.instances.AllInstances
 import cats.laws._
 import cats.laws.discipline._
-import com.twitter.util.{Return, Try}
 import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
 
@@ -12,8 +11,8 @@ trait DecodeEntityLaws[A] extends Laws with MissingInstances with AllInstances {
 
   def decode: DecodeEntity[A]
 
-  def roundTrip(a: A): IsEq[Try[A]] =
-    decode(a.toString) <-> Return(a)
+  def roundTrip(a: A): IsEq[Either[Throwable, A]] =
+    decode(a.toString) <-> Right(a)
 
   def all(implicit A: Arbitrary[A], eq: Eq[A]): RuleSet = new DefaultRuleSet(
     name = "all",

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -291,8 +291,8 @@ class EndpointSpec extends FinchSpec {
         a.fold[Set[Error]](e => Set(e), es => es.errors.toList.toSet) ++
         b.fold[Set[Error]](e => Set(e), es => es.errors.toList.toSet)
 
-      val Some(Throw(first)) = lr(Input.get("/")).awaitValue()
-      val Some(Throw(second)) = rl(Input.get("/")).awaitValue()
+      val Some(Left(first)) = lr(Input.get("/")).awaitValue()
+      val Some(Left(second)) = rl(Input.get("/")).awaitValue()
 
       first.asInstanceOf[Errors].errors.toList.toSet === all &&
       second.asInstanceOf[Errors].errors.toList.toSet === all

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -8,7 +8,6 @@ import cats.effect.IO
 import cats.laws.discipline.AlternativeTests
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import com.twitter.finagle.http.{Cookie, Method, Request}
-import com.twitter.util.{Return, Throw}
 import io.finch.data.Foo
 import scala.concurrent.duration.Duration
 import shapeless._
@@ -221,7 +220,7 @@ class EndpointSpec extends FinchSpec {
       val result = liftAsync[String](IO.raiseError(e)).handle {
         case _ => Created(s)
       }.apply(i).awaitOutput()
-      result === Some(Return(Created(s)))
+      result === Some(Left(Created(s)))
     }
   }
 
@@ -238,7 +237,7 @@ class EndpointSpec extends FinchSpec {
       param("foo"), header("foo"), cookie("foo").map(_.value),
       multipartFileUpload("foo").map(_.fileName), paramsNel("foo").map(_.toList.mkString),
       paramsNel("foor").map(_.toList.mkString), binaryBody.map(new String(_)), stringBody
-    ).foreach { ii => ii(i).awaitValue() shouldBe Some(Throw(Error.NotPresent(ii.item))) }
+    ).foreach { ii => ii(i).awaitValue() shouldBe Some(Left(Error.NotPresent(ii.item))) }
   }
 
   it should "maps lazily to values" in {
@@ -311,10 +310,10 @@ class EndpointSpec extends FinchSpec {
       val bbee = bb.product(ee)
       val eebb = ee.product(bb)
 
-      aaee(Input.get("/")).awaitValue() === Some(Throw(e)) &&
-      eeaa(Input.get("/")).awaitValue() === Some(Throw(e)) &&
-      bbee(Input.get("/")).awaitValue() === Some(Throw(e)) &&
-      eebb(Input.get("/")).awaitValue() === Some(Throw(e))
+      aaee(Input.get("/")).awaitValue() === Some(Left(e)) &&
+      eeaa(Input.get("/")).awaitValue() === Some(Left(e)) &&
+      bbee(Input.get("/")).awaitValue() === Some(Left(e)) &&
+      eebb(Input.get("/")).awaitValue() === Some(Left(e))
     }
   }
 

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -220,7 +220,7 @@ class EndpointSpec extends FinchSpec {
       val result = liftAsync[String](IO.raiseError(e)).handle {
         case _ => Created(s)
       }.apply(i).awaitOutput()
-      result === Some(Left(Created(s)))
+      result === Some(Right(Created(s)))
     }
   }
 
@@ -335,13 +335,6 @@ class EndpointSpec extends FinchSpec {
   it should "support the as[A] method on Endpoint[Seq[String]]" in {
     val foos = params[Foo]("testEndpoint")
     foos(Input.get("/index", "testEndpoint" -> "a")).awaitValueUnsafe() shouldBe Some(Seq(Foo("a")))
-  }
-
-  it should "liftToTry" in {
-    check { e: Endpoint[IO, Unit] =>
-      val i = Input.get("/")
-      e(i).awaitValue() === e.liftToTry.apply(i).awaitValueUnsafe()
-    }
   }
 
   it should "collect errors on Endpoint[Seq[String]] failure" in {

--- a/core/src/test/scala/io/finch/EvaluatingEndpointLaws.scala
+++ b/core/src/test/scala/io/finch/EvaluatingEndpointLaws.scala
@@ -2,7 +2,6 @@ package io.finch
 
 import cats.effect.Effect
 import cats.instances.AllInstances
-import com.twitter.util.Try
 import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
 
@@ -28,7 +27,7 @@ object EvaluatingEndpointLaws {
 
   private class EvalDecodeEntity[A](d: DecodeEntity[A]) extends DecodeEntity[A] {
     @volatile private var e = false
-    def apply(s: String): Try[A] = {
+    def apply(s: String): Either[Throwable, A] = {
       e = true
       d(s)
     }

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -253,7 +253,7 @@ trait FinchSpec extends FlatSpec
   implicit def eqEndpoint[F[_] : Effect, A: Eq]: Eq[Endpoint[F, A]] = new Eq[Endpoint[F, A]] {
     private[this] def count: Int = 16
 
-    private[this] def await(result: Endpoint.Result[F, A]): Option[(Input, Try[Output[A]])] = for {
+    private[this] def await(result: Endpoint.Result[F, A]): Option[(Input, Either[Throwable, Output[A]])] = for {
       r <- result.remainder
       o <- result.awaitOutput()
     } yield (r, o)
@@ -266,7 +266,7 @@ trait FinchSpec extends FlatSpec
       val resultX = await(x(input))
       val resultY = await(y(input))
 
-      Eq[Option[(Input, Try[Output[A]])]].eqv(resultX, resultY)
+      Eq[Option[(Input, Either[Throwable, Output[A]])]].eqv(resultX, resultY)
     }
   }
 

--- a/core/src/test/scala/io/finch/MissingInstances.scala
+++ b/core/src/test/scala/io/finch/MissingInstances.scala
@@ -8,9 +8,16 @@ import com.twitter.util.{Return, Throw, Try}
  * Type class instances for non-Finch types.
  */
 trait MissingInstances {
+
   implicit def eqTry[A](implicit A: Eq[A]): Eq[Try[A]] = Eq.instance {
     case (Return(a), Return(b)) => A.eqv(a, b)
     case (Throw(x), Throw(y)) => x == y
+    case _ => false
+  }
+
+  implicit def eqThrowable[A](implicit A: Eq[A]): Eq[Either[Throwable, A]] = Eq.instance {
+    case (Right(a), Right(b)) => A.eqv(a, b)
+    case (Left(x), Left(y)) => x == y
     case _ => false
   }
 

--- a/core/src/test/scala/io/finch/MissingInstances.scala
+++ b/core/src/test/scala/io/finch/MissingInstances.scala
@@ -2,20 +2,12 @@ package io.finch
 
 import cats.Eq
 import com.twitter.io.Buf
-import com.twitter.util.{Return, Throw, Try}
 
 /**
  * Type class instances for non-Finch types.
  */
 trait MissingInstances {
-
-  implicit def eqTry[A](implicit A: Eq[A]): Eq[Try[A]] = Eq.instance {
-    case (Return(a), Return(b)) => A.eqv(a, b)
-    case (Throw(x), Throw(y)) => x == y
-    case _ => false
-  }
-
-  implicit def eqThrowable[A](implicit A: Eq[A]): Eq[Either[Throwable, A]] = Eq.instance {
+  implicit def eqEither[A](implicit A: Eq[A]): Eq[Either[Throwable, A]] = Eq.instance {
     case (Right(a), Right(b)) => A.eqv(a, b)
     case (Left(x), Left(y)) => x == y
     case _ => false

--- a/core/src/test/scala/io/finch/data/Foo.scala
+++ b/core/src/test/scala/io/finch/data/Foo.scala
@@ -2,7 +2,6 @@ package io.finch.data
 
 import cats.{Eq, Show}
 import com.twitter.io.Buf
-import com.twitter.util.Return
 import io.finch.{Application, Decode, Encode}
 import io.finch.internal.HttpContent
 import org.scalacheck.{Arbitrary, Gen}
@@ -15,11 +14,11 @@ object Foo {
   implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals
 
   implicit val decodeTextFoo: Decode.Text[Foo] =
-    Decode.text((b, cs) => Return(Foo(b.asString(cs))))
+    Decode.text((b, cs) => Right(Foo(b.asString(cs))))
 
   implicit val decodeCsvFoo: Decode.Aux[Foo, Application.Csv] =
     Decode.instance((b, cs) =>
-      Return(Foo(b.asString(cs).split("\n").last))
+      Right(Foo(b.asString(cs).split("\n").last))
     )
 
   implicit val encodeCsvFoo: Encode.Aux[Foo, Application.Csv] =

--- a/json-test/src/main/scala/io/finch/test/JsonLaws.scala
+++ b/json-test/src/main/scala/io/finch/test/JsonLaws.scala
@@ -23,11 +23,11 @@ trait DecodeJsonLaws[A] extends Laws with AllInstances {
 
   def success(a: A, cs: Charset)(implicit e: Encoder[A], d: Decoder[A]): IsEq[A] = {
     val json = e(a).noSpaces
-    decode(Buf.ByteArray.Owned(json.getBytes(cs.name)), cs).get <-> jawn.decode(json).right.get
+    decode(Buf.ByteArray.Owned(json.getBytes(cs.name)), cs).right.get <-> jawn.decode(json).right.get
   }
 
   def failure(s: String, cs: Charset): Boolean =
-    decode(Buf.ByteArray.Owned(s"NOT A JSON$s".getBytes(cs.name)), cs).isThrow
+    decode(Buf.ByteArray.Owned(s"NOT A JSON$s".getBytes(cs.name)), cs).isLeft
 
   def all(implicit
     a: Arbitrary[A],

--- a/refined/src/main/scala/io/finch/refined/package.scala
+++ b/refined/src/main/scala/io/finch/refined/package.scala
@@ -14,10 +14,17 @@ package object refined {
     ad: DecodeEntity[A],
     v: Validate[A, B],
     rt: RefType[F]
-  ): DecodeEntity[F[A, B]] =
-    DecodeEntity.instance(s => ad(s).flatMap(e => rt.refine[B](e) match {
-      case Left(error) => Left(PredicateFailed(error))
-      case Right(ref) => Right(ref)
-    }))
+  ): DecodeEntity[F[A, B]] = {
+    DecodeEntity.instance { s =>
+      ad(s) match {
+        case Right(r) =>
+          rt.refine[B](r) match {
+            case Left(error) => Left(PredicateFailed(error))
+            case Right(ref) => Right(ref)
+          }
+        case Left(e) => Left(e)
+      }
+    }
+  }
 
 }

--- a/refined/src/main/scala/io/finch/refined/package.scala
+++ b/refined/src/main/scala/io/finch/refined/package.scala
@@ -1,6 +1,5 @@
 package io.finch
 
-import com.twitter.util.{Return, Throw}
 import eu.timepit.refined.api.{RefType, Validate}
 
 package object refined {
@@ -17,8 +16,8 @@ package object refined {
     rt: RefType[F]
   ): DecodeEntity[F[A, B]] =
     DecodeEntity.instance(s => ad(s).flatMap(e => rt.refine[B](e) match {
-      case Left(error) => Throw(PredicateFailed(error))
-      case Right(ref) => Return(ref)
+      case Left(error) => Left(PredicateFailed(error))
+      case Right(ref) => Right(ref)
     }))
 
 }

--- a/refined/src/test/scala/io/finch/refined/PredicateFailedSpec.scala
+++ b/refined/src/test/scala/io/finch/refined/PredicateFailedSpec.scala
@@ -1,6 +1,5 @@
 package io.finch.refined
 
-import com.twitter.util.Throw
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric._
 import io.finch._
@@ -14,7 +13,7 @@ class PredicateFailedSpec extends FinchSpec {
       Ok(i.value)
     }
 
-    val Some(Throw(result)) = endpoint(Input.get("/?int=-1")).awaitValue()
+    val Some(Left(result)) = endpoint(Input.get("/?int=-1")).awaitValue()
 
     result.getCause shouldBe a[PredicateFailed]
   }


### PR DESCRIPTION
This is a WIP for https://github.com/finagle/finch/issues/989

- [x]  replaced all occurances of `twitter.Try[A]` with `Either[Throwable, A]`
- [x] need to fix `DecodeEntityLaws`, providing view for `cats.laws.IsEq[Either[Throwable,A]]`, 

```scala
[error] /Users/prayagupd/buybest/sc212/finch/core/src/test/scala/io/finch/DecodeEntityLaws.scala:20:32: No implicit view available from cats.laws.IsEq[Either[Throwable,A]] => org.scalacheck.Prop.
[error]     "roundTrip" -> Prop.forAll { (a: A) => roundTrip(a) }
[error] 
```