### PR TITLE
Change Sigma to Merit in Adopters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Adopters
 * [QuizUp](http://www.quizup.com)
 * [Lookout](http://www.lookout.com)
 * [Project September](http://projectseptember.com/)
-* [Sigma](http://thesigma.com)
+* [Merit](https://merits.com)
 * [D.A.Consortium](http://www.dac.co.jp/english/)
 * [Redbubble](https://redbubble.com/)
 * [Zalando](https://zalando.de)


### PR DESCRIPTION
Sigma is now known as Merit (and is still using Finch!)
https://www.merits.com/blog/sigma-rebrands-as-merit