### PR TITLE
Matching multiple segments with path

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -592,7 +592,11 @@ object Endpoint {
   def pathAny[F[_]](implicit F: Applicative[F]): Endpoint[F, HNil] =
     new Endpoint[F, HNil] {
       final def apply(input: Input): Result[F, HNil] =
-        EndpointResult.Matched(input.withRoute(Nil), Trace.empty, F.pure(Output.HNil))
+        EndpointResult.Matched(
+          input.withRoute(Nil),
+          Trace.fromRoute(input.route),
+          F.pure(Output.HNil)
+        )
 
       final override def toString: String = "*"
     }
@@ -626,10 +630,10 @@ object Endpoint {
     new ExtractPaths[F, A]
 
   /**
-   * An [[Endpoint]] that matches a given string.
+   * An [[Endpoint]] that matches a given path.
    */
   def path[F[_]: Effect](s: String): Endpoint[F, HNil] =
-    new MatchPath[F](s)
+    new MatchPath[F](s.route)
 
   /**
    * A combinator that wraps the given [[Endpoint]] with additional check of the HTTP method. The

--- a/core/src/main/scala/io/finch/Input.scala
+++ b/core/src/main/scala/io/finch/Input.scala
@@ -4,10 +4,10 @@ import cats.Eq
 import com.twitter.finagle.http.{Method, Request}
 import com.twitter.finagle.netty3.ChannelBufferBuf
 import com.twitter.io.Buf
+import io.finch.internal.HttpPath
 import java.nio.charset.{Charset, StandardCharsets}
 import org.jboss.netty.handler.codec.http.{DefaultHttpRequest, HttpMethod, HttpVersion}
 import org.jboss.netty.handler.codec.http.multipart.{DefaultHttpDataFactory, HttpPostRequestEncoder}
-import scala.collection.mutable.ListBuffer
 import shapeless.Witness
 
 /**
@@ -120,30 +120,7 @@ object Input {
   /**
    * Creates an [[Input]] from a given [[Request]].
    */
-  def fromRequest(req: Request): Input = {
-    val p = req.path
-
-    if (p.length == 1) Input(req, Nil)
-    else {
-      val route = new ListBuffer[String]
-      var i, j = 1 // drop the first slash
-
-      while (j < p.length) {
-        if (p.charAt(j) == '/') {
-          route += p.substring(i, j)
-          i = j + 1
-        }
-
-        j += 1
-      }
-
-      if (j > i) {
-        route += p.substring(i, j)
-      }
-
-      Input(req, route.toList)
-    }
-  }
+  def fromRequest(req: Request): Input = Input(req, req.path.route)
 
   /**
    * Creates a `GET` input with a given query string (represented as `params`).

--- a/core/src/main/scala/io/finch/Trace.scala
+++ b/core/src/main/scala/io/finch/Trace.scala
@@ -63,6 +63,29 @@ object Trace {
   def empty: Trace = Empty
   def segment(s: String): Trace = Segment(s, empty)
 
+  def fromRoute(r: Seq[String]): Trace = {
+    var result = empty
+    var current: Segment = null
+
+    def prepend(segment: Segment): Unit = {
+      if (result == empty) {
+        result = segment
+        current = segment
+      } else {
+        current.next = segment
+        current = segment
+      }
+    }
+
+    var rs = r
+    while (rs.nonEmpty) {
+      prepend(Segment(rs.head, empty))
+      rs = rs.tail
+    }
+
+    result
+  }
+
   /**
    * Within a given context `fn`, capture the [[Trace]] instance under `Trace.captured` for each
    * matched endpoint.

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -5,6 +5,7 @@ import com.twitter.io.Buf
 import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
 import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
 
 /**
  * This package contains an internal-use only type-classes and utilities that power Finch's API.
@@ -122,4 +123,32 @@ package object internal {
     }
   }
 
+  implicit class HttpPath(val self: String) extends AnyVal {
+    // Cheap and quick HTTP path parsing.
+    def route: List[String] = {
+      if (self.length == 0) Nil
+      else if (self.length == 1 && self.charAt(0) == '/') Nil
+      else {
+        val result = new ListBuffer[String]
+        var i, j = 0
+
+        while (j < self.length) {
+          if (self.charAt(j) == '/') {
+            if (j > i) {
+              result += self.substring(i, j)
+            }
+            i = j + 1
+          }
+
+          j += 1
+        }
+
+        if (j > i) {
+          result += self.substring(i, j)
+        }
+
+        result.toList
+      }
+    }
+  }
 }

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -37,7 +37,7 @@ trait FinchSpec extends FlatSpec
   case class Headers(m: Map[String, String])
   case class Params(p: Map[String, String])
   case class Cookies(c: Seq[Cookie])
-  case class Path(p: String)
+  case class Path(p: String, segments: List[String])
 
   case class OptionalNonEmptyString(o: Option[String])
 
@@ -183,7 +183,7 @@ trait FinchSpec extends FlatSpec
       Gen.posNum[Long].map(_.toString),
       Gen.oneOf(true, false).map(_.toString)
     ))
-  } yield Path("/" + ss.mkString("/"))
+  } yield Path("/" + ss.mkString("/"), ss)
 
   def genBuf: Gen[Buf] = for {
     size <- Gen.choose(1, 100)

--- a/core/src/test/scala/io/finch/TraceSpec.scala
+++ b/core/src/test/scala/io/finch/TraceSpec.scala
@@ -16,4 +16,10 @@ class TraceSpec extends FinchSpec {
       a.concat(b).toList === (a.toList ++ b.toList)
     }
   }
+
+  it should "create fromRoute" in {
+    check { l: List[String] =>
+      Trace.fromRoute(l).toList === l
+    }
+  }
 }

--- a/core/src/test/scala/io/finch/internal/HttpMessageSpec.scala
+++ b/core/src/test/scala/io/finch/internal/HttpMessageSpec.scala
@@ -11,7 +11,7 @@ class HttpMessageSpec extends FinchSpec {
     case None => StandardCharsets.UTF_8
   }
 
-  behavior of "HttpMesage"
+  behavior of "HttpMessage"
 
   it should "charsetOrUtf8" in {
     check { cs: Charset =>

--- a/core/src/test/scala/io/finch/internal/HttpPathSpec.scala
+++ b/core/src/test/scala/io/finch/internal/HttpPathSpec.scala
@@ -1,0 +1,14 @@
+package io.finch.internal
+
+import io.finch.FinchSpec
+
+class HttpPathSpec extends FinchSpec {
+
+  behavior of "HttpPath"
+
+  it should "parse route correctly" in {
+    check { p: Path =>
+      p.p.route === p.segments && p.p.drop(1).route === p.segments
+    }
+  }
+}


### PR DESCRIPTION
This PR makes it possible to match multiple path segments with a single endpoint, `path`. The change is backward compatible with the current behavior: `path("foo")` or just `"foo"` works as expected.

In addition it enables a couple interesting use cases:
 
 - `get("/")` to match empty path 
 - `get("/foo/bar")` to match multiple segments (I've seen people doing this)
 - this would simplify #1017

