### PR TITLE
Add Endpoint.coproduct for summing a list of endpoints

### DIFF
--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -1118,4 +1118,16 @@ object Endpoint {
    */
   def multipartAttributesNel[F[_]: Sync, A: DecodeEntity: ClassTag](name: String): Endpoint[F, NonEmptyList[A]] =
     new Attribute[F, NonEmptyList, A](name) with Attribute.NonEmpty[F, A] with Attribute.MultipleErrors[F, NonEmptyList, A]
+
+  /**
+   * Sequentially composes the given `endpoints` by using [[Endpoint!.coproduct]].
+   *
+   * The resulting endpoint will match if at least one of the provided endpoints matches.
+   * If the sequence of provided endpoints is empty, the empty endpoint is returned, which never matches.
+   *
+   * @see [[Endpoint!.coproduct]] for the exact composition semantics.
+   * @see [[Endpoint.empty]] for the semantics of the empty endpoint.
+   */
+  def coproductAll[F[_], A](endpoints: Endpoint[F, A]*): Endpoint[F, A] =
+    if (endpoints.isEmpty) empty else endpoints.reduce(_ coproduct _)
 }

--- a/core/src/test/scala/io/finch/EndpointSpec.scala
+++ b/core/src/test/scala/io/finch/EndpointSpec.scala
@@ -305,6 +305,19 @@ class EndpointSpec extends FinchSpec {
     e2(b).remainder shouldBe Some(b.withRoute(b.route.drop(2)))
   }
 
+  it should "be greedy in terms of Endpoint.coproduct" in {
+    val a = Input(emptyRequest, List("a", "10"))
+    val b = Input(emptyRequest, List("a"))
+
+    val e1 = Endpoint.coproductAll("a", "b", "a" :: "10")
+    val e2 = Endpoint.coproductAll("a" :: "10", "b", "a")
+
+    e1(a).remainder shouldBe Some(a.withRoute(a.route.drop(2)))
+    e1(b).remainder shouldBe Some(b.withRoute(b.route.drop(2)))
+    e2(a).remainder shouldBe Some(a.withRoute(a.route.drop(2)))
+    e2(b).remainder shouldBe Some(b.withRoute(b.route.drop(2)))
+  }
+
   it should "accumulate errors on its product" in {
     check { (a: Either[Error, Errors], b: Either[Error, Errors]) =>
       val aa = a.fold[Exception](identity, identity)


### PR DESCRIPTION
It's equivalent to `List(endpoints: _*).foldK` but a bit more convenient.

