### PR TITLE
Abstract over Stream type in the outbound path

### DIFF
--- a/core/src/main/scala/io/finch/EncodeStream.scala
+++ b/core/src/main/scala/io/finch/EncodeStream.scala
@@ -1,0 +1,26 @@
+package io.finch
+
+import com.twitter.io.{Buf, Reader}
+import java.nio.charset.Charset
+
+/**
+ * A type-class that defines encoding of a stream in a shape of `S[F[_], A]` to Finagle's [[Reader]].
+ */
+trait EncodeStream[S[_[_], _], F[_], A] {
+
+  type ContentType <: String
+
+  def apply(s: S[F, A], cs: Charset): Reader[Buf]
+}
+
+object EncodeStream {
+
+  type Aux[S[_[_], _], F[_], A, CT <: String] =
+    EncodeStream[S, F, A] { type ContentType = CT }
+
+  type Json[S[_[_],_], F[_], A] = Aux[S, F, A, Application.Json]
+
+  type Text[S[_[_],_], F[_], A] = Aux[S, F, A, Text.Plain]
+}
+
+

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -893,8 +893,8 @@ object Endpoint {
     * an `S[F, A]`. The returned [[Endpoint]] only matches chunked (streamed) requests.
     */
   def streamBinaryBody[F[_], S[_[_], _]](implicit
-                                         liftReader: LiftReader[S, F],
-                                         F: Effect[F]
+    liftReader: LiftReader[S, F],
+    F: Effect[F]
   ): Endpoint[F, S[F, Buf]] = {
     new Endpoint[F, S[F, Buf]] {
       final def apply(input: Input): Endpoint.Result[F, S[F, Buf]] = {
@@ -915,9 +915,9 @@ object Endpoint {
   }
 
   def streamJsonBody[F[_], S[_[_], _], A](implicit
-                                          streamDecoder: DecodeStream.Aux[S, F, A, Application.Json],
-                                          liftReader: LiftReader[S, F],
-                                          F: Effect[F]
+    streamDecoder: DecodeStream.Aux[S, F, A, Application.Json],
+    liftReader: LiftReader[S, F],
+    F: Effect[F]
   ): Endpoint[F, S[F, A]] = new Endpoint[F, S[F, A]] {
     final def apply(input: Input): Result[F, S[F, A]] = {
       streamBinaryBody.apply(input).map(streamDecoder(_, input.request.charsetOrUtf8))

--- a/core/src/main/scala/io/finch/LiftReader.scala
+++ b/core/src/main/scala/io/finch/LiftReader.scala
@@ -8,13 +8,10 @@ import com.twitter.io.{Buf, Reader}
 trait LiftReader[S[_[_], _], F[_]] {
 
   def apply(reader: Reader[Buf]): S[F, Buf]
-
 }
 
 object LiftReader {
-
   def instance[S[_[_], _], F[_]](fn: Reader[Buf] => S[F, Buf]): LiftReader[S, F] = new LiftReader[S, F] {
     def apply(reader: Reader[Buf]): S[F, Buf] = fn(reader)
   }
-
 }

--- a/core/src/test/scala/io/finch/data/Foo.scala
+++ b/core/src/test/scala/io/finch/data/Foo.scala
@@ -29,6 +29,9 @@ object Foo {
       )
     )
 
+  implicit val encodeJsonFoo: Encode.Json[Foo] =
+    Encode.json((foo, cs) => Buf.ByteArray.Owned(s"""{s:"${foo.s}"""".getBytes(cs)))
+
   implicit val arbitraryFoo: Arbitrary[Foo] =
     Arbitrary(Gen.alphaStr.suchThat(_.nonEmpty).map(Foo.apply))
 }

--- a/fs2/src/main/scala/io/finch/fs2/package.scala
+++ b/fs2/src/main/scala/io/finch/fs2/package.scala
@@ -2,63 +2,67 @@ package io.finch
 
 import _root_.fs2.Stream
 import cats.effect.Effect
-import com.twitter.finagle.http.Response
-import com.twitter.io.Buf
+import com.twitter.io.{Buf, Pipe, Reader, Writer}
 import com.twitter.util.Future
-import shapeless.Witness
+import java.nio.charset.Charset
 
 package object fs2 extends StreamInstances {
 
-  implicit def streamLiftReader[F[_] : Effect](implicit toEffect: ToEffect[Future, F]): LiftReader[Stream, F] =
-    LiftReader.instance { reader =>
-      Stream
-        .repeatEval(Effect[F].defer(toEffect(reader.read)))
-        .unNoneTerminate
-        .onFinalize(Effect[F].delay(reader.discard()))
-    }
-
-  implicit def streamToJsonResponse[F[_] : Effect, A](implicit
-    e: Encode.Aux[A, Application.Json],
-    w: Witness.Aux[Application.Json]
-  ): ToResponse.Aux[Stream[F, A], Application.Json] = {
-    mkToResponse[F, A, Application.Json](delimiter = Some(ToResponse.NewLine))
+  implicit def streamLiftReader[F[_]](implicit
+    F: Effect[F],
+    TE: ToEffect[Future, F]
+  ): LiftReader[Stream, F] = LiftReader.instance { reader =>
+    Stream
+      .repeatEval(F.defer(TE(reader.read)))
+      .unNoneTerminate
+      .onFinalize(F.delay(reader.discard()))
   }
 
+  implicit def encodeJsonFs2Stream[F[_]: Effect, A](implicit
+    A: Encode.Json[A]
+  ): EncodeStream.Json[Stream, F, A] =
+    new EncodeFs2Stream[F, A, Application.Json] {
+      protected def encodeChunk(chunk: A, cs: Charset): Buf = A(chunk, cs)
+      override protected def writeChunk(chunk: Buf, w: Writer[Buf]): Future[Unit] =
+        w.write(chunk.concat(ToResponse.NewLine))
+    }
+
+  implicit def encodeTextFs2Stream[F[_]: Effect, A](implicit
+    A: Encode.Text[A]
+  ): EncodeStream.Text[Stream, F, A] =
+    new EncodeFs2Stream[F, A, Text.Plain] {
+      override protected def encodeChunk(chunk: A, cs: Charset): Buf = A(chunk, cs)
+    }
 }
 
 trait StreamInstances {
+  protected abstract class EncodeFs2Stream[F[_], A, CT <: String](implicit
+    F: Effect[F],
+    TE: ToEffect[Future, F]
+  ) extends EncodeStream[Stream, F, A] {
 
-  implicit def streamToResponse[F[_] : Effect, A, CT <: String](implicit
-    e: Encode.Aux[A, CT],
-    w: Witness.Aux[CT],
-    toEffect: ToEffect[Future, F]
-  ): ToResponse.Aux[Stream[F, A], CT] = {
-    mkToResponse[F, A, CT](delimiter = None)
-  }
+    type ContentType = CT
 
-  protected def mkToResponse[F[_] : Effect, A, CT <: String](delimiter: Option[Buf])(implicit
-    e: Encode.Aux[A, CT],
-    w: Witness.Aux[CT],
-    toEffect: ToEffect[Future, F]
-  ): ToResponse.Aux[Stream[F, A], CT] = {
-    ToResponse.instance[Stream[F, A], CT]((stream, cs) => {
-      val response = Response()
-      response.setChunked(true)
-      response.contentType = w.value
-      val writer = response.writer
-      val effect = stream
-        .map(e.apply(_, cs))
-        .evalMap(buf => toEffect(writer.write(delimiter match {
-          case Some(d) => buf.concat(d)
-          case _ => buf
-        })))
-        .onFinalize(Effect[F].defer(toEffect(writer.close())))
+    protected def encodeChunk(chunk: A, cs: Charset): Buf
+    protected def writeChunk(chunk: Buf, w: Writer[Buf]): Future[Unit] = w.write(chunk)
+
+    def apply(s: Stream[F, A], cs: Charset): Reader[Buf] = {
+      val p = new Pipe[Buf]
+      val run = s
+        .map(chunk => encodeChunk(chunk, cs))
+        .evalMap(chunk => TE(writeChunk(chunk, p)))
+        .onFinalize(F.suspend(TE(p.close())))
         .compile
         .drain
 
-      Effect[F].toIO(effect).unsafeRunAsyncAndForget()
-      response
-    })
+      F.toIO(run).unsafeRunAsyncAndForget()
+      p
+    }
   }
+
+  implicit def encodeBufFs2[F[_]: Effect, CT <: String]: EncodeStream.Aux[Stream, F, Buf, CT] =
+    new EncodeFs2Stream[F, Buf, CT] {
+      protected def encodeChunk(chunk: Buf, cs: Charset): Buf = chunk
+    }
 
 }


### PR DESCRIPTION
This to address #1038 as well as make it more pluggable to adopt new streaming libraries (eg FS2). The type-class name is inspired by what Sergey is doing in #1042. The new machinery allows us to reuse the same instances between `ToResponse` (when serving streaming content) and `Input.withStream` allowing users to created chunked requests for testing.

Here is how it looks and feels:

```scala
import io.finch._, io.finch.iteratee._, io.interatee.Enumerator, cats.effect.IO

val i = Input
  .post("/")
  .withStream[Text.Plain](Enumerator.enumerate[IO, String]("foo", "bar", "baz"))
```

Also possible to encode JSON (as you would imagine). This does the right thing and encodes ND (newline-delimited) JSON stream, reusing the same code that we use on the outbound path:

```scala
import io.finch._, io.finch.iteratee._, io.interatee.Enumerator, cats.effect.IO
import io.finch.circe._, io.circe.generic.auto._

case class Foo(s: String)

val i = Input
  .post("/")
  .withBody[Application.Json](Enumerator.enumerate[IO, Foo](Foo("foo"), Foo("bar"), Foo("baz")))
```

As a bonus, this addresses #1040.