### PR TITLE
Least powerful type classes + Endpoint.transformF

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -97,7 +97,7 @@ trait Endpoint[F[_], A] { self =>
 
   final def mapF[B](fn: F[A] => F[B])(implicit F: Monad[F]): Endpoint[F, B] =
     new Endpoint[F, B] {
-      def apply(input: Input): Result[F, B] =
+      def apply(input: Input): Endpoint.Result[F, B] =
         self(input) match {
           case EndpointResult.Matched(rem, trc, out) =>
             EndpointResult.Matched[F, B](rem, trc, out.flatMap { o =>

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -95,6 +95,21 @@ trait Endpoint[F[_], A] { self =>
       final override def toString: String = self.toString
     }
 
+  final def mapF[B](fn: F[A] => F[B])(implicit F: Monad[F]): Endpoint[F, B] =
+    new Endpoint[F, B] {
+      def apply(input: Input): Result[F, B] =
+        self(input) match {
+          case EndpointResult.Matched(rem, trc, out) =>
+            EndpointResult.Matched[F, B](rem, trc, out.flatMap { o =>
+              o.traverse(a => fn(F.pure(a)))
+            })
+          case skipped: EndpointResult.NotMatched[F] => skipped
+        }
+
+      final override def item = self.item
+      final override def toString: String = self.toString
+    }
+
   /**
     * Maps this endpoint to the given function `A => Output[B]`.
     */
@@ -490,7 +505,7 @@ object Endpoint {
       self.map(value => gen.from(value :: HNil))
   }
 
-  implicit def endpointInstances[F[_] : Effect]: Alternative[({type T[B] = Endpoint[F, B]})#T] = {
+  implicit def endpointInstances[F[_] : Sync]: Alternative[({type T[B] = Endpoint[F, B]})#T] = {
     new Alternative[({type T[B] = Endpoint[F, B]})#T] {
 
       final override def ap[A, B](ff: Endpoint[F, A => B])(fa: Endpoint[F, A]): Endpoint[F, B] =
@@ -610,7 +625,7 @@ object Endpoint {
    * @see [[fromFile]]
    */
   def fromInputStream[F[_]](stream: Resource[F, InputStream])(
-    implicit F: Effect[F], S: ContextShift[F]
+    implicit F: Sync[F], S: ContextShift[F]
   ): Endpoint[F, Buf] = new FromInputStream[F](stream)
 
   /**
@@ -620,7 +635,7 @@ object Endpoint {
    * @see [[fromInputStream]]
    */
   def fromFile[F[_]](file: File)(
-    implicit F: Effect[F], S: ContextShift[F]
+    implicit F: Sync[F], S: ContextShift[F]
   ): Endpoint[F, Buf] =
     fromInputStream[F](
       Resource.fromAutoCloseable(F.delay(new FileInputStream(file)))
@@ -658,7 +673,7 @@ object Endpoint {
    * @see https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html
    */
   def classpathAsset[F[_]](path: String)(implicit
-    F: Effect[F],
+    F: Sync[F],
     S: ContextShift[F]
   ): Endpoint[F, Buf] = {
     val asset = new Asset[F](path)
@@ -684,7 +699,7 @@ object Endpoint {
    * }}}
    */
   def filesystemAsset[F[_]](path: String)(implicit
-    F: Effect[F],
+    F: Sync[F],
     S: ContextShift[F]
   ): Endpoint[F, Buf] = {
     val asset = new Asset[F](path)
@@ -696,7 +711,7 @@ object Endpoint {
   /**
    * A root [[Endpoint]] that always matches and extracts the current request.
    */
-  def root[F[_]](implicit F: Effect[F]): Endpoint[F, Request] =
+  def root[F[_]](implicit F: Sync[F]): Endpoint[F, Request] =
     new Endpoint[F, Request] {
       final def apply(input: Input): Result[F, Request] =
         EndpointResult.Matched(input, Trace.empty, F.delay(Output.payload(input.request)))
@@ -737,20 +752,20 @@ object Endpoint {
    * A matching [[Endpoint]] that reads a value of type `A` (using the implicit
    * [[DecodePath]] instances defined for `A`) from the current path segment.
    */
-  def path[F[_]: Effect, A: DecodePath: ClassTag]: Endpoint[F, A] =
+  def path[F[_]: Sync, A: DecodePath: ClassTag]: Endpoint[F, A] =
     new ExtractPath[F, A]
 
   /**
    * A matching [[Endpoint]] that reads a tail value `A` (using the implicit
    * [[DecodePath]] instances defined for `A`) from the entire path.
    */
-  def paths[F[_]: Effect, A: DecodePath: ClassTag]: Endpoint[F, List[A]] =
+  def paths[F[_]: Sync, A: DecodePath: ClassTag]: Endpoint[F, List[A]] =
     new ExtractPaths[F, A]
 
   /**
    * An [[Endpoint]] that matches a given string.
    */
-  def path[F[_]: Effect](s: String): Endpoint[F, HNil] =
+  def path[F[_]: Sync](s: String): Endpoint[F, HNil] =
     new MatchPath[F](s)
 
   /**
@@ -821,21 +836,21 @@ object Endpoint {
    * An evaluating [[Endpoint]] that reads a required HTTP header `name` from the request or raises
    * an [[Error.NotPresent]] exception when the header is missing.
    */
-  def header[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, A] =
+  def header[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, A] =
     new Header[F, Id, A](name) with Header.Required[F, A]
 
   /**
    * An evaluating [[Endpoint]] that reads an optional HTTP header `name` from the request into an
    * `Option`.
    */
-  def headerOption[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, Option[A]] =
+  def headerOption[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, Option[A]] =
     new Header[F, Option, A](name) with Header.Optional[F, A]
 
   /**
    * An evaluating [[Endpoint]] that reads a binary request body, interpreted as a `Array[Byte]`,
    * into an `Option`. The returned [[Endpoint]] only matches non-chunked (non-streamed) requests.
    */
-  def binaryBodyOption[F[_]: Effect]: Endpoint[F, Option[Array[Byte]]] =
+  def binaryBodyOption[F[_]: Sync]: Endpoint[F, Option[Array[Byte]]] =
     new BinaryBody[F, Option[Array[Byte]]] with FullBody.Optional[F, Array[Byte]]
 
   /**
@@ -843,14 +858,14 @@ object Endpoint {
    * `Array[Byte]`, or throws a [[Error.NotPresent]] exception. The returned [[Endpoint]] only
    * matches non-chunked (non-streamed) requests.
    */
-  def binaryBody[F[_]: Effect]: Endpoint[F, Array[Byte]] =
+  def binaryBody[F[_]: Sync]: Endpoint[F, Array[Byte]] =
     new BinaryBody[F, Array[Byte]] with FullBody.Required[F, Array[Byte]]
 
   /**
    * An evaluating [[Endpoint]] that reads an optional request body, interpreted as a `String`, into
    * an `Option`. The returned [[Endpoint]] only matches non-chunked (non-streamed) requests.
    */
-  def stringBodyOption[F[_]: Effect]: Endpoint[F, Option[String]] =
+  def stringBodyOption[F[_]: Sync]: Endpoint[F, Option[String]] =
     new StringBody[F, Option[String]] with FullBody.Optional[F, String]
 
   /**
@@ -858,7 +873,7 @@ object Endpoint {
    * throws an [[Error.NotPresent]] exception. The returned [[Endpoint]] only matches non-chunked
    * (non-streamed) requests.
    */
-  def stringBody[F[_]: Effect]: Endpoint[F, String] =
+  def stringBody[F[_]: Sync]: Endpoint[F, String] =
     new StringBody[F, String] with FullBody.Required[F, String]
 
   /**
@@ -866,7 +881,7 @@ object Endpoint {
    * interpreted as `A`, into an `Option`. The returned [[Endpoint]] only matches non-chunked
    * (non-streamed) requests.
    */
-  def bodyOption[F[_]: Effect, A: ClassTag, CT](implicit D: Decode.Dispatchable[A, CT]): Endpoint[F, Option[A]] =
+  def bodyOption[F[_]: Sync, A: ClassTag, CT](implicit D: Decode.Dispatchable[A, CT]): Endpoint[F, Option[A]] =
     new Body[F, A, Option[A], CT] with FullBody.Optional[F, A]
 
   /**
@@ -874,31 +889,31 @@ object Endpoint {
    * interpreted as `A`, or throws an [[Error.NotPresent]] exception. The returned [[Endpoint]]
    * only matches non-chunked (non-streamed) requests.
    */
-  def body[F[_]: Effect, A: ClassTag, CT](implicit d: Decode.Dispatchable[A, CT]): Endpoint[F, A] =
+  def body[F[_]: Sync, A: ClassTag, CT](implicit d: Decode.Dispatchable[A, CT]): Endpoint[F, A] =
     new Body[F, A, A, CT] with FullBody.Required[F, A]
 
   /**
    * Alias for `body[F, A, Application.Json]`.
    */
-  def jsonBody[F[_]: Effect, A: Decode.Json: ClassTag]: Endpoint[F, A] =
+  def jsonBody[F[_]: Sync, A: Decode.Json: ClassTag]: Endpoint[F, A] =
     body[F, A, Application.Json]
 
   /**
    * Alias for `bodyOption[F, A, Application.Json]`.
    */
-  def jsonBodyOption[F[_]: Effect, A: Decode.Json: ClassTag]: Endpoint[F, Option[A]] =
+  def jsonBodyOption[F[_]: Sync, A: Decode.Json: ClassTag]: Endpoint[F, Option[A]] =
     bodyOption[F, A, Application.Json]
 
   /**
    * Alias for `body[F, A, Text.Plain]`
    */
-  def textBody[F[_]: Effect, A: Decode.Text: ClassTag]: Endpoint[F, A] =
+  def textBody[F[_]: Sync, A: Decode.Text: ClassTag]: Endpoint[F, A] =
     body[F, A, Text.Plain]
 
   /**
    * Alias for `bodyOption[A, Text.Plain]`
    */
-  def textBodyOption[F[_]: Effect, A: Decode.Text: ClassTag]: Endpoint[F, Option[A]] =
+  def textBodyOption[F[_]: Sync, A: Decode.Text: ClassTag]: Endpoint[F, Option[A]] =
     bodyOption[F, A, Text.Plain]
 
   /**
@@ -913,7 +928,7 @@ object Endpoint {
    *   bin: Endpoint[IO, Enumerator[IO, Array[Byte]]] = binaryBodyStream
    * }}}
    */
-  def binaryBodyStream[F[_]: Effect, S[_[_], _]](implicit
+  def binaryBodyStream[F[_]: Sync, S[_[_], _]](implicit
     LR: LiftReader[S, F]
   ): Endpoint[F, S[F, Array[Byte]]] = new BinaryBodyStream[F, S]
 
@@ -929,7 +944,7 @@ object Endpoint {
    *   bin: Endpoint[IO, Enumerator[IO, String]] = stringBodyStream
    * }}}
    */
-  def stringBodyStream[F[_]: Effect, S[_[_], _]](implicit
+  def stringBodyStream[F[_]: Sync, S[_[_], _]](implicit
     LR: LiftReader[S, F]
   ): Endpoint[F, S[F, String]] = new StringBodyStream[F, S]
 
@@ -951,7 +966,7 @@ object Endpoint {
    *   bin: Endpoint[IO, Enumerator[IO, Foo]] = bodyStream
    * }}}
    */
-  def bodyStream[F[_]: Effect, S[_[_], _], A, CT <: String](implicit
+  def bodyStream[F[_]: Sync, S[_[_], _], A, CT <: String](implicit
     LR: LiftReader[S, F],
     A: DecodeStream.Aux[S, F, A, CT]
   ): Endpoint[F, S[F, A]] = new BodyStream[F, S, A, CT]
@@ -959,7 +974,7 @@ object Endpoint {
   /**
    * See [[bodyStream]]. This is just an alias for `bodyStream[?, ?, Application.Json]`.
    */
-  def jsonBodyStream[F[_]: Effect, S[_[_], _], A](implicit
+  def jsonBodyStream[F[_]: Sync, S[_[_], _], A](implicit
     LR: LiftReader[S, F],
     A: DecodeStream.Aux[S, F, A, Application.Json]
   ) : Endpoint[F, S[F, A]] = bodyStream[F, S, A, Application.Json]
@@ -967,7 +982,7 @@ object Endpoint {
   /**
    * See [[bodyStream]]. This is just an alias for `bodyStream[?, ?, Text.Plain]`.
    */
-  def textBodyStream[F[_]: Effect, S[_[_], _], A](implicit
+  def textBodyStream[F[_]: Sync, S[_[_], _], A](implicit
     LR: LiftReader[S, F],
     A: DecodeStream.Aux[S, F, A, Text.Plain]
   ): Endpoint[F, S[F, A]] = bodyStream[F, S, A, Text.Plain]
@@ -976,21 +991,21 @@ object Endpoint {
    * An evaluating [[Endpoint]] that reads an optional HTTP cookie from the request into an
    * `Option`.
    */
-  def cookieOption[F[_]: Effect](name: String): Endpoint[F, Option[FinagleCookie]] =
+  def cookieOption[F[_]: Sync](name: String): Endpoint[F, Option[FinagleCookie]] =
     new Cookie[F, Option[FinagleCookie]](name) with Cookie.Optional[F]
 
   /**
    * An evaluating [[Endpoint]] that reads a required cookie from the request or raises an
    * [[Error.NotPresent]] exception when the cookie is missing.
    */
-  def cookie[F[_]: Effect](name: String): Endpoint[F, FinagleCookie] =
+  def cookie[F[_]: Sync](name: String): Endpoint[F, FinagleCookie] =
     new Cookie[F, FinagleCookie](name) with Cookie.Required[F]
 
   /**
    * An evaluating [[Endpoint]] that reads an optional query-string param `name` from the request
    * into an `Option`.
    */
-  def paramOption[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, Option[A]] =
+  def paramOption[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, Option[A]] =
     new Param[F, Option, A](name) with Param.Optional[F, A]
 
   /**
@@ -998,14 +1013,14 @@ object Endpoint {
    * request or raises an [[Error.NotPresent]] exception when the param is missing; an
    * [[Error.NotValid]] exception is the param is empty.
    */
-  def param[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, A] =
+  def param[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, A] =
     new Param[F, Id, A](name) with Param.Required[F, A]
 
   /**
    * An evaluating [[Endpoint]] that reads an optional (in a meaning that a resulting
    * `Seq` may be empty) multi-value query-string param `name` from the request into a `Seq`.
    */
-  def params[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, List[A]] =
+  def params[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, List[A]] =
     new Params[F, List, A](name) with Params.AllowEmpty[F, A]
 
   /**
@@ -1013,62 +1028,62 @@ object Endpoint {
    * from the request into a `NonEmptyList` or raises a [[Error.NotPresent]] exception
    * when the params are missing or empty.
    */
-  def paramsNel[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, NonEmptyList[A]] =
+  def paramsNel[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, NonEmptyList[A]] =
     new Params[F, NonEmptyList, A](name) with Params.NonEmpty[F, A]
 
   /**
    * An evaluating [[Endpoint]] that reads an optional file upload from a `multipart/form-data`
    * request into an `Option`.
    */
-  def multipartFileUploadOption[F[_]: Effect](name: String): Endpoint[F, Option[FinagleMultipart.FileUpload]] =
+  def multipartFileUploadOption[F[_]: Sync](name: String): Endpoint[F, Option[FinagleMultipart.FileUpload]] =
     new FileUpload[F, Option](name) with FileUpload.Optional[F]
 
   /**
    * An evaluating [[Endpoint]] that reads a required file upload from a `multipart/form-data`
    * request.
    */
-  def multipartFileUpload[F[_]: Effect](name: String): Endpoint[F, FinagleMultipart.FileUpload] =
+  def multipartFileUpload[F[_]: Sync](name: String): Endpoint[F, FinagleMultipart.FileUpload] =
     new FileUpload[F, Id](name) with FileUpload.Required[F]
 
   /**
    * An evaluating [[Endpoint]] that optionally reads multiple file uploads from a
    * `multipart/form-data` request.
    */
-  def multipartFileUploads[F[_]: Effect](name: String): Endpoint[F, List[FinagleMultipart.FileUpload]] =
+  def multipartFileUploads[F[_]: Sync](name: String): Endpoint[F, List[FinagleMultipart.FileUpload]] =
     new FileUpload[F, List](name) with FileUpload.AllowEmpty[F]
 
   /**
    * An evaluating [[Endpoint]] that requires multiple file uploads from a `multipart/form-data`
    * request.
    */
-  def multipartFileUploadsNel[F[_]: Effect](name: String): Endpoint[F, NonEmptyList[FinagleMultipart.FileUpload]] =
+  def multipartFileUploadsNel[F[_]: Sync](name: String): Endpoint[F, NonEmptyList[FinagleMultipart.FileUpload]] =
     new FileUpload[F, NonEmptyList](name) with FileUpload.NonEmpty[F]
 
   /**
    * An evaluating [[Endpoint]] that reads a required attribute from a `multipart/form-data`
    * request.
    */
-  def multipartAttribute[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, A] =
+  def multipartAttribute[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, A] =
     new Attribute[F, Id, A](name) with Attribute.Required[F, A] with Attribute.SingleError[F, Id, A]
 
   /**
    * An evaluating [[Endpoint]] that reads an optional attribute from a `multipart/form-data`
    * request.
    */
-  def multipartAttributeOption[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, Option[A]] =
+  def multipartAttributeOption[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, Option[A]] =
     new Attribute[F, Option, A](name) with Attribute.Optional[F, A] with Attribute.SingleError[F, Option, A]
 
   /**
    * An evaluating [[Endpoint]] that reads a required attribute from a `multipart/form-data`
    * request.
    */
-  def multipartAttributes[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, List[A]] =
+  def multipartAttributes[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, List[A]] =
     new Attribute[F, List, A](name) with Attribute.AllowEmpty[F, A] with Attribute.MultipleErrors[F, List, A]
 
   /**
    * An evaluating [[Endpoint]] that reads a required attribute from a `multipart/form-data`
    * request.
    */
-  def multipartAttributesNel[F[_]: Effect, A: DecodeEntity: ClassTag](name: String): Endpoint[F, NonEmptyList[A]] =
+  def multipartAttributesNel[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, NonEmptyList[A]] =
     new Attribute[F, NonEmptyList, A](name) with Attribute.NonEmpty[F, A] with Attribute.MultipleErrors[F, NonEmptyList, A]
 }

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -95,6 +95,9 @@ trait Endpoint[F[_], A] { self =>
       final override def toString: String = self.toString
     }
 
+  /**
+    * Maps this endpoint to the given function `F[A] => F[B]`
+    */
   final def mapF[B](fn: F[A] => F[B])(implicit F: Monad[F]): Endpoint[F, B] =
     new Endpoint[F, B] {
       def apply(input: Input): Endpoint.Result[F, B] =

--- a/core/src/main/scala/io/finch/EndpointModule.scala
+++ b/core/src/main/scala/io/finch/EndpointModule.scala
@@ -2,7 +2,7 @@ package io.finch
 
 import cats.Applicative
 import cats.data.NonEmptyList
-import cats.effect.{ContextShift, Effect, Resource, Sync}
+import cats.effect.{ContextShift, Resource, Sync}
 import com.twitter.finagle.http.{Cookie, Request}
 import com.twitter.finagle.http.exp.Multipart
 import com.twitter.io.Buf
@@ -99,7 +99,7 @@ trait EndpointModule[F[_]] {
    * An alias for [[Endpoint.fromInputStream]].
    */
   def fromInputStream(stream: Resource[F, InputStream])(
-    implicit F: Effect[F], S: ContextShift[F]
+    implicit F: Sync[F], S: ContextShift[F]
   ): Endpoint[F, Buf] =
     Endpoint.fromInputStream[F](stream)
 
@@ -107,26 +107,26 @@ trait EndpointModule[F[_]] {
    * An alias for [[Endpoint.fromFile]].
    */
   def fromFile(file: File)(
-    implicit F: Effect[F], S: ContextShift[F]
+    implicit F: Sync[F], S: ContextShift[F]
   ): Endpoint[F, Buf] =
     Endpoint.fromFile[F](file)
 
   /**
    * An alias for [[Endpoint.classpathAsset]].
    */
-  def classpathAsset(path: String)(implicit F: Effect[F], S: ContextShift[F]): Endpoint[F, Buf] =
+  def classpathAsset(path: String)(implicit F: Sync[F], S: ContextShift[F]): Endpoint[F, Buf] =
     Endpoint.classpathAsset[F](path)
 
   /**
    * An alias for [[Endpoint.classpathAsset]].
    */
-  def filesystemAsset(path: String)(implicit F: Effect[F], S: ContextShift[F]): Endpoint[F, Buf] =
+  def filesystemAsset(path: String)(implicit F: Sync[F], S: ContextShift[F]): Endpoint[F, Buf] =
     Endpoint.filesystemAsset[F](path)
 
   /**
    * An alias for [[Endpoint.root]].
    */
-  def root(implicit F: Effect[F]): Endpoint[F, Request] =
+  def root(implicit F: Sync[F]): Endpoint[F, Request] =
     Endpoint.root[F]
 
   /**
@@ -144,13 +144,13 @@ trait EndpointModule[F[_]] {
   /**
    * An alias for [[Endpoint.path]].
    */
-  def path[A: DecodePath: ClassTag](implicit F: Effect[F]): Endpoint[F, A] =
+  def path[A: DecodePath: ClassTag](implicit F: Sync[F]): Endpoint[F, A] =
     Endpoint.path[F, A]
 
   /**
    * An alias for [[Endpoint.paths]].
    */
-  def paths[A: DecodePath: ClassTag](implicit F: Effect[F]): Endpoint[F, List[A]] =
+  def paths[A: DecodePath: ClassTag](implicit F: Sync[F]): Endpoint[F, List[A]] =
     Endpoint.paths[F, A]
 
   /**
@@ -159,7 +159,7 @@ trait EndpointModule[F[_]] {
    * @note This method is implicit such that an implicit conversion `String => Endpoint[F, HNil]`
    *       works.
    */
-  implicit def path(s: String)(implicit F: Effect[F]): Endpoint[F, HNil] =
+  implicit def path(s: String)(implicit F: Sync[F]): Endpoint[F, HNil] =
     Endpoint.path[F](s)
 
   /**
@@ -213,80 +213,80 @@ trait EndpointModule[F[_]] {
   /**
    * An alias for [[Endpoint.header]].
    */
-  def header[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, A] =
+  def header[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, A] =
     Endpoint.header[F, A](name)
 
   /**
    * An alias for [[Endpoint.headerOption]].
    */
-  def headerOption[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, Option[A]] =
+  def headerOption[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, Option[A]] =
     Endpoint.headerOption[F, A](name)
 
   /**
    * An alias for [[Endpoint.binaryBodyOption]].
    */
-  def binaryBodyOption(implicit F: Effect[F]): Endpoint[F, Option[Array[Byte]]] =
+  def binaryBodyOption(implicit F: Sync[F]): Endpoint[F, Option[Array[Byte]]] =
     Endpoint.binaryBodyOption[F]
 
   /**
    * An alias for [[Endpoint.binaryBody]].
    */
-  def binaryBody(implicit F: Effect[F]): Endpoint[F, Array[Byte]] =
+  def binaryBody(implicit F: Sync[F]): Endpoint[F, Array[Byte]] =
     Endpoint.binaryBody[F]
 
   /**
    * An alias for [[Endpoint.stringBodyOption]].
    */
-  def stringBodyOption(implicit F: Effect[F]): Endpoint[F, Option[String]] =
+  def stringBodyOption(implicit F: Sync[F]): Endpoint[F, Option[String]] =
     Endpoint.stringBodyOption[F]
 
   /**
    * An alias for [[Endpoint.stringBody]].
    */
-  def stringBody(implicit F: Effect[F]): Endpoint[F, String] =
+  def stringBody(implicit F: Sync[F]): Endpoint[F, String] =
     Endpoint.stringBody[F]
 
   /**
    * An alias for [[Endpoint.bodyOption]].
    */
-  def bodyOption[A: ClassTag, CT](implicit F: Effect[F], D: Decode.Dispatchable[A, CT]): Endpoint[F, Option[A]] =
+  def bodyOption[A: ClassTag, CT](implicit F: Sync[F], D: Decode.Dispatchable[A, CT]): Endpoint[F, Option[A]] =
     Endpoint.bodyOption[F, A, CT]
 
   /**
    * An alias for [[Endpoint.body]].
    */
-  def body[A: ClassTag, CT](implicit D: Decode.Dispatchable[A, CT], F: Effect[F]): Endpoint[F, A] =
+  def body[A: ClassTag, CT](implicit D: Decode.Dispatchable[A, CT], F: Sync[F]): Endpoint[F, A] =
     Endpoint.body[F, A, CT]
 
   /**
    * An alias for [[Endpoint.jsonBody]].
    */
-  def jsonBody[A: Decode.Json: ClassTag](implicit F: Effect[F]): Endpoint[F, A] =
+  def jsonBody[A: Decode.Json: ClassTag](implicit F: Sync[F]): Endpoint[F, A] =
     Endpoint.jsonBody[F, A]
 
   /**
    * An alias for [[Endpoint.jsonBodyOption]].
    */
-  def jsonBodyOption[A: Decode.Json: ClassTag](implicit F: Effect[F]): Endpoint[F, Option[A]] =
+  def jsonBodyOption[A: Decode.Json: ClassTag](implicit F: Sync[F]): Endpoint[F, Option[A]] =
     Endpoint.jsonBodyOption[F, A]
 
   /**
    * An alias for [[Endpoint.textBody]].
    */
-  def textBody[A: Decode.Text: ClassTag](implicit F: Effect[F]): Endpoint[F, A] =
+  def textBody[A: Decode.Text: ClassTag](implicit F: Sync[F]): Endpoint[F, A] =
     Endpoint.textBody[F, A]
 
   /**
    * An alias for [[Endpoint.textBodyOption]].
    */
-  def textBodyOption[A: Decode.Text: ClassTag](implicit F: Effect[F]): Endpoint[F, Option[A]] =
+  def textBodyOption[A: Decode.Text: ClassTag](implicit F: Sync[F]): Endpoint[F, Option[A]] =
     Endpoint.textBodyOption[F, A]
 
   /**
    * An alias for [[Endpoint.binaryBodyStream]].
    */
   def binaryBodyStream[S[_[_], _]](implicit
-    F: Effect[F],
+    F: Sync[F],
     LR: LiftReader[S, F]
   ): Endpoint[F, S[F, Array[Byte]]] = Endpoint.binaryBodyStream[F, S]
 
@@ -294,7 +294,7 @@ trait EndpointModule[F[_]] {
    * An alias for [[Endpoint.stringBodyStream]].
    */
   def stringBodyStream[S[_[_], _]](implicit
-    F: Effect[F],
+    F: Sync[F],
     LR: LiftReader[S, F]
   ): Endpoint[F, S[F, String]] = Endpoint.stringBodyStream[F, S]
 
@@ -302,7 +302,7 @@ trait EndpointModule[F[_]] {
    * An alias for [[Endpoint.bodyStream]].
    */
   def bodyStream[S[_[_], _], A, CT <: String](implicit
-    F: Effect[F],
+    F: Sync[F],
     LR: LiftReader[S, F],
     A: DecodeStream.Aux[S, F, A, CT]
   ): Endpoint[F, S[F, A]] = Endpoint.bodyStream[F, S, A, CT]
@@ -311,7 +311,7 @@ trait EndpointModule[F[_]] {
    * An alias for [[Endpoint.jsonBodyStream]].
    */
   def jsonBodyStream[S[_[_], _], A](implicit
-    F: Effect[F],
+    F: Sync[F],
     LR: LiftReader[S, F],
     A: DecodeStream.Aux[S, F, A, Application.Json]
   ): Endpoint[F, S[F, A]] = Endpoint.jsonBodyStream[F, S, A]
@@ -320,7 +320,7 @@ trait EndpointModule[F[_]] {
    * An alias for [[Endpoint.textBodyStream]].
    */
   def textBodyStream[S[_[_], _], A](implicit
-    F: Effect[F],
+    F: Sync[F],
     LR: LiftReader[S, F],
     A: DecodeStream.Aux[S, F, A, Text.Plain]
   ): Endpoint[F, S[F, A]] = Endpoint.textBodyStream[F, S, A]
@@ -328,85 +328,85 @@ trait EndpointModule[F[_]] {
   /**
    * An alias for [[Endpoint.cookieOption]].
    */
-  def cookieOption(name: String)(implicit F: Effect[F]): Endpoint[F, Option[Cookie]] =
+  def cookieOption(name: String)(implicit F: Sync[F]): Endpoint[F, Option[Cookie]] =
     Endpoint.cookieOption[F](name)
 
   /**
    * An alias for [[Endpoint.cookie]].
    */
-  def cookie(name: String)(implicit F: Effect[F]): Endpoint[F, Cookie] =
+  def cookie(name: String)(implicit F: Sync[F]): Endpoint[F, Cookie] =
     Endpoint.cookie[F](name)
 
   /**
    * An alias for [[Endpoint.paramOption]].
    */
-  def paramOption[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, Option[A]] =
+  def paramOption[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, Option[A]] =
     Endpoint.paramOption[F, A](name)
 
   /**
    * An alias for [[Endpoint.param]].
    */
-  def param[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, A] =
+  def param[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, A] =
     Endpoint.param[F, A](name)
 
   /**
    * An alias for [[Endpoint.params]].
    */
-  def params[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, List[A]] =
+  def params[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, List[A]] =
     Endpoint.params[F, A](name)
 
   /**
    * An alias for [[Endpoint.paramsNel]].
    */
-  def paramsNel[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, NonEmptyList[A]] =
+  def paramsNel[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, NonEmptyList[A]] =
     Endpoint.paramsNel[F, A](name)
 
   /**
    * An alias for [[Endpoint.multipartFileUploadOption]].
    */
-  def multipartFileUploadOption(name: String)(implicit F: Effect[F]): Endpoint[F, Option[Multipart.FileUpload]] =
+  def multipartFileUploadOption(name: String)(implicit F: Sync[F]): Endpoint[F, Option[Multipart.FileUpload]] =
     Endpoint.multipartFileUploadOption[F](name)
 
   /**
    * An alias for [[Endpoint.multipartFileUpload]].
    */
-  def multipartFileUpload(name: String)(implicit F: Effect[F]): Endpoint[F, Multipart.FileUpload] =
+  def multipartFileUpload(name: String)(implicit F: Sync[F]): Endpoint[F, Multipart.FileUpload] =
     Endpoint.multipartFileUpload[F](name)
 
   /**
    * An alias for [[Endpoint.multipartFileUploads]].
    */
-  def multipartFileUploads(name: String)(implicit F: Effect[F]): Endpoint[F, List[Multipart.FileUpload]] =
+  def multipartFileUploads(name: String)(implicit F: Sync[F]): Endpoint[F, List[Multipart.FileUpload]] =
     Endpoint.multipartFileUploads[F](name)
 
   /**
    * An alias for [[Endpoint.multipartFileUploadsNel]].
    */
-  def multipartFileUploadsNel(name: String)(implicit F: Effect[F]): Endpoint[F, NonEmptyList[Multipart.FileUpload]] =
+  def multipartFileUploadsNel(name: String)(implicit F: Sync[F]): Endpoint[F, NonEmptyList[Multipart.FileUpload]] =
     Endpoint.multipartFileUploadsNel[F](name)
 
   /**
    * An alias for [[Endpoint.multipartAttribute]].
    */
-  def multipartAttribute[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, A] =
+  def multipartAttribute[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, A] =
     Endpoint.multipartAttribute[F, A](name)
 
   /**
    * An alias for [[Endpoint.multipartAttributeOption]].
    */
-  def multipartAttributeOption[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, Option[A]] =
+  def multipartAttributeOption[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, Option[A]] =
     Endpoint.multipartAttributeOption[F, A](name)
 
   /**
    * An alias for [[Endpoint.multipartAttributes]].
    */
-  def multipartAttributes[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, List[A]] =
+  def multipartAttributes[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, List[A]] =
     Endpoint.multipartAttributes[F, A](name)
 
   /**
    * An alias for [[Endpoint.multipartAttributesNel]].
    */
-  def multipartAttributesNel[A: DecodeEntity: ClassTag](name: String)(implicit F: Effect[F]): Endpoint[F, NonEmptyList[A]] =
+  def multipartAttributesNel[A: DecodeEntity: ClassTag](name: String)(implicit F: Sync[F]): Endpoint[F, NonEmptyList[A]] =
     Endpoint.multipartAttributesNel[F, A](name)
 }
 

--- a/core/src/main/scala/io/finch/endpoint/cookie.scala
+++ b/core/src/main/scala/io/finch/endpoint/cookie.scala
@@ -1,11 +1,11 @@
 package io.finch.endpoint
 
-import cats.effect.Effect
+import cats.effect.Sync
 import com.twitter.finagle.http.{Cookie => FinagleCookie}
 import io.finch._
 
 private[finch] abstract class Cookie[F[_], A](name: String)(implicit
-  protected val F: Effect[F]
+  protected val F: Sync[F]
 ) extends Endpoint[F, A] {
 
   protected def missing(name: String): F[Output[A]]

--- a/core/src/main/scala/io/finch/endpoint/endpoint.scala
+++ b/core/src/main/scala/io/finch/endpoint/endpoint.scala
@@ -1,6 +1,7 @@
 package io.finch
 
-import cats.effect.{ContextShift, Effect, Resource}
+import cats.Applicative
+import cats.effect.{ContextShift, Resource, Sync}
 import cats.syntax.all._
 import com.twitter.finagle.http.{Method => FinagleMethod}
 import com.twitter.io.Buf
@@ -10,7 +11,7 @@ import shapeless.HNil
 package object endpoint {
 
   private[finch] class FromInputStream[F[_]](stream: Resource[F, InputStream])(
-    implicit F: Effect[F], S: ContextShift[F]
+    implicit F: Sync[F], S: ContextShift[F]
   ) extends Endpoint[F, Buf] {
 
     private def readLoop(left: Buf, stream: InputStream): F[Buf] = F.suspend {
@@ -30,7 +31,7 @@ package object endpoint {
       )
   }
 
-  private[finch] class Asset[F[_]](path: String)(implicit F: Effect[F]) extends Endpoint[F, HNil] {
+  private[finch] class Asset[F[_]](path: String)(implicit F: Applicative[F]) extends Endpoint[F, HNil] {
     final def apply(input: Input): Endpoint.Result[F, HNil] = {
       val req = input.request
       if (req.method != FinagleMethod.Get || req.path != path) EndpointResult.NotMatched[F]

--- a/core/src/main/scala/io/finch/endpoint/header.scala
+++ b/core/src/main/scala/io/finch/endpoint/header.scala
@@ -1,7 +1,7 @@
 package io.finch.endpoint
 
 import cats.Id
-import cats.effect.Effect
+import cats.effect.Sync
 import io.finch._
 import io.finch.items._
 import scala.reflect.ClassTag
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 private[finch] abstract class Header[F[_], G[_], A](name: String)(implicit
   d: DecodeEntity[A],
   tag: ClassTag[A],
-  protected val F: Effect[F]
+  protected val F: Sync[F]
 ) extends Endpoint[F, G[A]] { self =>
 
   protected def missing(name: String): F[Output[G[A]]]

--- a/core/src/main/scala/io/finch/endpoint/param.scala
+++ b/core/src/main/scala/io/finch/endpoint/param.scala
@@ -2,14 +2,14 @@ package io.finch.endpoint
 
 import cats.Id
 import cats.data.NonEmptyList
-import cats.effect.Effect
+import cats.effect.Sync
 import io.finch._
 import scala.reflect.ClassTag
 
 private[finch] abstract class Param[F[_], G[_], A](name: String)(implicit
   d: DecodeEntity[A],
   tag: ClassTag[A],
-  protected val F: Effect[F]
+  protected val F: Sync[F]
 ) extends Endpoint[F, G[A]] { self =>
 
   protected def missing(name: String): F[Output[G[A]]]
@@ -50,7 +50,7 @@ private[finch] object Param {
 private[finch] abstract class Params[F[_], G[_], A](name: String)(implicit
   d: DecodeEntity[A],
   tag: ClassTag[A],
-  protected val F: Effect[F]
+  protected val F: Sync[F]
 ) extends Endpoint[F, G[A]] {
 
   protected def missing(name: String): F[Output[G[A]]]

--- a/core/src/main/scala/io/finch/endpoint/path.scala
+++ b/core/src/main/scala/io/finch/endpoint/path.scala
@@ -1,13 +1,13 @@
 package io.finch.endpoint
 
-import cats.effect.Effect
+import cats.Applicative
 import io.finch._
 import io.netty.handler.codec.http.QueryStringDecoder
 import scala.reflect.ClassTag
 import shapeless.HNil
 
 private[finch] class MatchPath[F[_]](s: String)(implicit
-  F: Effect[F]
+  F: Applicative[F]
 ) extends Endpoint[F, HNil] {
   final def apply(input: Input): EndpointResult[F, HNil] = input.route match {
     case `s` :: rest =>
@@ -25,7 +25,7 @@ private[finch] class MatchPath[F[_]](s: String)(implicit
 private[finch] class ExtractPath[F[_], A](implicit
   d: DecodePath[A],
   ct: ClassTag[A],
-  F: Effect[F]
+  F: Applicative[F]
 ) extends Endpoint[F, A] {
   final def apply(input: Input): EndpointResult[F, A] = input.route match {
     case s :: rest => d(QueryStringDecoder.decodeComponent(s)) match {
@@ -46,7 +46,7 @@ private[finch] class ExtractPath[F[_], A](implicit
 private[finch] class ExtractPaths[F[_], A](implicit
   d: DecodePath[A],
   ct: ClassTag[A],
-  F: Effect[F]
+  F: Applicative[F]
 ) extends Endpoint[F, List[A]] {
   final def apply(input: Input): EndpointResult[F, List[A]] = EndpointResult.Matched(
     input.copy(route = Nil),

--- a/core/src/main/scala/io/finch/internal/Mapper.scala
+++ b/core/src/main/scala/io/finch/internal/Mapper.scala
@@ -1,7 +1,7 @@
 package io.finch.internal
 
 import cats.Monad
-import cats.effect.Effect
+import cats.effect.Async
 import cats.syntax.functor._
 import com.twitter.finagle.http.Response
 import io.finch.{Endpoint, Output}
@@ -76,35 +76,35 @@ private[finch] trait HighPriorityMapperConversions extends LowPriorityMapperConv
   implicit def mapperFromResponseValue[F[_] : Monad](r: => Response): Mapper.Aux[F, HNil, Response] =
     instance(_.mapOutput(_ => Output.payload(r, r.status)))
 
-  implicit def mapperFromKindToEffectOutputFunction[A, B, F[_], G[_]: Effect](f: A => F[Output[B]])(
-    implicit conv: ToEffect[F, G]): Mapper.Aux[G, A, B] =
+  implicit def mapperFromKindToEffectOutputFunction[A, B, F[_], G[_]: Async](f: A => F[Output[B]])(
+    implicit conv: ToAsync[F, G]): Mapper.Aux[G, A, B] =
     instance(_.mapOutputAsync(a => conv.apply(f(a))))
 
-  implicit def mapperFromKindToEffectOutputValue[A, B, F[_], G[_]: Effect](f: => F[Output[B]])(
-    implicit conv: ToEffect[F, G]): Mapper.Aux[G, A, B] = instance(_.mapOutputAsync(a => conv.apply(f)))
+  implicit def mapperFromKindToEffectOutputValue[A, B, F[_], G[_]: Async](f: => F[Output[B]])(
+    implicit conv: ToAsync[F, G]): Mapper.Aux[G, A, B] = instance(_.mapOutputAsync(a => conv.apply(f)))
 
-  implicit def mapperFromKindToEffectResponsFunction[A, F[_], G[_]: Effect](f: A => F[Response])(
-    implicit conv: ToEffect[F, G]): Mapper.Aux[G, A, Response] =
+  implicit def mapperFromKindToEffectResponsFunction[A, F[_], G[_]: Async](f: A => F[Response])(
+    implicit conv: ToAsync[F, G]): Mapper.Aux[G, A, Response] =
     instance(_.mapOutputAsync(f.andThen(fr => conv(fr).map(r => Output.payload(r, r.status)))))
 
-  implicit def mapperFromKindToEffectResponseValue[A, F[_], G[_]: Effect](f: => F[Response])(
-    implicit conv: ToEffect[F, G]): Mapper.Aux[G, A, Response] =
+  implicit def mapperFromKindToEffectResponseValue[A, F[_], G[_]: Async](f: => F[Response])(
+    implicit conv: ToAsync[F, G]): Mapper.Aux[G, A, Response] =
     instance(_.mapOutputAsync(_=>conv(f).map(r => Output.payload(r, r.status))))
 }
 
 object Mapper extends HighPriorityMapperConversions {
 
-  implicit def mapperFromKindOutputHFunction[F[_]: Effect, G[_], A, B, FN, FOB](f: FN)(implicit
+  implicit def mapperFromKindOutputHFunction[F[_]: Async, G[_], A, B, FN, FOB](f: FN)(implicit
     ftp: FnToProduct.Aux[FN, A => FOB],
     ev: FOB <:< G[Output[B]],
-    conv: ToEffect[G, F]
+    conv: ToAsync[G, F]
   ): Mapper.Aux[F, A, B] =
     instance(_.mapOutputAsync(a => conv.apply(ev(ftp(f)(a)))))
 
-  implicit def mapperFromKindResponseHFunction[F[_] : Effect, G[_], A, FN, FR](f: FN)(implicit
+  implicit def mapperFromKindResponseHFunction[F[_] : Async, G[_], A, FN, FR](f: FN)(implicit
     ftp: FnToProduct.Aux[FN, A => FR],
     ev: FR <:< G[Response],
-    conv: ToEffect[G, F]
+    conv: ToAsync[G, F]
   ): Mapper.Aux[F, A, Response] = instance(_.mapOutputAsync { value =>
     val fr = conv(ev(ftp(f)(value)))
     fr.map(r => Output.payload(r, r.status))

--- a/core/src/main/scala/io/finch/package.scala
+++ b/core/src/main/scala/io/finch/package.scala
@@ -8,7 +8,7 @@ import cats.effect.IO
   */
 package object finch extends Outputs with ValidationRules {
 
-  type ToEffect[F[_], E[_]] = internal.ToEffect[F, E]
+  type ToAsync[F[_], E[_]] = internal.ToAsync[F, E]
 
   object catsEffect extends EndpointModule[IO]
 

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -5,6 +5,8 @@ import java.util.concurrent.TimeUnit
 
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
+import cats.laws._
+import cats.laws.discipline._
 import cats.laws.discipline.AlternativeTests
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import com.twitter.finagle.http.{Cookie, Method, Request}
@@ -36,6 +38,13 @@ class EndpointSpec extends FinchSpec {
   it should "support very basic map" in {
     check { i: Input =>
       path[String].map(_ * 2).apply(i).awaitValueUnsafe() === i.route.headOption.map(_ * 2)
+    }
+  }
+
+  it should "correctly run mapF" in {
+    check { e: Endpoint[IO, String] =>
+      val fn: String => Int = _.length
+      e.mapF(_.map(fn)) <-> e.map(fn)
     }
   }
 

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -44,7 +44,7 @@ class EndpointSpec extends FinchSpec {
   it should "correctly run mapF" in {
     check { e: Endpoint[IO, String] =>
       val fn: String => Int = _.length
-      e.mapF(_.map(fn)) <-> e.map(fn)
+      e.transformF(_.map(fn)) <-> e.map(fn)
     }
   }
 

--- a/core/src/test/scala/io/finch/MethodSpec.scala
+++ b/core/src/test/scala/io/finch/MethodSpec.scala
@@ -122,7 +122,7 @@ class MethodSpec
 
   case class Program[A](value: A)
 
-  implicit val conv = new ToEffect[Program,IO] {
+  implicit val conv = new ToAsync[Program,IO] {
     def apply[A](a: Program[A]): IO[A] = IO(a.value)
   }
 

--- a/core/src/test/scala/io/finch/internal/ToEffectLaws.scala
+++ b/core/src/test/scala/io/finch/internal/ToEffectLaws.scala
@@ -14,7 +14,7 @@ abstract trait ToEffectLaws[F[_], G[_], A] extends Laws with MissingInstances wi
   def G: Applicative[G]
   def extract: G[A] => A
 
-  def T: ToEffect[F, G]
+  def T: ToAsync[F, G]
 
   def nTransformation(f: => F[A], g: G[A], fn: A => A): IsEq[A] = {
     extract(G.map(T(f))(fn)) <-> extract(T(F.map(f)(fn)))
@@ -31,12 +31,12 @@ abstract trait ToEffectLaws[F[_], G[_], A] extends Laws with MissingInstances wi
 object ToEffectLaws {
 
   def apply[F[_] : Applicative, G[_] : Applicative, A](e: G[A] => A)(implicit
-    t: ToEffect[F, G]
+    t: ToAsync[F, G]
   ): ToEffectLaws[F, G, A] =
     new ToEffectLaws[F, G, A] {
       val F: Applicative[F] = implicitly[Applicative[F]]
       val G: Applicative[G] = implicitly[Applicative[G]]
-      val T: ToEffect[F, G] = t
+      val T: ToAsync[F, G] = t
       val extract: G[A] => A = e
     }
 

--- a/examples/src/main/scala/io/finch/iteratee/Main.scala
+++ b/examples/src/main/scala/io/finch/iteratee/Main.scala
@@ -73,7 +73,7 @@ object Main extends IOApp {
 
   def run(args: List[String]): IO[ExitCode] = {
     val server = Resource.make(serve)(s =>
-      IO.suspend(implicitly[ToEffect[Future, IO]].apply(s.close()))
+      IO.suspend(implicitly[ToAsync[Future, IO]].apply(s.close()))
     )
 
     server.use(_ => IO.never).as(ExitCode.Success)

--- a/fs2/src/main/scala/io/finch/fs2/package.scala
+++ b/fs2/src/main/scala/io/finch/fs2/package.scala
@@ -11,7 +11,7 @@ package object fs2 extends StreamInstances {
 
   implicit def streamLiftReader[F[_]](implicit
     F: Effect[F],
-    TE: ToEffect[Future, F]
+    TE: ToAsync[Future, F]
   ): LiftReader[Stream, F] =
     new LiftReader[Stream, F] {
       final def apply[A](reader: Reader[Buf], process: Buf => A): Stream[F, A] = {
@@ -52,7 +52,7 @@ trait StreamInstances {
 
   protected abstract class EncodeFs2Stream[F[_], A, CT <: String](implicit
     F: Effect[F],
-    TE: ToEffect[Future, F]
+    TE: ToAsync[Future, F]
   ) extends EncodeStream[F, Stream, A] with (Either[Throwable, Unit] => IO[Unit]) {
 
     type ContentType = CT


### PR DESCRIPTION
- Replace `Effect` type class boundaries with the least powerful one wherever it's possible. Mostly with `Sync`/`Async`
- Introduce `Endpoint.transformF` for `F[A] => F[B]` transformation, similar to `Kleisli.mapF`

In combination, those two changes open very promising doors together with `Endpoint.Compiled[F]`.

As an example, there is no `Effect` instance for `StateT` monad but there is one available for `Async`. Shortly speaking, it allows to maintain state over the Kleisli compositions of compiled Endpoint, so it piggybacks on top of `F[_]`. Instead of abusing `Request.ctx` users would be able to pass and change some request local state using `State[F, State, ?]` as async type:

```scala
case class State(msg: String)

type ST[A] = StateT[IO, State, A]

val state: Endpoint[ST, State] = root.mapF(state => state.get)
val hello: Endpoint[ST, String] = get("hello" :: state) { (state: State) =>
  Ok(state.msg)
}

val finale = hello.compiled.compose[ST, State] { state =>
  StateT.set(State("foo"))
} //optionally run .mapK after to convert StateT ~> IO

finale(Request("/hello")) //there is foo Response inside
```

Also, `WriterT` might be the option too.