### PR TITLE
Model NotMatched result more explicitly

### DIFF
--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -62,15 +62,13 @@ sealed abstract class EndpointResult[F[_], +A] {
   }
 
   def awaitOutputUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Output[A]] =
-    awaitOutput(d).map{toa => {
-      toa match {
-        case Right(r) => r
-        case Left(ex) => throw ex
-      }
-    }}
+    awaitOutput(d).map {
+      case Right(r) => r
+      case Left(ex) => throw ex
+    }
 
   def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, A]]=
-    awaitOutput(d) map {
+    awaitOutput(d).map {
       case Right(oa) => Right(oa.value)
       case Left(ob) => Left(ob)
     }
@@ -95,8 +93,7 @@ object EndpointResult {
 
   object NotMatched extends NotMatched[Id] {
     final case class MethodNotAllowed[F[_]](allowed: List[Method]) extends NotMatched[F]
-  }
 
-  implicit def covaryEndpointResult[F[_], A](result: EndpointResult[Id, A]): EndpointResult[F, A] =
-    result.asInstanceOf[EndpointResult[F, A]]
+    def apply[F[_]]: NotMatched[F] = NotMatched.asInstanceOf[NotMatched[F]]
+  }
 }

--- a/core/src/main/scala/io/finch/endpoint/body.scala
+++ b/core/src/main/scala/io/finch/endpoint/body.scala
@@ -15,7 +15,7 @@ private[finch] abstract class FullBody[F[_], A] extends Endpoint[F, A] {
   protected def present(contentType: String, content: Buf, cs: Charset): F[Output[A]]
 
   final def apply(input: Input): EndpointResult[F, A] =
-    if (input.request.isChunked) EndpointResult.NotMatched
+    if (input.request.isChunked) EndpointResult.NotMatched[F]
     else {
       val output = F.suspend {
         val contentLength = input.request.contentLengthOrNull

--- a/core/src/main/scala/io/finch/endpoint/multipart.scala
+++ b/core/src/main/scala/io/finch/endpoint/multipart.scala
@@ -30,7 +30,7 @@ private[finch] abstract class Attribute[F[_]: Effect, G[_], A](val name: String)
   }
 
   final def apply(input: Input): EndpointResult[F, G[A]] = {
-    if (input.request.isChunked) EndpointResult.NotMatched
+    if (input.request.isChunked) EndpointResult.NotMatched[F]
     else {
       val output = F.suspend {
         all(input) match {
@@ -113,7 +113,7 @@ private[finch] abstract class FileUpload[F[_]: Effect, G[_]](name: String)
     } yield nel
 
   final def apply(input: Input): EndpointResult[F, G[FinagleFileUpload]] =
-    if (input.request.isChunked) EndpointResult.NotMatched
+    if (input.request.isChunked) EndpointResult.NotMatched[F]
     else {
       val output = Effect[F].suspend {
         all(input) match {

--- a/core/src/main/scala/io/finch/endpoint/path.scala
+++ b/core/src/main/scala/io/finch/endpoint/path.scala
@@ -16,7 +16,7 @@ private[finch] class MatchPath[F[_]](s: String)(implicit
         Trace.segment(s),
         F.pure(Output.payload(HNil))
       )
-    case _ => EndpointResult.NotMatched
+    case _ => EndpointResult.NotMatched[F]
   }
 
   final override def toString: String = s
@@ -35,9 +35,9 @@ private[finch] class ExtractPath[F[_], A](implicit
           Trace.segment(toString),
           F.pure(Output.payload(a))
         )
-      case _ => EndpointResult.NotMatched
+      case _ => EndpointResult.NotMatched[F]
     }
-    case _ => EndpointResult.NotMatched
+    case _ => EndpointResult.NotMatched[F]
   }
 
   final override lazy val toString: String = s":${ct.runtimeClass.getSimpleName.toLowerCase}"

--- a/iteratee/src/main/scala/io/finch/iteratee/package.scala
+++ b/iteratee/src/main/scala/io/finch/iteratee/package.scala
@@ -35,7 +35,7 @@ package object iteratee extends IterateeInstances {
     decode: Enumerate.Aux[F, A, CT]
   ): Endpoint[F, Enumerator[F, A]] = new Endpoint[F, Enumerator[F, A]] {
       final def apply(input: Input): Endpoint.Result[F, Enumerator[F, A]] = {
-        if (!input.request.isChunked) EndpointResult.NotMatched
+        if (!input.request.isChunked) EndpointResult.NotMatched[F]
         else {
           val req = input.request
           EndpointResult.Matched(


### PR DESCRIPTION
This PR gets rid of implicit conversion we had to go from `EndpointResult[Id, A]` to `EndpointResult[F, A]`. This type-casting is now happening explicitly either via pattern matching `_: NotMatched[F]` or via `NotMatched.apply[F]` method.