### PR TITLE
Replace references to deprecated GeneratorDrivenPropertyChecks

### DIFF
--- a/core/src/test/scala/io/finch/MethodSpec.scala
+++ b/core/src/test/scala/io/finch/MethodSpec.scala
@@ -5,13 +5,13 @@ import cats.effect.IO
 import com.twitter.finagle.http.Response
 import com.twitter.util.{Future => TwitterFuture}
 import org.scalacheck.Arbitrary
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scala.concurrent.{Future => ScalaFuture}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MethodSpec
   extends FinchSpec
-  with GeneratorDrivenPropertyChecks {
+  with ScalaCheckDrivenPropertyChecks {
 
   behavior of "method"
 

--- a/fs2/src/test/scala/io/finch/fs2/Fs2StreamingSpec.scala
+++ b/fs2/src/test/scala/io/finch/fs2/Fs2StreamingSpec.scala
@@ -4,9 +4,9 @@ import _root_.fs2.Stream
 import cats.effect.IO
 import com.twitter.io.Buf
 import io.finch._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class Fs2StreamingSpec extends FinchSpec with GeneratorDrivenPropertyChecks {
+class Fs2StreamingSpec extends FinchSpec with ScalaCheckDrivenPropertyChecks {
 
   checkAll("fs2.streamBody", StreamingLaws[Stream, IO](
     list => Stream(list:_*),

--- a/iteratee/src/test/scala/io/finch/iteratee/IterateeStreamingSpec.scala
+++ b/iteratee/src/test/scala/io/finch/iteratee/IterateeStreamingSpec.scala
@@ -4,9 +4,9 @@ import cats.effect.IO
 import com.twitter.io.Buf
 import io.finch._
 import io.iteratee.Enumerator
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class IterateeStreamingSpec extends FinchSpec with GeneratorDrivenPropertyChecks {
+class IterateeStreamingSpec extends FinchSpec with ScalaCheckDrivenPropertyChecks {
 
   checkAll("Iteratee.streamBody", StreamingLaws[Enumerator, IO](
     Enumerator.enumList,


### PR DESCRIPTION
Deprecated since scalatest 3.0.6

The drop-in replacement is `ScalaCheckDrivenPropertyChecks`.