### PR TITLE
catch possible exceptions of mapOutputs function

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -98,8 +98,8 @@ trait Endpoint[F[_], A] { self =>
   /**
     * Maps this endpoint to the given function `A => Output[B]`.
     */
-  final def mapOutput[B](fn: A => Output[B])(implicit F: Monad[F]): Endpoint[F, B] =
-    mapOutputAsync(fn.andThen(F.pure))
+  final def mapOutput[B](fn: A => Output[B])(implicit F: MonadError[F, Throwable]): Endpoint[F, B] =
+    mapOutputAsync(a => F.catchNonFatal(fn(a)))
 
   /**
     * Maps this endpoint to the given function `A => Future[Output[B]]`.

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -402,4 +402,13 @@ class EndpointSpec extends FinchSpec {
     r(Input.post("/")).awaitOutputUnsafe() shouldBe None
     r(Input.get("/test.txt")).awaitValueUnsafe() shouldBe Some(Buf.Utf8("foo bar baz\n"))
   }
+
+  it should "wrap up an exception thrown inside mapOutputs function" in {
+    check { (ep: EndpointIO[Int], p: Output.Payload[Int], e: Exception) => {
+      val mappedEndpoint = ep.mapOutput[Int](_ => throw e)
+      val asFunction = mappedEndpoint.asInstanceOf[Output[Int] => IO[Output[Int]]]
+
+      asFunction.apply(p).attempt.unsafeRunSync() === Left(e)
+    }}
+  }
 }


### PR DESCRIPTION
fix for #1138
Idea is catch every exception that may happen in function that provided to Endpoint#mapOutput from Mapper. 