### PR TITLE
Enable content negotiation automatically

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -199,16 +199,10 @@ abstract class BootstrapBenchmark[CT](init: Bootstrap[HNil, HNil])(implicit
 
 class JsonBootstrapBenchmark extends BootstrapBenchmark[Application.Json](Bootstrap)
 
-class JsonNegotiatedBootstrapBenchmark extends BootstrapBenchmark[Application.Json](
-    Bootstrap.configure(negotiateContentType = true))
-
 class TextBootstrapBenchmark extends BootstrapBenchmark[Text.Plain](Bootstrap)
 
-class TextNegotiatedBootstrapBenchmark extends BootstrapBenchmark[Text.Plain](
-    Bootstrap.configure(negotiateContentType = true))
-
 class JsonAndTextNegotiatedBootstrapBenchmark extends BootstrapBenchmark[Application.Json :+: Text.Plain :+: CNil](
-    Bootstrap.configure(negotiateContentType = true)) {
+    Bootstrap) {
 
   private val acceptValues: Array[String] = Array("application/json", "text/plain")
 

--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -24,9 +24,6 @@ import shapeless._
  * - `includeServerHeader` (default: `true`): whether or not to include the Server header into
  *   each response (see RFC2616, section 14.38)
  *
- * - `negotiateContentType` (default: `false`): whether or not to enable server-driven content type
- *   negotiation (see RFC2616, section 12.1)
- *
  * - `enableMethodNotAllowed` (default: `false`): whether or not to enable 405 MethodNotAllowed HTTP
  *   response (see RFC2616, section 10.4.6)
  *
@@ -42,7 +39,6 @@ class Bootstrap[ES <: HList, CTS <: HList](
     val endpoints: ES,
     val includeDateHeader: Boolean = true,
     val includeServerHeader: Boolean = true,
-    val negotiateContentType: Boolean = false,
     val enableMethodNotAllowed: Boolean = false,
     val enableUnsupportedMediaType: Boolean = false) { self =>
 
@@ -52,7 +48,6 @@ class Bootstrap[ES <: HList, CTS <: HList](
         e :: self.endpoints,
         includeDateHeader,
         includeServerHeader,
-        negotiateContentType,
         enableMethodNotAllowed,
         enableUnsupportedMediaType
       )
@@ -61,14 +56,12 @@ class Bootstrap[ES <: HList, CTS <: HList](
   def configure(
     includeDateHeader: Boolean = self.includeDateHeader,
     includeServerHeader: Boolean = self.includeServerHeader,
-    negotiateContentType: Boolean = self.negotiateContentType,
     enableMethodNotAllowed: Boolean = self.enableMethodNotAllowed,
     enableUnsupportedMediaType: Boolean = self.enableUnsupportedMediaType
   ): Bootstrap[ES, CTS] = new Bootstrap[ES, CTS](
     endpoints,
     includeDateHeader,
     includeServerHeader,
-    negotiateContentType,
     enableMethodNotAllowed,
     enableUnsupportedMediaType
   )
@@ -79,7 +72,6 @@ class Bootstrap[ES <: HList, CTS <: HList](
     val opts = ToService.Options(
       includeDateHeader,
       includeServerHeader,
-      negotiateContentType,
       enableMethodNotAllowed,
       enableUnsupportedMediaType
     )
@@ -96,7 +88,6 @@ object Bootstrap extends Bootstrap[HNil, HNil](
   endpoints = HNil,
   includeDateHeader = true,
   includeServerHeader = true,
-  negotiateContentType = false,
   enableMethodNotAllowed = false,
   enableUnsupportedMediaType = false
 )

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -111,6 +111,7 @@ object ToService {
         private[this] val handler =
           if (opts.enableUnsupportedMediaType) respond415.orElse(respond400) else respond400
 
+        private[this] val negotiateContent = isNegotiable.fold(_ => true, _ => false)
         private[this] val underlying = es.head.handle(handler)
 
         def apply(req: Request): Future[Response] = underlying(Input.fromRequest(req)) match {
@@ -118,7 +119,6 @@ object ToService {
 
             Trace.captureIfNeeded(trc)
 
-            val negotiateContent = isNegotiable.fold(_ => true, _ => false)
             val accept = if (negotiateContent) req.accept.map(a => Accept.fromString(a)) else Nil
 
             val rep = new Promise[Response]

--- a/core/src/main/scala/io/finch/ToService.scala
+++ b/core/src/main/scala/io/finch/ToService.scala
@@ -97,14 +97,14 @@ object ToService {
       }
   }
 
-  type IsCoproduct[C] = OrElse[C <:< Coproduct, DummyImplicit]
+  type IsNegotiable[C] = OrElse[C <:< Coproduct, DummyImplicit]
 
   implicit def hlistTS[F[_], A, EH <: Endpoint[F, A], ET <: HList, CTH, CTT <: HList](implicit
     ntrA: ToResponse.Negotiable[A, CTH],
     ntrE: ToResponse.Negotiable[Exception, CTH],
     effect: Effect[F],
     tsT: ToService[ET, CTT],
-    isCoproduct: IsCoproduct[CTH]
+    isNegotiable: IsNegotiable[CTH]
   ): ToService[Endpoint[F, A] :: ET, CTH :: CTT] = new ToService[Endpoint[F, A] :: ET, CTH :: CTT] {
     def apply(es: Endpoint[F, A] :: ET, opts: Options, ctx: Context): Service[Request, Response] =
       new Service[Request, Response] {
@@ -118,7 +118,7 @@ object ToService {
 
             Trace.captureIfNeeded(trc)
 
-            val negotiateContent = isCoproduct.fold(_ => true, _ => false)
+            val negotiateContent = isNegotiable.fold(_ => true, _ => false)
             val accept = if (negotiateContent) req.accept.map(a => Accept.fromString(a)) else Nil
 
             val rep = new Promise[Response]

--- a/core/src/test/scala/io/finch/EndToEndSpec.scala
+++ b/core/src/test/scala/io/finch/EndToEndSpec.scala
@@ -69,18 +69,9 @@ class EndToEndSpec extends FinchSpec {
     rep.status shouldBe Status.Created
   }
 
-  it should "ignore Accept header when negotiation is not enabled" in {
-    check { req: Request =>
-      val s = Bootstrap.serve[AllContentTypes](pathAny).toService
-      val rep = Await.result(s(req))
-
-      rep.contentType === Some("text/event-stream")
-    }
-  }
-
   it should "ignore Accept header when single type is used for serve" in {
     check { req: Request =>
-      val s = Bootstrap.serve[Text.Plain](pathAny).configure(negotiateContentType = true).toService
+      val s = Bootstrap.serve[Text.Plain](pathAny).toService
       val rep = Await.result(s(req))
 
       rep.contentType === Some("text/plain")
@@ -89,7 +80,7 @@ class EndToEndSpec extends FinchSpec {
 
   it should "respect Accept header when coproduct type is used for serve" in {
     check { req: Request =>
-      val s = Bootstrap.serve[AllContentTypes](pathAny).configure(negotiateContentType = true).toService
+      val s = Bootstrap.serve[AllContentTypes](pathAny).toService
       val rep = Await.result(s(req))
 
       rep.contentType === req.accept.headOption
@@ -101,7 +92,7 @@ class EndToEndSpec extends FinchSpec {
       val a = s"${accept.primary}/${accept.sub}"
       req.accept = a +: req.accept
 
-      val s = Bootstrap.serve[AllContentTypes](pathAny).configure(negotiateContentType = true).toService
+      val s = Bootstrap.serve[AllContentTypes](pathAny).toService
       val rep = Await.result(s(req))
 
       val first = allContentTypes.collectFirst {
@@ -115,7 +106,7 @@ class EndToEndSpec extends FinchSpec {
   it should "select last encoder when Accept header is missing/empty" in {
     check { req: Request =>
       req.headerMap.remove(Fields.Accept)
-      val s = Bootstrap.serve[AllContentTypes](pathAny).configure(negotiateContentType = true).toService
+      val s = Bootstrap.serve[AllContentTypes](pathAny).toService
       val rep = Await.result(s(req))
 
       rep.contentType === Some("text/event-stream")
@@ -125,7 +116,7 @@ class EndToEndSpec extends FinchSpec {
   it should "select last encoder when Accept header value doesn't match any existing encoder" in {
     check { (req: Request, accept: Accept) =>
       req.accept = s"${accept.primary}/foo"
-      val s = Bootstrap.serve[AllContentTypes](pathAny).configure(negotiateContentType = true).toService
+      val s = Bootstrap.serve[AllContentTypes](pathAny).toService
       val rep = Await.result(s(req))
 
       rep.contentType === Some("text/event-stream")


### PR DESCRIPTION
Use `shapeless.OrElse` to resolve implicit evidence of `CTH` being a Coproduct or return `DummyImplicit` otherwise. Then fold this structure into boolean value to understand if we need to negotiate on Content-Type.

#1041 