### PR TITLE
Add syntax support for Scala & Twitter Futures in Mapper

### DIFF
--- a/core/src/main/scala/io/finch/internal/DummyExecutionContext.scala
+++ b/core/src/main/scala/io/finch/internal/DummyExecutionContext.scala
@@ -1,0 +1,8 @@
+package io.finch.internal
+
+import scala.concurrent.ExecutionContext
+
+object DummyExecutionContext extends ExecutionContext {
+  def execute(runnable: Runnable): Unit = runnable.run()
+  def reportFailure(cause: Throwable): Unit = throw new NotImplementedError()
+}

--- a/core/src/main/scala/io/finch/internal/Mapper.scala
+++ b/core/src/main/scala/io/finch/internal/Mapper.scala
@@ -47,7 +47,7 @@ private[finch] trait LowPriorityMapperConversions {
       f.onComplete {
         case Success(s) => cb(Right(s))
         case Failure(t) => cb(Left(t))
-      }(dummieExecutionContext)
+      }(DummyExecutionContext)
     }
   }
 
@@ -78,6 +78,7 @@ private[finch] trait LowPriorityMapperConversions {
   /**
     * @group LowPriorityMapper
     */
+  @deprecated("com.twitter.util.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromFutureOutputFunction[A, B, F[_] : Effect](f: A => TwitterFuture[Output[B]]): Mapper.Aux[F, A, B] =
     instance(_.mapOutputAsync(a =>
       twitterFutureToEffect(f(a))
@@ -86,12 +87,14 @@ private[finch] trait LowPriorityMapperConversions {
   /**
     * @group LowPriorityMapper
     */
+  @deprecated("com.twitter.util.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromFutureResponseFunction[A, F[_] : Effect](f: A => TwitterFuture[Response]): Mapper.Aux[F, A, Response] =
     instance(_.mapOutputAsync(f.andThen(fr => twitterFutureToEffect(fr).map(r => Output.payload(r, r.status)))))
 
   /**
     * @group LowPriorityMapper
     */
+  @deprecated("scala.concurrent.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromScFutureOutputFunction[A, B, F[_] : Effect](f: A => ScalaFuture[Output[B]]): Mapper.Aux[F, A, B] =
     instance(_.mapOutputAsync(a =>
       scalaFutureToEffect(f(a))
@@ -100,6 +103,7 @@ private[finch] trait LowPriorityMapperConversions {
   /**
     * @group LowPriorityMapper
     */
+  @deprecated("scala.concurrent.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromScFutureResponseFunction[A, F[_] : Effect](f: A => ScalaFuture[Response]): Mapper.Aux[F, A, Response] =
     instance(_.mapOutputAsync(f.andThen(fr => scalaFutureToEffect(fr).map(r => Output.payload(r, r.status)))))
 }
@@ -153,24 +157,28 @@ private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConv
   /**
     * @group HighPriorityMapper
     */
+  @deprecated("com.twitter.util.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromFutureOutputValue[F[_] : Effect, A](o: => TwitterFuture[Output[A]]): Mapper.Aux[F, HNil, A] =
     instance(_.mapOutputAsync(_ => twitterFutureToEffect(o)))
 
   /**
     * @group HighPriorityMapper
     */
+  @deprecated("com.twitter.util.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromFutureResponseValue[F[_] : Effect](fr: => TwitterFuture[Response]): Mapper.Aux[F, HNil, Response] =
     instance(_.mapOutputAsync(_ => twitterFutureToEffect(fr).map(r => Output.payload(r, r.status))))
 
   /**
     * @group HighPriorityMapper
     */
+  @deprecated("scala.concurrent.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromScFutureOutputValue[F[_] : Effect, A](o: => ScalaFuture[Output[A]]): Mapper.Aux[F, HNil, A] =
     instance(_.mapOutputAsync(_ => scalaFutureToEffect(o)))
 
   /**
     * @group HighPriorityMapper
     */
+  @deprecated("scala.concurrent.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromScFutureResponseValue[F[_] : Effect](fr: => ScalaFuture[Response]): Mapper.Aux[F, HNil, Response] =
     instance(_.mapOutputAsync(_ => scalaFutureToEffect(fr).map(r => Output.payload(r, r.status))))
 }
@@ -189,11 +197,13 @@ object Mapper extends HighPriorityMapperConversions {
     fr.map(r => Output.payload(r, r.status))
   })
 
+  @deprecated("com.twitter.util.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromFutureOutputHFunction[F[_] : Effect, A, B, FN, FOB](f: FN)(implicit
     ftp: FnToProduct.Aux[FN, A => FOB],
     ev: FOB <:< TwitterFuture[Output[B]]
   ): Mapper.Aux[F, A, B] = instance(_.mapOutputAsync(value => twitterFutureToEffect(ev(ftp(f)(value)))))
 
+  @deprecated("com.twitter.util.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromFutureResponseHFunction[F[_] : Effect, A, FN, FR](f: FN)(implicit
     ftp: FnToProduct.Aux[FN, A => FR],
     ev: FR <:< TwitterFuture[Response]
@@ -202,14 +212,16 @@ object Mapper extends HighPriorityMapperConversions {
     fr.map(r => Output.payload(r, r.status))
   })
 
+  @deprecated("scala.concurrent.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromScFutureOutputHFunction[F[_] : Effect, A, B, FN, FOB](f: FN)(implicit
-                                                                                    ftp: FnToProduct.Aux[FN, A => FOB],
-                                                                                    ev: FOB <:< ScalaFuture[Output[B]]
+    ftp: FnToProduct.Aux[FN, A => FOB],
+    ev: FOB <:< ScalaFuture[Output[B]]
   ): Mapper.Aux[F, A, B] = instance(_.mapOutputAsync(value => scalaFutureToEffect(ev(ftp(f)(value)))))
 
+  @deprecated("scala.concurrent.Future use is deprecated in Endpoints. Consider to use cats-effect compatible effect", "0.25.0")
   implicit def mapperFromScFutureResponseHFunction[F[_] : Effect, A, FN, FR](f: FN)(implicit
-                                                                                  ftp: FnToProduct.Aux[FN, A => FR],
-                                                                                  ev: FR <:< ScalaFuture[Response]
+    ftp: FnToProduct.Aux[FN, A => FR],
+    ev: FR <:< ScalaFuture[Response]
   ): Mapper.Aux[F, A, Response] = instance(_.mapOutputAsync { value =>
     val fr = scalaFutureToEffect(ev(ftp(f)(value)))
     fr.map(r => Output.payload(r, r.status))

--- a/core/src/main/scala/io/finch/internal/Mapper.scala
+++ b/core/src/main/scala/io/finch/internal/Mapper.scala
@@ -1,9 +1,13 @@
 package io.finch.internal
 
 import cats.Monad
+import cats.effect.Effect
 import cats.syntax.functor._
 import com.twitter.finagle.http.Response
+import com.twitter.util.{Future => TwitterFuture, Return, Throw}
 import io.finch.{Endpoint, Output}
+import scala.concurrent.{Future => ScalaFuture}
+import scala.util.{Failure, Success}
 import shapeless.HNil
 import shapeless.ops.function.FnToProduct
 
@@ -21,11 +25,30 @@ trait Mapper[F[_], A] {
 }
 
 private[finch] trait LowPriorityMapperConversions {
+
   type Aux[F[_], A, B] = Mapper[F, A] { type Out = B }
 
   def instance[F[_], A, B](f: Endpoint[F, A] => Endpoint[F, B]): Mapper.Aux[F, A, B] = new Mapper[F, A] {
     type Out = B
     def apply(e: Endpoint[F, A]): Endpoint[F, B] = f(e)
+  }
+
+  protected def twitterFutureToEffect[F[_], A](f: => TwitterFuture[A])(implicit F: Effect[F]): F[A] = {
+    F.async { cb =>
+      f.respond {
+        case Return(r) => cb(Right(r))
+        case Throw(t) => cb(Left(t))
+      }
+    }
+  }
+
+  protected def scalaFutureToEffect[F[_], A](f: => ScalaFuture[A])(implicit F: Effect[F]): F[A] = {
+    F.async { cb =>
+      f.onComplete {
+        case Success(s) => cb(Right(s))
+        case Failure(t) => cb(Left(t))
+      }(dummieExecutionContext)
+    }
   }
 
   /**
@@ -51,6 +74,34 @@ private[finch] trait LowPriorityMapperConversions {
    */
   implicit def mapperFromEffectResponseFunction[A, F[_] : Monad](f: A => F[Response]): Mapper.Aux[F, A, Response] =
     instance(_.mapOutputAsync(f.andThen(fr => fr.map(r => Output.payload(r, r.status)))))
+
+  /**
+    * @group LowPriorityMapper
+    */
+  implicit def mapperFromFutureOutputFunction[A, B, F[_] : Effect](f: A => TwitterFuture[Output[B]]): Mapper.Aux[F, A, B] =
+    instance(_.mapOutputAsync(a =>
+      twitterFutureToEffect(f(a))
+    ))
+
+  /**
+    * @group LowPriorityMapper
+    */
+  implicit def mapperFromFutureResponseFunction[A, F[_] : Effect](f: A => TwitterFuture[Response]): Mapper.Aux[F, A, Response] =
+    instance(_.mapOutputAsync(f.andThen(fr => twitterFutureToEffect(fr).map(r => Output.payload(r, r.status)))))
+
+  /**
+    * @group LowPriorityMapper
+    */
+  implicit def mapperFromScFutureOutputFunction[A, B, F[_] : Effect](f: A => ScalaFuture[Output[B]]): Mapper.Aux[F, A, B] =
+    instance(_.mapOutputAsync(a =>
+      scalaFutureToEffect(f(a))
+    ))
+
+  /**
+    * @group LowPriorityMapper
+    */
+  implicit def mapperFromScFutureResponseFunction[A, F[_] : Effect](f: A => ScalaFuture[Response]): Mapper.Aux[F, A, Response] =
+    instance(_.mapOutputAsync(f.andThen(fr => scalaFutureToEffect(fr).map(r => Output.payload(r, r.status)))))
 }
 
 private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConversions {
@@ -98,6 +149,30 @@ private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConv
    */
   implicit def mapperFromEffectResponseValue[F[_] : Monad](fr: F[Response]): Mapper.Aux[F, HNil, Response] =
     instance(_.mapOutputAsync(_ => fr.map(r => Output.payload(r, r.status))))
+
+  /**
+    * @group HighPriorityMapper
+    */
+  implicit def mapperFromFutureOutputValue[F[_] : Effect, A](o: => TwitterFuture[Output[A]]): Mapper.Aux[F, HNil, A] =
+    instance(_.mapOutputAsync(_ => twitterFutureToEffect(o)))
+
+  /**
+    * @group HighPriorityMapper
+    */
+  implicit def mapperFromFutureResponseValue[F[_] : Effect](fr: => TwitterFuture[Response]): Mapper.Aux[F, HNil, Response] =
+    instance(_.mapOutputAsync(_ => twitterFutureToEffect(fr).map(r => Output.payload(r, r.status))))
+
+  /**
+    * @group HighPriorityMapper
+    */
+  implicit def mapperFromScFutureOutputValue[F[_] : Effect, A](o: => ScalaFuture[Output[A]]): Mapper.Aux[F, HNil, A] =
+    instance(_.mapOutputAsync(_ => scalaFutureToEffect(o)))
+
+  /**
+    * @group HighPriorityMapper
+    */
+  implicit def mapperFromScFutureResponseValue[F[_] : Effect](fr: => ScalaFuture[Response]): Mapper.Aux[F, HNil, Response] =
+    instance(_.mapOutputAsync(_ => scalaFutureToEffect(fr).map(r => Output.payload(r, r.status))))
 }
 
 object Mapper extends HighPriorityMapperConversions {
@@ -106,11 +181,37 @@ object Mapper extends HighPriorityMapperConversions {
     ev: FOB <:< F[Output[B]]
   ): Mapper.Aux[F, A, B] = instance(_.mapOutputAsync(value => ev(ftp(f)(value))))
 
-  implicit def mapperFromFutureResponseHFunction[F[_] : Monad, A, FN, FR](f: FN)(implicit
+  implicit def mapperFromEffectResponseHFunction[F[_] : Monad, A, FN, FR](f: FN)(implicit
     ftp: FnToProduct.Aux[FN, A => FR],
     ev: FR <:< F[Response]
   ): Mapper.Aux[F, A, Response] = instance(_.mapOutputAsync { value =>
     val fr = ev(ftp(f)(value))
+    fr.map(r => Output.payload(r, r.status))
+  })
+
+  implicit def mapperFromFutureOutputHFunction[F[_] : Effect, A, B, FN, FOB](f: FN)(implicit
+    ftp: FnToProduct.Aux[FN, A => FOB],
+    ev: FOB <:< TwitterFuture[Output[B]]
+  ): Mapper.Aux[F, A, B] = instance(_.mapOutputAsync(value => twitterFutureToEffect(ev(ftp(f)(value)))))
+
+  implicit def mapperFromFutureResponseHFunction[F[_] : Effect, A, FN, FR](f: FN)(implicit
+    ftp: FnToProduct.Aux[FN, A => FR],
+    ev: FR <:< TwitterFuture[Response]
+  ): Mapper.Aux[F, A, Response] = instance(_.mapOutputAsync { value =>
+    val fr = twitterFutureToEffect(ev(ftp(f)(value)))
+    fr.map(r => Output.payload(r, r.status))
+  })
+
+  implicit def mapperFromScFutureOutputHFunction[F[_] : Effect, A, B, FN, FOB](f: FN)(implicit
+                                                                                    ftp: FnToProduct.Aux[FN, A => FOB],
+                                                                                    ev: FOB <:< ScalaFuture[Output[B]]
+  ): Mapper.Aux[F, A, B] = instance(_.mapOutputAsync(value => scalaFutureToEffect(ev(ftp(f)(value)))))
+
+  implicit def mapperFromScFutureResponseHFunction[F[_] : Effect, A, FN, FR](f: FN)(implicit
+                                                                                  ftp: FnToProduct.Aux[FN, A => FR],
+                                                                                  ev: FR <:< ScalaFuture[Response]
+  ): Mapper.Aux[F, A, Response] = instance(_.mapOutputAsync { value =>
+    val fr = scalaFutureToEffect(ev(ftp(f)(value)))
     fr.map(r => Output.payload(r, r.status))
   })
 }

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -5,6 +5,7 @@ import com.twitter.io.Buf
 import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
 import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
 
 /**
  * This package contains an internal-use only type-classes and utilities that power Finch's API.
@@ -120,5 +121,10 @@ package object internal {
       val (array, begin, end) = asByteArrayWithBeginAndEnd
       new String(array, begin, end - begin, cs.name)
     }
+  }
+
+  private[internal] val dummieExecutionContext: ExecutionContext = new ExecutionContext {
+    def execute(runnable: Runnable): Unit = runnable.run()
+    def reportFailure(cause: Throwable): Unit = throw new NotImplementedError()
   }
 }

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -5,7 +5,6 @@ import com.twitter.io.Buf
 import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
 import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext
 
 /**
  * This package contains an internal-use only type-classes and utilities that power Finch's API.
@@ -123,8 +122,4 @@ package object internal {
     }
   }
 
-  private[internal] val dummieExecutionContext: ExecutionContext = new ExecutionContext {
-    def execute(runnable: Runnable): Unit = runnable.run()
-    def reportFailure(cause: Throwable): Unit = throw new NotImplementedError()
-  }
 }


### PR DESCRIPTION
Related to #1013 