### PR TITLE
Remove an allocation of Either in decodeCirce

### DIFF
--- a/circe/src/main/scala/io/finch/circe/CirceError.scala
+++ b/circe/src/main/scala/io/finch/circe/CirceError.scala
@@ -1,0 +1,8 @@
+package io.finch.circe
+
+import cats.syntax.show._
+import scala.util.control.NoStackTrace
+
+private class CirceError(cause: io.circe.Error) extends Exception with NoStackTrace {
+  override def getMessage: String = cause.show
+}

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -17,13 +17,9 @@ trait Decoders {
   /**
    * Maps a Circe's [[Decoder]] to Finch's [[Decode]].
    */
-  implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json { (b, cs) =>
-    val attemptJson = cs match {
-      case StandardCharsets.UTF_8 => decodeByteBuffer[A](b.asByteBuffer)
-      case _ => decode[A](b.asString(cs))
-    }
-
-    attemptJson.fold[Either[Throwable, A]](Left.apply, Right.apply)
+  implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json {
+    case (b, StandardCharsets.UTF_8) => decodeByteBuffer[A](b.asByteBuffer)
+    case (b, cs) => decode[A](b.asString(cs))
   }
 
   implicit def enumerateCirce[F[_], A: Decoder](implicit


### PR DESCRIPTION
The result is already of type `Either`.
Also simplify the implementation a bit.

The second commit adds a specialized `CirceError` type,
that forwards to `cats.Show` for printing the error message.