### PR TITLE
Add Support for Scala 2.13 and drop support for Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import ReleaseTransformations._
 import microsites.ExtraMdFileConfig
 
+parallelExecution := false
+
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   scalaVersion := "2.12.7",
@@ -19,7 +21,7 @@ lazy val refinedVersion = "0.9.12"
 lazy val catsEffectVersion = "2.0.0"
 lazy val fs2Version =  "2.1.0"
 
-lazy val compilerOptions = Seq(
+def compilerOptions(scalaVersion: String) = Seq(
   "-deprecation",
   "-encoding", "UTF-8",
   "-feature",
@@ -30,6 +32,19 @@ lazy val compilerOptions = Seq(
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
   "-Xlint"
+) ++ (CrossVersion.partialVersion(scalaVersion) match {
+  case Some((2, scalaMajor)) if scalaMajor == 12 => scala212CompilerOptions
+  case Some((2, scalaMajor)) if scalaMajor == 13 => scala213CompilerOptions
+})
+
+lazy val scala212CompilerOptions = Seq(
+  "-Yno-adapted-args", 
+  "-Ywarn-unused-import",
+  "-Xfuture"
+)
+
+lazy val scala213CompilerOptions = Seq(
+  "-Wunused:imports"
 )
 
 val testDependencies = Seq(
@@ -51,12 +66,7 @@ val baseSettings = Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots")
   ),
-  scalacOptions ++= compilerOptions ++ (
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, p)) if p == 12 => Seq("-Yno-adapted-args", "-Ywarn-unused-import", "-Xfuture")
-      case _ => Nil
-    }
-  ),
+  scalacOptions ++= compilerOptions(scalaVersion.value),
   scalacOptions in (Compile, console) ~= {
     _.filterNot(Set("-Ywarn-unused-import"))
   },

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val buildSettings = Seq(
   crossScalaVersions := Seq("2.12.7", "2.13.1")
 )
 
-lazy val twitterVersion = "20.1.0"
+lazy val twitterVersion = "20.3.0"
 lazy val circeVersion = "0.13.0"
 lazy val circeIterateeVersion = "0.13.0-M2"
 lazy val circeFs2Version = "0.13.0-M1"

--- a/build.sbt
+++ b/build.sbt
@@ -4,17 +4,17 @@ import microsites.ExtraMdFileConfig
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   scalaVersion := "2.12.7",
-  crossScalaVersions := Seq("2.11.12", "2.12.7")
+  crossScalaVersions := Seq("2.12.7", "2.13.1")
 )
 
-lazy val twitterVersion = "19.10.0"
-lazy val circeVersion = "0.11.2"
-lazy val circeIterateeVersion = "0.12.0"
-lazy val circeFs2Version = "0.11.0"
+lazy val twitterVersion = "20.1.0"
+lazy val circeVersion = "0.13.0"
+lazy val circeIterateeVersion = "0.13.0-M2"
+lazy val circeFs2Version = "0.13.0-M1"
 lazy val shapelessVersion = "2.3.3"
 lazy val catsVersion = "2.0.0"
 lazy val argonautVersion = "6.2.4"
-lazy val iterateeVersion = "0.18.0"
+lazy val iterateeVersion = "0.19.0"
 lazy val refinedVersion = "0.9.12"
 lazy val catsEffectVersion = "2.0.0"
 lazy val fs2Version =  "2.1.0"
@@ -27,18 +27,16 @@ lazy val compilerOptions = Seq(
   "-language:higherKinds",
   "-language:implicitConversions",
   "-unchecked",
-  "-Yno-adapted-args",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
-  "-Xfuture",
   "-Xlint"
 )
 
 val testDependencies = Seq(
   "org.scalacheck" %% "scalacheck" % "1.14.2",
-  "org.scalatest" %% "scalatest" % "3.0.7",
+  "org.scalatest" %% "scalatest" % "3.1.0",
   "org.typelevel" %% "cats-laws" % catsVersion,
-  "org.typelevel" %% "discipline" % "0.11.1"
+  "org.typelevel" %% "discipline-scalatest" % "1.0.0"
 )
 
 val baseSettings = Seq(
@@ -55,7 +53,7 @@ val baseSettings = Seq(
   ),
   scalacOptions ++= compilerOptions ++ (
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, p)) if p >= 11 => Seq("-Ywarn-unused-import")
+      case Some((2, p)) if p == 12 => Seq("-Yno-adapted-args", "-Ywarn-unused-import", "-Xfuture")
       case _ => Nil
     }
   ),
@@ -235,8 +233,9 @@ lazy val finch = project.in(file("."))
   .settings(libraryDependencies ++= Seq(
     "io.circe" %% "circe-generic" % circeVersion
   ))
+  // Bring back examples when Twitter Server is published for Scala 2.13.
   .aggregate(
-    core, fs2, iteratee, generic, argonaut, circe, benchmarks, test, jsonTest, examples, refined
+    core, fs2, iteratee, generic, argonaut, circe, benchmarks, test, jsonTest, /*examples,*/ refined
   )
   .dependsOn(core, iteratee, generic, circe)
 
@@ -323,9 +322,11 @@ lazy val refined = project
   )
   .dependsOn(core % "test->test;compile->compile")
 
+// We need to wait for Twitter Server to be published for 2.13 for `docs` and `examples` to cross build for 2.13
 lazy val docs = project
   .settings(moduleName := "finchx-docs")
   .settings(docSettings)
+  .settings(crossScalaVersions := Seq("2.12.7"))
   .settings(noPublish)
   .settings(
     libraryDependencies ++= Seq(
@@ -341,6 +342,7 @@ lazy val docs = project
 lazy val examples = project
   .settings(moduleName := "finchx-examples")
   .settings(allSettings)
+  .settings(crossScalaVersions := Seq("2.12.7"))
   .settings(noPublish)
   .settings(resolvers += "TM" at "https://maven.twttr.com")
   .settings(coverageExcludedPackages :=

--- a/build.sbt
+++ b/build.sbt
@@ -243,9 +243,8 @@ lazy val finch = project.in(file("."))
   .settings(libraryDependencies ++= Seq(
     "io.circe" %% "circe-generic" % circeVersion
   ))
-  // Bring back examples when Twitter Server is published for Scala 2.13.
   .aggregate(
-    core, fs2, iteratee, generic, argonaut, circe, benchmarks, test, jsonTest, /*examples,*/ refined
+    core, fs2, iteratee, generic, argonaut, circe, benchmarks, test, jsonTest, examples, refined
   )
   .dependsOn(core, iteratee, generic, circe)
 
@@ -332,11 +331,9 @@ lazy val refined = project
   )
   .dependsOn(core % "test->test;compile->compile")
 
-// We need to wait for Twitter Server to be published for 2.13 for `docs` and `examples` to cross build for 2.13
 lazy val docs = project
   .settings(moduleName := "finchx-docs")
   .settings(docSettings)
-  .settings(crossScalaVersions := Seq("2.12.7"))
   .settings(noPublish)
   .settings(
     libraryDependencies ++= Seq(
@@ -352,7 +349,6 @@ lazy val docs = project
 lazy val examples = project
   .settings(moduleName := "finchx-examples")
   .settings(allSettings)
-  .settings(crossScalaVersions := Seq("2.12.7"))
   .settings(noPublish)
   .settings(resolvers += "TM" at "https://maven.twttr.com")
   .settings(coverageExcludedPackages :=

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 import ReleaseTransformations._
 import microsites.ExtraMdFileConfig
 
-parallelExecution := false
-
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
   scalaVersion := "2.12.7",

--- a/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
+++ b/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
@@ -42,7 +42,7 @@ trait AccumulatingDecoders {
     F: MonadError[F, Throwable],
       decode: Decoder[A]
   ): Enumeratee[F, Json, A] = Enumeratee.flatMap(json =>
-    decode.accumulating(json.hcursor) match {
+    decode.decodeAccumulating(json.hcursor) match {
       case Validated.Invalid(errors) => Enumerator.liftM(F.raiseError(Errors(errors)))
       case Validated.Valid(a) => Enumerator.enumOne(a)
     }

--- a/circe/src/main/scala/io/finch/circe/Encoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Encoders.scala
@@ -8,7 +8,7 @@ import java.nio.charset.Charset
 trait Encoders {
 
   protected def print(json: Json, cs: Charset): Buf =
-    Buf.ByteBuffer.Owned(Printer.noSpaces.prettyByteBuffer(json, cs))
+    Buf.ByteBuffer.Owned(Printer.noSpaces.printToByteBuffer(json, cs))
 
   /**
    * Maps Circe's [[Encoder]] to Finch's [[Encode]].

--- a/circe/src/main/scala/io/finch/circe/package.scala
+++ b/circe/src/main/scala/io/finch/circe/package.scala
@@ -12,7 +12,7 @@ package object circe extends Encoders with Decoders {
   object dropNullValues extends Encoders with Decoders {
     private[this] val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
     override protected def print(json: Json, cs: Charset): Buf =
-      Buf.ByteBuffer.Owned(printer.prettyByteBuffer(json, cs))
+      Buf.ByteBuffer.Owned(printer.printToByteBuffer(json, cs))
   }
 
   /**
@@ -22,7 +22,7 @@ package object circe extends Encoders with Decoders {
   object predictSize extends Encoders with Decoders {
     private[this] val printer: Printer = Printer.noSpaces.copy(predictSize = true)
     override protected def print(json: Json, cs: Charset): Buf =
-      Buf.ByteBuffer.Owned(printer.prettyByteBuffer(json, cs))
+      Buf.ByteBuffer.Owned(printer.printToByteBuffer(json, cs))
   }
 
   object accumulating extends Encoders with AccumulatingDecoders

--- a/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
@@ -3,7 +3,6 @@ package io.finch.circe.test
 import cats.effect.IO
 import fs2.Stream
 import io.finch.test.AbstractJsonSpec
-import io.finch.test.data.ExampleNestedCaseClass
 import io.iteratee.Enumerator
 
 class CirceSpec extends AbstractJsonSpec {
@@ -11,7 +10,7 @@ class CirceSpec extends AbstractJsonSpec {
   checkJson("circe")
   checkStreamJson[Enumerator, IO]("circe-iteratee")(Enumerator.enumList, _.toVector.unsafeRunSync().toList)
   checkStreamJson[Stream, IO]("circe-fs2")(
-    list => Stream.fromIterator[IO, ExampleNestedCaseClass](list.toIterator),
+    list => Stream.fromIterator[IO](list.toIterator),
     _.compile.toList.unsafeRunSync()
   )
 }

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -361,7 +361,7 @@ trait Endpoint[F[_], A] { self =>
     */
   final def handle(pf: PartialFunction[Throwable, Output[A]])(implicit
     F: ApplicativeError[F, Throwable]
-  ): Endpoint[F, A] = rescue(pf.andThen(F.pure))
+  ): Endpoint[F, A] = rescue(pf.andThen(F.pure(_)))
 
   /**
     * Validates the result of this endpoint using a `predicate`. The rule is used for error

--- a/core/src/main/scala/io/finch/internal/Mapper.scala
+++ b/core/src/main/scala/io/finch/internal/Mapper.scala
@@ -18,7 +18,13 @@ import shapeless.ops.function.FnToProduct
 trait Mapper[F[_], A] {
   type Out
 
-  def apply(e: Endpoint[F, A]): Endpoint[F, Out]
+  /**
+   *
+   * @param e The endpoint to map
+   * @tparam X Hack to stop the compiler from converting this to a SAM
+   * @return An endpoint that returns an `Out`
+   */
+  def apply[X](e: Endpoint[F, A]): Endpoint[F, Out]
 }
 
 private[finch] trait LowPriorityMapperConversions {
@@ -27,7 +33,7 @@ private[finch] trait LowPriorityMapperConversions {
 
   def instance[F[_], A, B](f: Endpoint[F, A] => Endpoint[F, B]): Mapper.Aux[F, A, B] = new Mapper[F, A] {
     type Out = B
-    def apply(e: Endpoint[F, A]): Endpoint[F, B] = f(e)
+    def apply[X](e: Endpoint[F, A]): Endpoint[F, B] = f(e)
   }
 
   /**

--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -13,7 +13,7 @@ import com.twitter.io.Buf
 import com.twitter.util._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.Laws
 import scala.reflect.ClassTag
 import shapeless.Witness

--- a/core/src/test/scala/io/finch/ServerSentEventSpec.scala
+++ b/core/src/test/scala/io/finch/ServerSentEventSpec.scala
@@ -9,7 +9,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Gen.Choose
 import org.scalacheck.Prop.propBoolean
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class ServerSentEventSpec extends FlatSpec with Matchers with Checkers {
 

--- a/core/src/test/scala/io/finch/StreamingLaws.scala
+++ b/core/src/test/scala/io/finch/StreamingLaws.scala
@@ -7,7 +7,7 @@ import cats.instances.AllInstances
 import cats.laws._
 import cats.laws.discipline._
 import com.twitter.finagle.http.Request
-import com.twitter.io.{Buf, Reader}
+import com.twitter.io.{Buf, Pipe}
 import org.scalacheck.{Arbitrary, Prop}
 import org.typelevel.discipline.Laws
 
@@ -26,7 +26,7 @@ abstract class StreamingLaws[S[_[_], _], F[_]] extends Laws with AllInstances wi
 
     val rep = F.toIO(toResponse(fromList(a), cs)).unsafeRunSync()
 
-    Reader.copy(rep.reader, req.writer).ensure(req.writer.close())
+    Pipe.copy(rep.reader, req.writer).ensure(req.writer.close())
 
     Endpoint
       .binaryBodyStream[F, S]

--- a/core/src/test/scala/io/finch/internal/TooFastStringSpec.scala
+++ b/core/src/test/scala/io/finch/internal/TooFastStringSpec.scala
@@ -4,7 +4,7 @@ import com.twitter.util.Try
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class TooFastStringSpec extends FlatSpec with Matchers with Checkers {
 

--- a/examples/src/test/scala/io/finch/todo/TodoSpec.scala
+++ b/examples/src/test/scala/io/finch/todo/TodoSpec.scala
@@ -9,7 +9,7 @@ import io.finch.circe._
 import io.finch.internal.DummyExecutionContext
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 class TodoSpec extends FlatSpec with Matchers with Checkers {
 

--- a/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
+++ b/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
@@ -9,7 +9,7 @@ import io.finch.{Decode, DecodeStream, Encode}
 import io.finch.test.data._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.Laws
 import scala.util.Try
 

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,4 @@
+// DO NOT EDIT! This file is auto-generated.
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")


### PR DESCRIPTION
Resolves #1202 by adding support for 2.13. We're also forced to drop support for 2.11 here because a number of dependencies that are not cross built for both. Big thanks to @sergeykolbasov for figuring the weird SAM issue that caused the Mapper to not get resolved in a bunch of cases.

Couple things about this PR:
- Introduces a bunch of warnings from Scalatest, I plan on cleaning these up in a separate PR
- I'd still like to investigate cleaning up the sbt settings, I really like how Odin is does it.
- Examples and docs cannot be cross built until Twitter Server is cross built for 2.13