### PR TITLE
Do not run stream out of band

### DIFF
--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -12,7 +12,6 @@ import io.finch.internal.HttpContent
 import io.iteratee.Enumerator
 import java.nio.charset.StandardCharsets
 
-
 trait Decoders {
 
   /**
@@ -27,9 +26,9 @@ trait Decoders {
     attemptJson.fold[Either[Throwable, A]](Left.apply, Right.apply)
   }
 
-  implicit def enumerateCirce[F[_], A : Decoder](implicit
-    monadError: MonadError[F, Throwable]
-  ): DecodeStream.Json[Enumerator, F, A] = {
+  implicit def enumerateCirce[F[_], A: Decoder](implicit
+    F: MonadError[F, Throwable]
+  ): DecodeStream.Json[Enumerator, F, A] =
     DecodeStream.instance[Enumerator, F, A, Application.Json]((enum, cs) => {
       val parsed = cs match {
         case StandardCharsets.UTF_8 =>
@@ -39,11 +38,8 @@ trait Decoders {
       }
       parsed.through(iteratee.decoder[F, A])
     })
-  }
 
-  implicit def fs2Circe[F[_] : Sync, A : Decoder](implicit
-    monadError: MonadError[F, Throwable]
-  ): DecodeStream.Json[Stream, F, A] = {
+  implicit def fs2Circe[F[_]: Sync, A: Decoder]: DecodeStream.Json[Stream, F, A] =
     DecodeStream.instance[Stream, F, A, Application.Json]((stream, cs) => {
       val parsed = cs match {
         case StandardCharsets.UTF_8 =>
@@ -57,6 +53,4 @@ trait Decoders {
       }
       parsed.through(fs2.decoder[F, A])
     })
-  }
-
 }

--- a/core/src/main/scala/io/finch/EncodeStream.scala
+++ b/core/src/main/scala/io/finch/EncodeStream.scala
@@ -6,21 +6,21 @@ import java.nio.charset.Charset
 /**
  * A type-class that defines encoding of a stream in a shape of `S[F[_], A]` to Finagle's [[Reader]].
  */
-trait EncodeStream[S[_[_], _], F[_], A] {
+trait EncodeStream[F[_], S[_[_], _], A] {
 
   type ContentType <: String
 
-  def apply(s: S[F, A], cs: Charset): Reader[Buf]
+  def apply(s: S[F, A], cs: Charset): F[Reader[Buf]]
 }
 
 object EncodeStream {
 
-  type Aux[S[_[_], _], F[_], A, CT <: String] =
-    EncodeStream[S, F, A] { type ContentType = CT }
+  type Aux[F[_], S[_[_], _], A, CT <: String] =
+    EncodeStream[F, S, A] { type ContentType = CT }
 
-  type Json[S[_[_],_], F[_], A] = Aux[S, F, A, Application.Json]
+  type Json[F[_], S[_[_],_], A] = Aux[F, S, A, Application.Json]
 
-  type Text[S[_[_],_], F[_], A] = Aux[S, F, A, Text.Plain]
+  type Text[F[_], S[_[_],_], A] = Aux[F, S, A, Text.Plain]
 }
 
 

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -266,9 +266,9 @@ trait Endpoint[F[_], A] { self =>
     * Consider using [[io.finch.Bootstrap]] instead.
     */
   final def toService(implicit
-    tr: ToResponse.Aux[A, Application.Json],
-    tre: ToResponse.Aux[Exception, Application.Json],
-    F: Effect[F]
+    F: Effect[F],
+    tr: ToResponse.Aux[F, A, Application.Json],
+    tre: ToResponse.Aux[F, Exception, Application.Json]
   ): Service[Request, Response] = toServiceAs[Application.Json]
 
   /**
@@ -278,9 +278,9 @@ trait Endpoint[F[_], A] { self =>
     * Consider using [[io.finch.Bootstrap]] instead.
     */
   final def toServiceAs[CT <: String](implicit
-    tr: ToResponse.Aux[A, CT],
-    tre: ToResponse.Aux[Exception, CT],
-    F: Effect[F]
+    F: Effect[F],
+    tr: ToResponse.Aux[F, A, CT],
+    tre: ToResponse.Aux[F, Exception, CT]
   ): Service[Request, Response] = Bootstrap.serve[CT](this).toService
 
   /**

--- a/core/src/test/scala/io/finch/MethodSpec.scala
+++ b/core/src/test/scala/io/finch/MethodSpec.scala
@@ -1,5 +1,6 @@
 package io.finch
 
+import cats.Id
 import cats.effect.IO
 import com.twitter.finagle.http.Response
 import com.twitter.util.{Future => TwitterFuture}
@@ -14,7 +15,8 @@ class MethodSpec
 
   behavior of "method"
 
-  implicit val arbResponse: Arbitrary[Response] = Arbitrary(genOutput[String].map(_.toResponse[Text.Plain]))
+  implicit val arbResponse: Arbitrary[Response] =
+    Arbitrary(genOutput[String].map(_.toResponse[Id, Text.Plain]))
 
   it should "map Output value to endpoint" in {
     checkValue((i: String) => get(zero) { Ok(i) })
@@ -38,15 +40,15 @@ class MethodSpec
   }
 
   it should "map F[Response] value to endpoint" in {
-    checkValue((i: Response) => get(zero) { IO.pure(Ok(i).toResponse[Text.Plain]) })
+    checkValue((i: Response) => get(zero) { IO.pure(Ok(i).toResponse[Id, Text.Plain]) })
   }
 
   it should "map TwitterFuture[Response] value to endpoint" in {
-    checkValue((i: Response) => get(zero) { TwitterFuture.value(Ok(i).toResponse[Text.Plain]) })
+    checkValue((i: Response) => get(zero) { TwitterFuture.value(Ok(i).toResponse[Id, Text.Plain]) })
   }
 
   it should "map ScalaFuture[Response] value to endpoint" in {
-    checkValue((i: Response) => get(zero) { ScalaFuture.successful(Ok(i).toResponse[Text.Plain]) })
+    checkValue((i: Response) => get(zero) { ScalaFuture.successful(Ok(i).toResponse[Id, Text.Plain]) })
   }
 
   it should "map A => Output function to endpoint" in {
@@ -54,7 +56,7 @@ class MethodSpec
   }
 
   it should "map A => Response function to endpoint" in {
-    checkFunction(get(path[Int]) { i: Int => Ok(i).toResponse[Text.Plain] })
+    checkFunction(get(path[Int]) { i: Int => Ok(i).toResponse[Id, Text.Plain] })
   }
 
   it should "map A => F[Output[A]] function to endpoint" in {
@@ -70,15 +72,15 @@ class MethodSpec
   }
 
   it should "map A => F[Response] function to endpoint" in {
-    checkFunction(get(path[Int]) { i: Int => IO.pure(i).map(Ok(_).toResponse[Text.Plain]) })
+    checkFunction(get(path[Int]) { i: Int => IO.pure(i).map(Ok(_).toResponse[Id, Text.Plain]) })
   }
 
   it should "map A => TwitterFuture[Response] function to endpoint" in {
-    checkFunction(get(path[Int]) { i: Int => TwitterFuture.value(i).map(Ok(_).toResponse[Text.Plain]) })
+    checkFunction(get(path[Int]) { i: Int => TwitterFuture.value(i).map(Ok(_).toResponse[Id, Text.Plain]) })
   }
 
   it should "map A => ScalaFuture[Response] function to endpoint" in {
-    checkFunction(get(path[Int]) { i: Int => ScalaFuture.successful(i).map(Ok(_).toResponse[Text.Plain]) })
+    checkFunction(get(path[Int]) { i: Int => ScalaFuture.successful(i).map(Ok(_).toResponse[Id, Text.Plain]) })
   }
 
   it should "map (A, B) => Output function to endpoint" in {
@@ -86,7 +88,7 @@ class MethodSpec
   }
 
   it should "map (A, B) => Response function to endpoint" in {
-    checkFunction2(get(path[Int] :: path[Int]) { (x: Int, y: Int) => Ok(s"$x$y").toResponse[Text.Plain] })
+    checkFunction2(get(path[Int] :: path[Int]) { (x: Int, y: Int) => Ok(s"$x$y").toResponse[Id, Text.Plain] })
   }
 
   it should "map (A, B) => F[Output[String]] function to endpoint" in {
@@ -103,17 +105,17 @@ class MethodSpec
 
   it should "map (A, B) => F[Response] function to endpoint" in {
     checkFunction2(get(path[Int] :: path[Int]) { (x: Int, y: Int) =>
-      IO.pure(Ok(s"$x$y").toResponse[Text.Plain]) })
+      IO.pure(Ok(s"$x$y").toResponse[Id, Text.Plain]) })
   }
 
   it should "map (A, B) => TwitterFuture[Response] function to endpoint" in {
     checkFunction2(get(path[Int] :: path[Int]) { (x: Int, y: Int) =>
-      TwitterFuture.value(Ok(s"$x$y").toResponse[Text.Plain]) })
+      TwitterFuture.value(Ok(s"$x$y").toResponse[Id, Text.Plain]) })
   }
 
   it should "map (A, B) => ScalaFuture[Response] function to endpoint" in {
     checkFunction2(get(path[Int] :: path[Int]) { (x: Int, y: Int) =>
-      ScalaFuture.successful(Ok(s"$x$y").toResponse[Text.Plain]) })
+      ScalaFuture.successful(Ok(s"$x$y").toResponse[Id, Text.Plain]) })
   }
 
   behavior of "Custom Type Program[_]"
@@ -143,12 +145,12 @@ class MethodSpec
   }
 
   it should "map A => Program[Response] function to endpoint" in {
-    checkFunction(get(path[Int]) { i: Int => Program(Ok(i).toResponse[Text.Plain]) })
+    checkFunction(get(path[Int]) { i: Int => Program(Ok(i).toResponse[Id, Text.Plain]) })
   }
 
   it should "map (A, B) => Program[Response] function to endpoint" in {
     checkFunction2(get(path[Int] :: path[Int]) { (x: Int, y: Int) =>
-      Program(Ok(s"$x$y").toResponse[Text.Plain])
+      Program(Ok(s"$x$y").toResponse[Id, Text.Plain])
     })
   }
 

--- a/examples/src/main/scala/io/finch/iteratee/Main.scala
+++ b/examples/src/main/scala/io/finch/iteratee/Main.scala
@@ -1,10 +1,12 @@
 package io.finch.iteratee
 
-import cats.effect.IO
-import com.twitter.finagle.Http
-import com.twitter.util.Await
+import cats.effect.{ExitCode, IO, IOApp, Resource}
+import cats.implicits._
+import com.twitter.finagle.{Http, ListeningServer}
+import com.twitter.util.Future
 import io.circe.generic.auto._
 import io.finch._
+import io.finch.catsEffect._
 import io.finch.circe._
 import io.iteratee.{Enumerator, Iteratee}
 import scala.util.Random
@@ -35,7 +37,7 @@ import scala.util.Random
   *   $ curl -X POST --header "Transfer-Encoding: chunked" -d '{"i": 40} {"i": 42}' localhost:8081/streamPrime
   * }}}
   */
-object Main extends EndpointModule[IO] {
+object Main extends IOApp {
 
   final case class Result(result: Int) {
     def add(n: Number): Result = copy(result = result + n.i)
@@ -63,9 +65,17 @@ object Main extends EndpointModule[IO] {
       Ok(enum.map(_.isPrime))
     }
 
-  def main(args: Array[String]): Unit = Await.result(
+  def serve: IO[ListeningServer] = IO(
     Http.server
       .withStreaming(enabled = true)
       .serve(":8081", (sumJson :+: streamJson :+: isPrime).toServiceAs[Application.Json])
+  )
+
+  def run(args: List[String]): IO[ExitCode] = {
+    val server = Resource.make(serve)(s =>
+      IO.suspend(implicitly[ToEffect[Future, IO]].apply(s.close()))
     )
+
+    server.use(_ => IO.never).as(ExitCode.Success)
+  }
 }

--- a/fs2/src/main/scala/io/finch/fs2/package.scala
+++ b/fs2/src/main/scala/io/finch/fs2/package.scala
@@ -1,7 +1,7 @@
 package io.finch
 
 import _root_.fs2.Stream
-import cats.effect.Effect
+import cats.effect.{Effect, IO}
 import com.twitter.io.{Buf, Pipe, Reader}
 import com.twitter.util.Future
 import io.finch.internal._
@@ -25,17 +25,17 @@ package object fs2 extends StreamInstances {
 
   implicit def encodeJsonFs2Stream[F[_]: Effect, A](implicit
     A: Encode.Json[A]
-  ): EncodeStream.Json[Stream, F, A] =
+  ): EncodeStream.Json[F, Stream, A] =
     new EncodeNewLineDelimitedFs2Stream[F, A, Application.Json]
 
   implicit def encodeSseFs2Stream[F[_]: Effect, A](implicit
     A: Encode.Aux[A, Text.EventStream]
-  ): EncodeStream.Aux[Stream, F, A, Text.EventStream] =
+  ): EncodeStream.Aux[F, Stream, A, Text.EventStream] =
     new EncodeNewLineDelimitedFs2Stream[F, A, Text.EventStream]
 
   implicit def encodeTextFs2Stream[F[_]: Effect, A](implicit
     A: Encode.Text[A]
-  ): EncodeStream.Text[Stream, F, A] =
+  ): EncodeStream.Text[F, Stream, A] =
     new EncodeFs2Stream[F, A, Text.Plain] {
       override protected def encodeChunk(chunk: A, cs: Charset): Buf = A(chunk, cs)
     }
@@ -53,13 +53,15 @@ trait StreamInstances {
   protected abstract class EncodeFs2Stream[F[_], A, CT <: String](implicit
     F: Effect[F],
     TE: ToEffect[Future, F]
-  ) extends EncodeStream[Stream, F, A] {
+  ) extends EncodeStream[F, Stream, A] with (Either[Throwable, Unit] => IO[Unit]) {
 
     type ContentType = CT
 
     protected def encodeChunk(chunk: A, cs: Charset): Buf
 
-    def apply(s: Stream[F, A], cs: Charset): Reader[Buf] = {
+    def apply(cb: Either[Throwable, Unit]): IO[Unit] = IO.unit
+
+    def apply(s: Stream[F, A], cs: Charset): F[Reader[Buf]] = {
       val p = new Pipe[Buf]
       val run = s
         .map(chunk => encodeChunk(chunk, cs))
@@ -68,14 +70,12 @@ trait StreamInstances {
         .compile
         .drain
 
-      F.toIO(run).unsafeRunAsyncAndForget()
-      p
+      F.productR(F.runAsync(run)(this).to[F])(F.pure(p))
     }
   }
 
-  implicit def encodeBufFs2[F[_]: Effect, CT <: String]: EncodeStream.Aux[Stream, F, Buf, CT] =
+  implicit def encodeBufFs2[F[_]: Effect, CT <: String]: EncodeStream.Aux[F, Stream, Buf, CT] =
     new EncodeFs2Stream[F, Buf, CT] {
       protected def encodeChunk(chunk: Buf, cs: Charset): Buf = chunk
     }
-
 }

--- a/iteratee/src/main/scala/io/finch/iteratee/package.scala
+++ b/iteratee/src/main/scala/io/finch/iteratee/package.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import cats.effect.Effect
+import cats.effect.{Effect, IO}
 import com.twitter.io._
 import com.twitter.util.Future
 import io.finch.internal._
@@ -29,18 +29,21 @@ package object iteratee extends IterateeInstances {
     }
 
   implicit def encodeJsonEnumerator[F[_]: Effect, A](implicit
-    A: Encode.Json[A]
-  ): EncodeStream.Json[Enumerator, F, A] =
+    A: Encode.Json[A],
+    TE: ToEffect[Future, F]
+  ): EncodeStream.Json[F, Enumerator, A] =
     new EncodeNewLineDelimitedEnumerator[F, A, Application.Json]
 
   implicit def encodeSseEnumerator[F[_]: Effect, A](implicit
-    A: Encode.Aux[A, Text.EventStream]
-  ): EncodeStream.Aux[Enumerator, F, A, Text.EventStream] =
+    A: Encode.Aux[A, Text.EventStream],
+    TE: ToEffect[Future, F]
+  ): EncodeStream.Aux[F, Enumerator, A, Text.EventStream] =
     new EncodeNewLineDelimitedEnumerator[F, A, Text.EventStream]
 
   implicit def encodeTextEnumerator[F[_]: Effect, A](implicit
-    A: Encode.Text[A]
-  ): EncodeStream.Text[Enumerator, F, A] =
+    A: Encode.Text[A],
+    TE: ToEffect[Future, F]
+  ): EncodeStream.Text[F, Enumerator, A] =
     new EncodeEnumerator[F, A, Text.Plain] {
       override protected def encodeChunk(chunk: A, cs: Charset): Buf = A(chunk, cs)
     }
@@ -50,7 +53,8 @@ package object iteratee extends IterateeInstances {
 trait IterateeInstances {
 
   protected final class EncodeNewLineDelimitedEnumerator[F[_]: Effect, A, CT <: String](implicit
-    A: Encode.Aux[A, CT]
+    A: Encode.Aux[A, CT],
+    TE: ToEffect[Future, F]
   ) extends EncodeEnumerator[F, A, CT] {
     protected def encodeChunk(chunk: A, cs: Charset): Buf =
       A(chunk, cs).concat(newLine(cs))
@@ -59,7 +63,7 @@ trait IterateeInstances {
   protected abstract class EncodeEnumerator[F[_], A, CT <: String](implicit
     F: Effect[F],
     TE: ToEffect[Future, F]
-  ) extends EncodeStream[Enumerator, F, A] {
+  ) extends EncodeStream[F, Enumerator, A] with (Either[Throwable, Unit] => IO[Unit]) {
 
     type ContentType = CT
 
@@ -68,19 +72,20 @@ trait IterateeInstances {
     private def writeIteratee(w: Writer[Buf]): Iteratee[F, Buf, Unit] =
       Iteratee.foreachM[F, Buf](chunk => TE(w.write(chunk)))
 
-    def apply(s: Enumerator[F, A], cs: Charset): Reader[Buf] = {
+    final def apply(cb: Either[Throwable, Unit]): IO[Unit] = IO.unit
+
+    def apply(s: Enumerator[F, A], cs: Charset): F[Reader[Buf]] = {
       val p = new Pipe[Buf]
       val run = s
         .ensure(F.suspend(TE(p.close())))
         .map(chunk => encodeChunk(chunk, cs))
         .into(writeIteratee(p))
 
-      F.toIO(run).unsafeRunAsyncAndForget()
-      p
+      F.productR(F.runAsync(run)(this).to[F])(F.pure(p))
     }
   }
 
-  implicit def encodeBufEnumerator[F[_]: Effect, CT <: String]: EncodeStream.Aux[Enumerator, F, Buf, CT] =
+  implicit def encodeBufEnumerator[F[_]: Effect, CT <: String]: EncodeStream.Aux[F, Enumerator, Buf, CT] =
     new EncodeEnumerator[F, Buf, CT] {
       protected def encodeChunk(chunk: Buf, cs: Charset): Buf = chunk
     }


### PR DESCRIPTION
See #1057.

This refactors `ToResponse` so it returns `F[Response]`, instead of just `Response` to allow for in-band stream evaluation.

UPDATE:

Nothing concerning in the benchmark:

```
BEFORE:

[info] JsonBootstrapBenchmark.foos                                thrpt   10   28777.149 ± 1351.610   ops/s
[info] JsonBootstrapBenchmark.foos:·gc.alloc.rate.norm            thrpt   10  103896.055 ±    0.019    B/op
[success] Total time: 37 s, completed Jan 19, 2019 5:09:30 PM


AFTER:

[info] Benchmark                                                   Mode  Cnt       Score      Error   Units
[info] JsonBootstrapBenchmark.foos                                thrpt   10   29342.207 ± 1092.418   ops/s
[info] JsonBootstrapBenchmark.foos:·gc.alloc.rate.norm            thrpt   10  104088.054 ±    0.018    B/op
```