### PR TITLE
Introduce Output.HNil to reduce allocations

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -517,7 +517,7 @@ object Endpoint {
   def zero[F[_]](implicit F: Applicative[F]): Endpoint[F, HNil] =
     new Endpoint[F, HNil] {
       final def apply(input: Input): Result[F, HNil] =
-        EndpointResult.Matched(input, Trace.empty, F.pure(Output.payload(HNil)))
+        EndpointResult.Matched(input, Trace.empty, F.pure(Output.HNil))
 
       final override def toString: String = ""
     }
@@ -594,7 +594,7 @@ object Endpoint {
   def pathAny[F[_]](implicit F: Applicative[F]): Endpoint[F, HNil] =
     new Endpoint[F, HNil] {
       final def apply(input: Input): Result[F, HNil] =
-        EndpointResult.Matched(input.withRoute(Nil), Trace.empty, F.pure(Output.payload(HNil)))
+        EndpointResult.Matched(input.withRoute(Nil), Trace.empty, F.pure(Output.HNil))
 
       final override def toString: String = "*"
     }

--- a/core/src/main/scala/io/finch/EndpointResult.scala
+++ b/core/src/main/scala/io/finch/EndpointResult.scala
@@ -48,10 +48,10 @@ sealed abstract class EndpointResult[F[_], +A] {
     case _ => None
   }
 
-  def awaitOutput(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, Output[A]]] = this match {
+  def awaitOutput(d: Duration = Duration.Inf)(implicit F: Effect[F]): Option[Either[Throwable, Output[A]]] = this match {
     case EndpointResult.Matched(_, _, out) =>
       try {
-        e.toIO(out).unsafeRunTimed(d) match {
+        F.toIO(out).unsafeRunTimed(d) match {
           case Some(a) => Some(Right(a))
           case _ => Some(Left(new TimeoutException(s"Output wasn't returned in time: $d")))
         }
@@ -61,19 +61,19 @@ sealed abstract class EndpointResult[F[_], +A] {
     case _ => None
   }
 
-  def awaitOutputUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Output[A]] =
+  def awaitOutputUnsafe(d: Duration = Duration.Inf)(implicit F: Effect[F]): Option[Output[A]] =
     awaitOutput(d).map {
       case Right(r) => r
       case Left(ex) => throw ex
     }
 
-  def awaitValue(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[Either[Throwable, A]]=
+  def awaitValue(d: Duration = Duration.Inf)(implicit F: Effect[F]): Option[Either[Throwable, A]]=
     awaitOutput(d).map {
       case Right(oa) => Right(oa.value)
       case Left(ob) => Left(ob)
     }
 
-  def awaitValueUnsafe(d: Duration = Duration.Inf)(implicit e: Effect[F]): Option[A] =
+  def awaitValueUnsafe(d: Duration = Duration.Inf)(implicit F: Effect[F]): Option[A] =
     awaitOutputUnsafe(d).map(oa => oa.value)
 }
 

--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -126,9 +126,14 @@ object Output {
   final def unit(status: Status): Output[Unit] = empty(status)
 
   /**
-   * An [[Output]] with `None` as payload.
+   * An [[Output]] with `None` as a payload.
    */
   val None: Output[Option[Nothing]] = Output.payload(Option.empty[Nothing])
+
+  /**
+   * An [[Output]] with [[shapeless.HNil]] as a payload.
+   */
+  val HNil: Output[shapeless.HNil] = Output.payload(shapeless.HNil)
 
   /**
    * A successful [[Output]] that captures a payload `value`.

--- a/core/src/main/scala/io/finch/endpoint/path.scala
+++ b/core/src/main/scala/io/finch/endpoint/path.scala
@@ -14,7 +14,7 @@ private[finch] class MatchPath[F[_]](s: String)(implicit
       EndpointResult.Matched(
         input.withRoute(rest),
         Trace.segment(s),
-        F.pure(Output.payload(HNil))
+        F.pure(Output.HNil)
       )
     case _ => EndpointResult.NotMatched[F]
   }


### PR DESCRIPTION
Let's pre-allocate `Ouput[HNil]` so we can provide cheaper path matching.