### PR TITLE
Enable 406 support with additional type

### DIFF
--- a/core/src/main/scala/io/finch/NotAcceptable406.scala
+++ b/core/src/main/scala/io/finch/NotAcceptable406.scala
@@ -1,0 +1,6 @@
+package io.finch
+
+/**
+  * Uninhabited type that exists only to mark the end of failed Content-Type negotiation
+  */
+sealed trait NotAcceptable406

--- a/core/src/main/scala/io/finch/internal/package.scala
+++ b/core/src/main/scala/io/finch/internal/package.scala
@@ -1,6 +1,6 @@
 package io.finch
 
-import com.twitter.finagle.http.{Fields, Message}
+import com.twitter.finagle.http.{Fields, Message, Response}
 import com.twitter.io.Buf
 import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
@@ -117,4 +117,13 @@ package object internal {
     }
   }
 
+  implicit class RichResponse(val response: Response) extends AnyVal {
+    /**
+      * Set headers for given response
+      */
+    def withHeaders(headers: Map[String, String]): Response = {
+      headers.foreach { case (k, v) => response.headerMap.set(k, v) }
+      response
+    }
+  }
 }

--- a/core/src/test/scala/io/finch/StreamingLaws.scala
+++ b/core/src/test/scala/io/finch/StreamingLaws.scala
@@ -6,7 +6,7 @@ import cats.effect.Effect
 import cats.instances.AllInstances
 import cats.laws._
 import cats.laws.discipline._
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.{Request, Status}
 import com.twitter.io.{Buf, Reader}
 import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
@@ -24,7 +24,7 @@ abstract class StreamingLaws[S[_[_], _], F[_]] extends Laws with AllInstances wi
     val req = Request()
     req.setChunked(true)
 
-    val rep = F.toIO(toResponse(fromList(a), cs)).unsafeRunSync()
+    val rep = F.toIO(toResponse(Status.Ok, Map.empty, fromList(a), cs)).unsafeRunSync()
 
     Reader.copy(rep.reader, req.writer).ensure(req.writer.close())
 


### PR DESCRIPTION
- Refactor `ToResponse` to consume also status and headers instead of overriding it again in `outputToResponse`. It enables returning _kind of final_ responses from `ToResponse` type class (there are still cookies).
- Add `NotAcceptable406` uninhabited type
- In case if the last element of Content-Type negotiation `Coproduct` is `NotAcceptable406`, fail with 406 instead of using the last possible `ToResponse` on failed negotiation.

Essentially, it allows users to decide on type-level whether they want to enable or disable 406 errors:

```scala
Bootstrap.serve[Text.Plain :+: Text.Html :+: CNil] //would pick text/html encoding
Bootstrap.serve[Text.Plain :+: Text.Html :+: NotAcceptable406 :+: CNil] //would fail with 406
```