### PR TITLE
Use HTTPS for more resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -342,7 +342,7 @@ lazy val examples = project
   .settings(moduleName := "finchx-examples")
   .settings(allSettings)
   .settings(noPublish)
-  .settings(resolvers += "TM" at "http://maven.twttr.com")
+  .settings(resolvers += "TM" at "https://maven.twttr.com")
   .settings(coverageExcludedPackages :=
     """
       |io\.finch\.div\..*;

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers ++= Seq(
   Classpaths.typesafeReleases,
   Classpaths.sbtPluginReleases,
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven",
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven",
   Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns),
   Resolver.sonatypeRepo("snapshots")
 )


### PR DESCRIPTION
Looks like we are still calling `http://dl.bintray.com/tpolecat/maven` but I'm not sure why.