### PR TITLE
Use .recoverWith instead of .handleErrorWith

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -296,7 +296,7 @@ trait Endpoint[F[_], A] { self =>
     */
   final def rescue(pf: PartialFunction[Throwable, F[Output[A]]])(implicit
     F: ApplicativeError[F, Throwable]
-  ): Endpoint[F, A] = transform(foa => foa.handleErrorWith(pf))
+  ): Endpoint[F, A] = transform(foa => foa.recoverWith(pf))
 
   /**
     * Recovers from any exception occurred in this endpoint by creating a new endpoint that will

--- a/core/src/test/scala/io/finch/EndToEndSpec.scala
+++ b/core/src/test/scala/io/finch/EndToEndSpec.scala
@@ -131,4 +131,13 @@ class EndToEndSpec extends FinchSpec {
       rep.contentType === Some("text/event-stream")
     }
   }
+
+  it should "return the exception occurred in endpoint's effect" in {
+    val endpoint = pathAny.mapAsync { _ =>
+      IO.raiseError[String](new IllegalStateException)
+    }
+    val s = Bootstrap.serve[Text.Plain](endpoint).toService
+    val rep = s(Request())
+    assertThrows[IllegalStateException](Await.result(rep))
+  }
 }

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -233,6 +233,17 @@ class EndpointSpec extends FinchSpec {
     }
   }
 
+  it should "re-raise the exception if it wasn't handled" in {
+    case object CustomException extends Exception
+
+    check { (i: Input, s: String, e: Exception) =>
+      val result = liftAsync[String](IO.raiseError(e)).handle {
+        case CustomException  => Created(s)
+      }.apply(i).awaitOutput()
+      result === Some(Left(e))
+    }
+  }
+
   it should "not split comma separated param values" in {
     val i = Input.get("/index", "foo" -> "a,b")
     val e = params("foo")


### PR DESCRIPTION
`.handleErrorWith` doesn't re-raise the error if the partial function doesn't match, so it leads to `MatchError` exception pointing to `ToService.handler` in the `Future` from `Service`.

Users lose the information about the type of exception caused the original problem.