### PR TITLE
Fs2 EncodeStream for both ConcurrentEffect and Effect monads

### DIFF
--- a/core/src/test/scala/io/finch/StreamingLaws.scala
+++ b/core/src/test/scala/io/finch/StreamingLaws.scala
@@ -56,7 +56,7 @@ abstract class StreamingLaws[S[_[_], _], F[_]] extends Laws with AllInstances wi
 
 object StreamingLaws {
 
-  def apply[S[_[_], _], F[_]: Effect](
+  def apply[S[_[_], _], F[_]](
     streamFromList: List[Buf] => S[F, Buf],
     listFromStream: S[F, Array[Byte]] => List[Buf]
   )(implicit

--- a/fs2/src/main/scala/io/finch/fs2/package.scala
+++ b/fs2/src/main/scala/io/finch/fs2/package.scala
@@ -1,81 +1,139 @@
 package io.finch
 
 import _root_.fs2.Stream
-import cats.effect.{Effect, IO}
+import cats.effect._
 import com.twitter.io.{Buf, Pipe, Reader}
 import com.twitter.util.Future
 import io.finch.internal._
 import java.nio.charset.Charset
 
-package object fs2 extends StreamInstances {
+package object fs2 extends StreamConcurrentInstances {
 
   implicit def streamLiftReader[F[_]](implicit
-    F: Effect[F],
-    TE: ToAsync[Future, F]
+    F: Sync[F],
+    TA: ToAsync[Future, F]
   ): LiftReader[Stream, F] =
     new LiftReader[Stream, F] {
       final def apply[A](reader: Reader[Buf], process: Buf => A): Stream[F, A] = {
         Stream
-          .repeatEval(F.suspend(TE(reader.read())))
+          .repeatEval(F.suspend(TA(reader.read())))
           .unNoneTerminate
           .map(process)
           .onFinalize(F.delay(reader.discard()))
       }
     }
 
-  implicit def encodeJsonFs2Stream[F[_]: Effect, A](implicit
+  implicit def encodeBufConcurrentFs2[F[_]: ConcurrentEffect, CT <: String]: EncodeStream.Aux[F, Stream, Buf, CT] =
+    new EncodeConcurrentFs2Stream[F, Buf, CT] {
+      protected def encodeChunk(chunk: Buf, cs: Charset): Buf = chunk
+    }
+}
+
+trait StreamConcurrentInstances extends StreamEffectInstances {
+
+  implicit def encodeJsonConcurrentFs2Stream[F[_]: ConcurrentEffect, A](implicit
     A: Encode.Json[A]
   ): EncodeStream.Json[F, Stream, A] =
-    new EncodeNewLineDelimitedFs2Stream[F, A, Application.Json]
+    new EncodeNewLineDelimitedConcurrentFs2Stream[F, A, Application.Json]
 
-  implicit def encodeSseFs2Stream[F[_]: Effect, A](implicit
+  implicit def encodeSseConcurrentFs2Stream[F[_]: ConcurrentEffect, A](implicit
     A: Encode.Aux[A, Text.EventStream]
   ): EncodeStream.Aux[F, Stream, A, Text.EventStream] =
-    new EncodeNewLineDelimitedFs2Stream[F, A, Text.EventStream]
+    new EncodeNewLineDelimitedConcurrentFs2Stream[F, A, Text.EventStream]
 
-  implicit def encodeTextFs2Stream[F[_]: Effect, A](implicit
+  implicit def encodeTextConcurrentFs2Stream[F[_]: ConcurrentEffect, A](implicit
     A: Encode.Text[A]
   ): EncodeStream.Text[F, Stream, A] =
-    new EncodeFs2Stream[F, A, Text.Plain] {
+    new EncodeConcurrentFs2Stream[F, A, Text.Plain] {
+      override protected def encodeChunk(chunk: A, cs: Charset): Buf = A(chunk, cs)
+    }
+
+  implicit def encodeBufEffectFs2[F[_]: Effect, CT <: String]: EncodeStream.Aux[F, Stream, Buf, CT] =
+    new EncodeEffectFs2Stream[F, Buf, CT] {
+      protected def encodeChunk(chunk: Buf, cs: Charset): Buf = chunk
+    }
+}
+
+trait StreamEffectInstances extends StreamInstances {
+
+  implicit def encodeJsonEffectFs2Stream[F[_]: Effect, A](implicit
+    A: Encode.Json[A]
+  ): EncodeStream.Json[F, Stream, A] =
+    new EncodeNewLineDelimitedEffectFs2Stream[F, A, Application.Json]
+
+  implicit def encodeSseEffectFs2Stream[F[_]: Effect, A](implicit
+    A: Encode.Aux[A, Text.EventStream]
+  ): EncodeStream.Aux[F, Stream, A, Text.EventStream] =
+    new EncodeNewLineDelimitedEffectFs2Stream[F, A, Text.EventStream]
+
+  implicit def encodeTextEffectFs2Stream[F[_]: Effect, A](implicit
+    A: Encode.Text[A]
+  ): EncodeStream.Text[F, Stream, A] =
+    new EncodeEffectFs2Stream[F, A, Text.Plain] {
       override protected def encodeChunk(chunk: A, cs: Charset): Buf = A(chunk, cs)
     }
 }
 
 trait StreamInstances {
 
-  protected final class EncodeNewLineDelimitedFs2Stream[F[_]: Effect, A, CT <: String](implicit
+  protected final class EncodeNewLineDelimitedConcurrentFs2Stream[F[_]: ConcurrentEffect, A, CT <: String](implicit
     A: Encode.Aux[A, CT]
-  ) extends EncodeFs2Stream[F, A, CT] {
+  ) extends EncodeConcurrentFs2Stream[F, A, CT] {
     protected def encodeChunk(chunk: A, cs: Charset): Buf =
       A(chunk, cs).concat(newLine(cs))
   }
 
-  protected abstract class EncodeFs2Stream[F[_], A, CT <: String](implicit
+  protected final class EncodeNewLineDelimitedEffectFs2Stream[F[_]: Effect, A, CT <: String](implicit
+    A: Encode.Aux[A, CT]
+  ) extends EncodeEffectFs2Stream[F, A, CT] {
+    protected def encodeChunk(chunk: A, cs: Charset): Buf =
+      A(chunk, cs).concat(newLine(cs))
+  }
+
+  protected abstract class EncodeConcurrentFs2Stream[F[_], A, CT <: String](implicit
+    F: Concurrent[F],
+    TA: ToAsync[Future, F]
+  ) extends EncodeFs2Stream[F, A, CT] {
+
+    protected def dispatch(reader: Reader[Buf], run: F[Unit]): F[Reader[Buf]] =
+      F.bracketCase(F.start(run))(_ => F.pure(reader)) {
+        case (f, ExitCase.Canceled) => f.cancel
+        case _ => F.unit
+      }
+  }
+
+  protected abstract class EncodeEffectFs2Stream[F[_], A, CT <: String](implicit
     F: Effect[F],
-    TE: ToAsync[Future, F]
-  ) extends EncodeStream[F, Stream, A] with (Either[Throwable, Unit] => IO[Unit]) {
+    TA: ToAsync[Future, F]
+  ) extends EncodeFs2Stream[F, A, CT] with (Either[Throwable, Unit] => IO[Unit]) {
+
+    def apply(cb: Either[Throwable, Unit]): IO[Unit] = IO.unit
+
+    protected def dispatch(reader: Reader[Buf], run: F[Unit]): F[Reader[Buf]] =
+      F.productR(F.runAsync(run)(this).to[F])(F.pure(reader))
+  }
+
+  protected abstract class EncodeFs2Stream[F[_], A, CT <: String](implicit
+    F: Sync[F],
+    TA: ToAsync[Future, F]
+  ) extends EncodeStream[F, Stream, A] {
 
     type ContentType = CT
 
     protected def encodeChunk(chunk: A, cs: Charset): Buf
 
-    def apply(cb: Either[Throwable, Unit]): IO[Unit] = IO.unit
+    protected def dispatch(reader: Reader[Buf], run: F[Unit]): F[Reader[Buf]]
 
-    def apply(s: Stream[F, A], cs: Charset): F[Reader[Buf]] = {
+    def apply(s: Stream[F, A], cs: Charset): F[Reader[Buf]] = F.suspend {
       val p = new Pipe[Buf]
       val run = s
         .map(chunk => encodeChunk(chunk, cs))
-        .evalMap(chunk => TE(p.write(chunk)))
-        .onFinalize(F.suspend(TE(p.close())))
+        .evalMap(chunk => TA(p.write(chunk)))
+        .onFinalize(F.suspend(TA(p.close())))
         .compile
         .drain
 
-      F.productR(F.runAsync(run)(this).to[F])(F.pure(p))
+      dispatch(p, run)
     }
   }
-
-  implicit def encodeBufFs2[F[_]: Effect, CT <: String]: EncodeStream.Aux[F, Stream, Buf, CT] =
-    new EncodeFs2Stream[F, Buf, CT] {
-      protected def encodeChunk(chunk: Buf, cs: Charset): Buf = chunk
-    }
 }

--- a/fs2/src/test/scala/io/finch/fs2/Fs2StreamingSpec.scala
+++ b/fs2/src/test/scala/io/finch/fs2/Fs2StreamingSpec.scala
@@ -1,16 +1,25 @@
 package io.finch.fs2
 
 import _root_.fs2.Stream
-import cats.effect.IO
+import cats.effect.{ConcurrentEffect, Effect, IO}
 import com.twitter.io.Buf
 import io.finch._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 class Fs2StreamingSpec extends FinchSpec with GeneratorDrivenPropertyChecks {
 
-  checkAll("fs2.streamBody", StreamingLaws[Stream, IO](
-    list => Stream(list:_*),
-    _.map(array => Buf.ByteArray.Owned(array)).compile.toList.unsafeRunSync()
-  ).all)
+  checkEffect[IO]
+  checkConcurrentEffect[IO]
 
+  def checkEffect[F[_]](implicit F: Effect[F]): Unit =
+    checkAll("fs2.streamBody[F[_]: Effect]", StreamingLaws[Stream, F](
+      list => Stream(list:_*),
+      stream => F.toIO(stream.map(array => Buf.ByteArray.Owned(array)).compile.toList).unsafeRunSync()
+    ).all)
+
+  def checkConcurrentEffect[F[_]](implicit F: ConcurrentEffect[F]): Unit =
+    checkAll("fs2.streamBody[F[_]: ConcurrentEffect]", StreamingLaws[Stream, F](
+      list => Stream(list:_*),
+      stream => F.toIO(stream.map(array => Buf.ByteArray.Owned(array)).compile.toList).unsafeRunSync()
+    ).all)
 }


### PR DESCRIPTION
The `ConcurrentEffect` instances are prioritized higher.
This means users can benefit from cancellation when possible
without loss of generality.

@vkostyukov this is what I had in mind with providing both versions and prioritizing them. But I don't know how to test that cancellation actually works. Any ideas?