### PR TITLE
Update dependencies (except Finagle)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,13 +8,13 @@ lazy val buildSettings = Seq(
 )
 
 lazy val twitterVersion = "19.10.0"
-lazy val circeVersion = "0.11.2"
+lazy val circeVersion = "0.12.2"
 lazy val circeIterateeVersion = "0.12.0"
-lazy val circeFs2Version = "0.11.0"
+lazy val circeFs2Version = "0.12.0"
 lazy val shapelessVersion = "2.3.3"
 lazy val catsVersion = "2.0.0"
 lazy val argonautVersion = "6.2.3"
-lazy val iterateeVersion = "0.18.0"
+lazy val iterateeVersion = "0.19.0"
 lazy val refinedVersion = "0.9.10"
 lazy val catsEffectVersion = "2.0.0"
 lazy val fs2Version =  "2.1.0"
@@ -30,13 +30,14 @@ lazy val compilerOptions = Seq(
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
+  "-Xfatal-warnings",
   "-Xfuture",
   "-Xlint"
 )
 
 val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.14.2",
-  "org.scalatest" %% "scalatest" % "3.0.7",
+  "org.scalatest" %% "scalatest" % "3.0.8",
   "org.typelevel" %% "cats-laws" % catsVersion,
   "org.typelevel" %% "discipline" % "0.11.1"
 )

--- a/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
+++ b/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
@@ -42,7 +42,7 @@ trait AccumulatingDecoders {
     F: MonadError[F, Throwable],
       decode: Decoder[A]
   ): Enumeratee[F, Json, A] = Enumeratee.flatMap(json =>
-    decode.accumulating(json.hcursor) match {
+    decode.decodeAccumulating(json.hcursor) match {
       case Validated.Invalid(errors) => Enumerator.liftM(F.raiseError(Errors(errors)))
       case Validated.Valid(a) => Enumerator.enumOne(a)
     }

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -8,7 +8,7 @@ import java.nio.charset.Charset
 trait Encoders {
 
   protected def print(json: Json, cs: Charset): Buf =
-    Buf.ByteBuffer.Owned(Printer.noSpaces.prettyByteBuffer(json, cs))
+    Buf.ByteBuffer.Owned(Printer.noSpaces.printToByteBuffer(json, cs))
 
   /**
    * Maps Circe's [[Encoder]] to Finch's [[Encode]].

--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -12,7 +12,7 @@ package object circe extends Encoders with Decoders {
   object dropNullValues extends Encoders with Decoders {
     private[this] val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
     override protected def print(json: Json, cs: Charset): Buf =
-      Buf.ByteBuffer.Owned(printer.prettyByteBuffer(json, cs))
+      Buf.ByteBuffer.Owned(printer.printToByteBuffer(json, cs))
   }
 
   /**
@@ -22,7 +22,7 @@ package object circe extends Encoders with Decoders {
   object predictSize extends Encoders with Decoders {
     private[this] val printer: Printer = Printer.noSpaces.copy(predictSize = true)
     override protected def print(json: Json, cs: Charset): Buf =
-      Buf.ByteBuffer.Owned(printer.prettyByteBuffer(json, cs))
+      Buf.ByteBuffer.Owned(printer.printToByteBuffer(json, cs))
   }
 
   object accumulating extends Encoders with AccumulatingDecoders

--- a/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
@@ -3,7 +3,6 @@ package io.finch.circe.test
 import cats.effect.IO
 import fs2.Stream
 import io.finch.test.AbstractJsonSpec
-import io.finch.test.data.ExampleNestedCaseClass
 import io.iteratee.Enumerator
 
 class CirceSpec extends AbstractJsonSpec {
@@ -11,7 +10,7 @@ class CirceSpec extends AbstractJsonSpec {
   checkJson("circe")
   checkStreamJson[Enumerator, IO]("circe-iteratee")(Enumerator.enumList, _.toVector.unsafeRunSync().toList)
   checkStreamJson[Stream, IO]("circe-fs2")(
-    list => Stream.fromIterator[IO, ExampleNestedCaseClass](list.toIterator),
+    list => Stream.fromIterator[IO](list.toIterator),
     _.compile.toList.unsafeRunSync()
   )
 }

--- a/core/src/main/scala/io/finch/endpoint/endpoint.scala
+++ b/core/src/main/scala/io/finch/endpoint/endpoint.scala
@@ -8,7 +8,7 @@ import com.twitter.io.Buf
 import java.io.InputStream
 import shapeless.HNil
 
-package object endpoint {
+package endpoint {
 
   private[finch] class FromInputStream[F[_]](stream: Resource[F, InputStream])(
     implicit F: Sync[F], S: ContextShift[F]

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -42,10 +42,10 @@ class EndpointSpec extends FinchSpec {
     }
   }
 
-  it should "correctly run mapF" in {
+  it should "correctly run transform" in {
     check { e: Endpoint[IO, String] =>
       val fn: String => Int = _.length
-      e.transformF(_.map(fn)) <-> e.map(fn)
+      e.transform(_.map(fn)) <-> e.map(fn)
     }
   }
 

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -13,7 +13,7 @@ import com.twitter.io.Buf
 import com.twitter.util._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.Laws
 import scala.reflect.ClassTag
 import shapeless.Witness

--- a/core/src/test/scala/io/finch/ServerSentEventSpec.scala
+++ b/core/src/test/scala/io/finch/ServerSentEventSpec.scala
@@ -9,7 +9,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Gen.Choose
 import org.scalacheck.Prop.propBoolean
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class ServerSentEventSpec extends FlatSpec with Matchers with Checkers {
 

--- a/core/src/test/scala/io/finch/internal/TooFastStringSpec.scala
+++ b/core/src/test/scala/io/finch/internal/TooFastStringSpec.scala
@@ -4,7 +4,7 @@ import com.twitter.util.Try
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class TooFastStringSpec extends FlatSpec with Matchers with Checkers {
 

--- a/examples/src/test/scala/io/finch/todo/TodoSpec.scala
+++ b/examples/src/test/scala/io/finch/todo/TodoSpec.scala
@@ -9,7 +9,7 @@ import io.finch.circe._
 import io.finch.internal.DummyExecutionContext
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class TodoSpec extends FlatSpec with Matchers with Checkers {
 

--- a/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
+++ b/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
@@ -9,7 +9,7 @@ import io.finch.{Decode, DecodeStream, Encode}
 import io.finch.test.data._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.Laws
 import scala.util.Try
 
@@ -38,7 +38,7 @@ abstract class AbstractJsonSpec extends FlatSpec with Matchers with Checkers wit
   )
 
   private def loop(name: String, ruleSet: Laws#RuleSet, library: String): Unit =
-    for ((id, prop) <- ruleSet.all.properties) it should (s"$library.$id.$name") in { check(prop) }
+    for ((id, prop) <- ruleSet.all.properties) it should s"$library.$id.$name" in { check(prop) }
 
   def checkJson(library: String)(implicit
     e: Encode.Json[List[ExampleNestedCaseClass]],

--- a/json-test/src/main/scala/io/finch/test/JsonLaws.scala
+++ b/json-test/src/main/scala/io/finch/test/JsonLaws.scala
@@ -50,7 +50,7 @@ abstract class StreamJsonLaws[S[_[_], _], F[_], A](implicit
 
   def toList: S[F, A] => List[A]
 
-  def success(a: List[A], cs: Charset)(implicit e: Encoder[A], eq: Eq[A]): IsEq[List[A]] = {
+  def success(a: List[A], cs: Charset)(implicit e: Encoder[A]): IsEq[List[A]] = {
     val json = F.map(fromList(a))(a => e(a).noSpaces + "\n")
     val enum = F.map(json)(str => Buf.ByteArray.Owned(str.getBytes(cs.name)))
     toList(streamDecoder(enum, cs)) <-> a


### PR DESCRIPTION
It seems appropriate to do these updates atomically,
because we bump major versions of many interconnected libraries:

  * cats to 2.0.0
  * cats-effect to 2.0.0
  * fs2 to 2.0.1
  * circe to 0.12.2

Also we add the `-Xfatal-warnings` option to ensure deprecated
API usages are replaced.