### PR TITLE
attempt to fix broken build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ lazy val buildSettings = Seq(
 )
 
 lazy val twitterVersion = "18.10.0"
+lazy val catbirdVersion = "18.9.1"
+//lazy val catbirdVersion = "18.10.0"
 lazy val circeVersion = "0.10.0"
 lazy val circeIterateeVersion = "0.11.0"
 lazy val shapelessVersion = "2.3.3"
@@ -246,7 +248,8 @@ lazy val iteratee = project
   .settings(allSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "io.iteratee" %% "iteratee-core" % iterateeVersion
+      "io.iteratee" %% "iteratee-core" % iterateeVersion,
+      "io.catbird" %% "catbird-finagle" % catbirdVersion
     )
   )
   .dependsOn(core % "compile->compile;test->test")

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val twitterVersion = "18.10.0"
-lazy val catbirdVersion = "18.9.1"
-//lazy val catbirdVersion = "18.10.0"
+lazy val catbirdVersion = "18.10.0"
 lazy val circeVersion = "0.10.0"
 lazy val circeIterateeVersion = "0.11.0"
 lazy val shapelessVersion = "2.3.3"

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -13,7 +13,7 @@ import com.twitter.finagle.http.{
   Response
 }
 import com.twitter.finagle.http.exp.{Multipart => FinagleMultipart}
-import com.twitter.io.Buf
+import com.twitter.io.{Buf, Reader}
 import io.finch.endpoint._
 import io.finch.internal._
 import io.finch.items.RequestItem
@@ -779,7 +779,7 @@ object Endpoint {
           EndpointResult.Matched(
             input,
             Trace.empty,
-            F.delay(Output.payload(AsyncStream.fromReader(input.request.reader)))
+            F.delay(Output.payload(Reader.toAsyncStream(input.request.reader)))
           )
 
       final override def item: RequestItem = items.BodyItem

--- a/core/src/test/scala/io/finch/ToResponseSpec.scala
+++ b/core/src/test/scala/io/finch/ToResponseSpec.scala
@@ -2,6 +2,7 @@ package io.finch
 
 import com.twitter.concurrent.AsyncStream
 import com.twitter.io.Buf
+import com.twitter.io.Reader
 import com.twitter.util.Await
 import java.nio.charset.StandardCharsets
 
@@ -14,7 +15,7 @@ class ToResponseSpec extends FinchSpec {
 
     check { (chunks: List[Buf]) =>
       val in = AsyncStream.fromSeq(chunks)
-      val out = AsyncStream.fromReader(tr(in, StandardCharsets.UTF_8).reader)
+      val out = Reader.toAsyncStream(tr(in, StandardCharsets.UTF_8).reader)
       Await.result(in.toSeq) === Await.result(out.toSeq)
     }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.25.0-SNAPSHOT"
+version in ThisBuild := "0.25.0"


### PR DESCRIPTION
appears that dropping `iteratee-twitter` also dropped the transitive dependency for `catbird`

`catbird` still has a dependency on the previous finagle release so i created https://github.com/travisbrown/catbird/pull/75 to match that version