### PR TITLE
Use HeaderMap.setUnsafe when possible

### DIFF
--- a/core/src/main/scala/io/finch/Output.scala
+++ b/core/src/main/scala/io/finch/Output.scala
@@ -203,13 +203,6 @@ object Output {
       tr: ToResponse.Aux[A, CT],
       tre: ToResponse.Aux[Exception, CT]
     ): Response = {
-      convertToResponse(tr.apply, tre.apply)
-    }
-
-    private[finch] def convertToResponse(
-      tr: (A, Charset) => Response,
-      tre: (Exception, Charset) => Response
-    ): Response = {
       val rep = o match {
         case p: Output.Payload[A] => tr(p.value, p.charset.getOrElse(StandardCharsets.UTF_8))
         case f: Output.Failure => tre(f.cause, f.charset.getOrElse(StandardCharsets.UTF_8))

--- a/core/src/main/scala/io/finch/ToResponse.scala
+++ b/core/src/main/scala/io/finch/ToResponse.scala
@@ -45,7 +45,7 @@ trait LowPriorityToResponseInstances {
     val writable = rep.writer
 
     as.foreachF(chunk => writable.write(writer(chunk, cs))).ensure(writable.close())
-    rep.contentType = w.value
+    rep.headerMap.setUnsafe("Content-Type", w.value)
 
     rep
   }
@@ -80,7 +80,7 @@ trait HighPriorityToResponseInstances extends LowPriorityToResponseInstances {
 
     if (!buf.isEmpty) {
       rep.content = buf
-      rep.contentType = w.value
+      rep.headerMap.setUnsafe("Content-Type", w.value)
     }
 
     rep


### PR DESCRIPTION
There is new API that allows us to skip header validation for certain headers. While it's not generally safe to use, it's totally fine if we know headers are always valid (content-length, date, etc).