### PR TITLE
Introduce pathEmpty

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -518,8 +518,6 @@ object Endpoint {
     new Endpoint[F, HNil] {
       final def apply(input: Input): Result[F, HNil] =
         EndpointResult.Matched(input, Trace.empty, F.pure(Output.HNil))
-
-      final override def toString: String = ""
     }
 
   /**
@@ -597,6 +595,20 @@ object Endpoint {
         EndpointResult.Matched(input.withRoute(Nil), Trace.empty, F.pure(Output.HNil))
 
       final override def toString: String = "*"
+    }
+
+  /**
+   *
+   * An [[Endpoint]] that matches an empty path.
+   */
+  def pathEmpty[F[_]](implicit F: Applicative[F]): Endpoint[F, HNil] =
+    new Endpoint[F, HNil] {
+      final def apply(input: Input): Result[F, HNil] =
+        if (input.route.isEmpty)
+          EndpointResult.Matched(input, Trace.empty, F.pure(Output.HNil))
+        else EndpointResult.NotMatched[F]
+
+      final override def toString: String = ""
     }
 
   /**

--- a/core/src/main/scala/io/finch/EndpointModule.scala
+++ b/core/src/main/scala/io/finch/EndpointModule.scala
@@ -108,6 +108,12 @@ trait EndpointModule[F[_]] {
     Endpoint.pathAny[F]
 
   /**
+   * An alias for [[Endpoint.pathEmpty]].
+   */
+  def pathEmpty(implicit F: Applicative[F]): Endpoint[F, HNil] =
+    Endpoint.pathEmpty[F]
+
+  /**
    * An alias for [[Endpoint.path]].
    */
   def path[A: DecodePath: ClassTag](implicit F: Effect[F]): Endpoint[F, A] =

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -95,6 +95,13 @@ class EndpointSpec extends FinchSpec {
     }
   }
 
+  it should "match empty path" in {
+    check { i: Input =>
+      (i.route.isEmpty && pathEmpty.apply(i).isMatched) ||
+      (!i.route.isEmpty && !pathEmpty.apply(i).isMatched)
+    }
+  }
+
   it should "match the HTTP method" in {
     def matchMethod(
         m: Method,
@@ -173,7 +180,7 @@ class EndpointSpec extends FinchSpec {
     check { s: String => path(s).product[String](pathAny.map(_ => "foo")).toString === s }
     check { (s: String, t: String) => path(s).mapAsync(_ => IO.pure(t)).toString === s }
 
-    zero.toString shouldBe ""
+    pathEmpty.toString shouldBe ""
     pathAny.toString shouldBe "*"
     path[Int].toString shouldBe ":int"
     path[String].toString shouldBe ":string"


### PR DESCRIPTION
It does what you think it does.

```scala
import io.finch._, io.finch.catsEffect._

val e = get(pathEmpty) { Ok("foo") }  // matches GET /
```