### PR TITLE
Prepare a release 0.25

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -246,8 +246,7 @@ lazy val iteratee = project
   .settings(allSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "io.iteratee" %% "iteratee-core" % iterateeVersion,
-      "io.iteratee" %% "iteratee-twitter" % twitterVersion
+      "io.iteratee" %% "iteratee-core" % iterateeVersion
     )
   )
   .dependsOn(core % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val buildSettings = Seq(
   crossScalaVersions := Seq("2.11.12", "2.12.7")
 )
 
-lazy val twitterVersion = "18.9.0"
+lazy val twitterVersion = "18.10.0"
 lazy val circeVersion = "0.10.0"
 lazy val circeIterateeVersion = "0.11.0"
 lazy val shapelessVersion = "2.3.3"

--- a/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
@@ -1,9 +1,8 @@
 package io.finch.circe.test
 
-import com.twitter.util.Try
-import io.catbird.util._
 import io.circe.generic.auto._
 import io.finch.test.AbstractJsonSpec
+import scala.util.Try
 
 class CirceSpec extends AbstractJsonSpec {
   import io.finch.circe._

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -13,7 +13,7 @@ import com.twitter.finagle.http.{
   Response
 }
 import com.twitter.finagle.http.exp.{Multipart => FinagleMultipart}
-import com.twitter.io.Buf
+import com.twitter.io.{Buf, Reader}
 import io.finch.endpoint._
 import io.finch.internal._
 import io.finch.items.RequestItem
@@ -779,7 +779,7 @@ object Endpoint {
           EndpointResult.Matched(
             input,
             Trace.empty,
-            F.delay(Output.payload(AsyncStream.fromReader(input.request.reader)))
+            F.delay(Output.payload(Reader.toAsyncStream(input.request.reader)))
           )
 
       final override def item: RequestItem = items.BodyItem

--- a/core/src/test/scala/io/finch/ToResponseSpec.scala
+++ b/core/src/test/scala/io/finch/ToResponseSpec.scala
@@ -1,7 +1,7 @@
 package io.finch
 
 import com.twitter.concurrent.AsyncStream
-import com.twitter.io.Buf
+import com.twitter.io.{Buf, Reader}
 import com.twitter.util.Await
 import java.nio.charset.StandardCharsets
 
@@ -12,9 +12,9 @@ class ToResponseSpec extends FinchSpec {
   it should "pick correct instance for AsyncStream[Buf]" in {
     val tr: ToResponse.Aux[AsyncStream[Buf], Text.Plain] = implicitly
 
-    check { (chunks: List[Buf]) =>
+    check { chunks: List[Buf] =>
       val in = AsyncStream.fromSeq(chunks)
-      val out = AsyncStream.fromReader(tr(in, StandardCharsets.UTF_8).reader)
+      val out = Reader.toAsyncStream(tr(in, StandardCharsets.UTF_8).reader)
       Await.result(in.toSeq) === Await.result(out.toSeq)
     }
   }

--- a/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
+++ b/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
@@ -4,7 +4,6 @@ import java.nio.charset.{Charset, StandardCharsets}
 
 import cats.{Comonad, Eq, MonadError}
 import cats.instances.AllInstances
-import com.twitter.util.Try
 import io.circe.Decoder
 import io.finch.{Decode, Encode}
 import io.finch.iteratee.Enumerate
@@ -13,11 +12,12 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.Checkers
 import org.typelevel.discipline.Laws
+import scala.util.Try
 
 abstract class AbstractJsonSpec extends FlatSpec with Matchers with Checkers with AllInstances {
 
   implicit val comonadEither: Comonad[Try] = new Comonad[Try] {
-    def extract[A](x: Try[A]): A = x.get() //never do it in production, kids
+    def extract[A](x: Try[A]): A = x.get //never do it in production, kids
 
     def coflatMap[A, B](fa: Try[A])(f: Try[A] => B): Try[B] = Try(f(fa))
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.25.0-SNAPSHOT"
+version in ThisBuild := "0.25.0"


### PR DESCRIPTION
- Drops iteratee-twitter dependency
- Bumps Finagle to 18.10
- Triggers a release.