### PR TITLE
Point to index.scala-lang.org with version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Badges
 [![Build Status](https://img.shields.io/travis/finagle/finch/master.svg)](https://travis-ci.org/finagle/finch)
 [![Coverage Status](https://img.shields.io/codecov/c/github/finagle/finch/master.svg)](https://codecov.io/github/finagle/finch)
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat-green.svg)](https://gitter.im/finagle/finch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.finagle/finch-core_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.finagle/finch-core_2.11)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.finagle/finch-core_2.11.svg)](https://index.scala-lang.org/finagle/finch/finch-core)
 
 Standard Modules
 ----------------


### PR DESCRIPTION
Just a small life quality improvement to point to https://index.scala-lang.org/finagle/finch/finch-core instead of maven search