### PR TITLE
Fix microsite compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ local.*
 
 .bloop
 .metals
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -181,6 +181,7 @@ lazy val docSettings = allSettings ++ Seq(
   micrositeName := "Finch",
   micrositeDescription := "Scala combinator library for building Finagle HTTP services",
   micrositeAuthor := "Vladimir Kostyukov",
+  micrositeCompilingDocsTool := WithTut,
   micrositeHighlightTheme := "atom-one-light",
   micrositeHomepage := "https://finagle.github.io/finch/",
   micrositeDocumentationUrl := "api",
@@ -342,7 +343,7 @@ lazy val docs = project
     )
   )
   .enablePlugins(MicrositesPlugin, ScalaUnidocPlugin)
-  .dependsOn(core, circe, argonaut, iteratee, refined)
+  .dependsOn(core, circe, argonaut, iteratee, refined, fs2)
 
 lazy val examples = project
   .settings(moduleName := "finchx-examples")

--- a/docs/src/main/tut/contributing.md
+++ b/docs/src/main/tut/contributing.md
@@ -1,6 +1,5 @@
 ---
 layout: docs
-
 ---
 Generally, Finch follows a standard [fork and pull][0] model for contributions via GitHub pull requests. Thus, the
 _contributing process_ looks as follows:

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -2,10 +2,7 @@
 layout: home
 title:  "Home"
 section: "home"
-technologies:
- - first: ["Scala", "sbt-microsites plugin is completely written in Scala"]
- - second: ["SBT", "sbt-microsites plugin uses SBT and other sbt plugins to generate microsites easily"]
- - third: ["Jekyll", "Jekyll allows for the transformation of plain text into static websites and blogs."]
+position: 0
 ---
 
 Finch provides a combinator API over the [Finagle][finagle] HTTP services. An `Endpoint[A]`, main
@@ -24,7 +21,7 @@ build.sbt:
 libraryDependencies ++= Seq(
   "com.github.finagle" %% "finch-core" % "0.32.1",
   "com.github.finagle" %% "finch-circe" % "0.32.1",
-  "io.circe" %% "circe-generic" % "0.9.3"
+  "io.circe" %% "circe-generic" % "0.13.1"
 )
 ```
 
@@ -33,10 +30,10 @@ Main.scala:
 ```tut:silent
 import com.twitter.finagle.Http
 import com.twitter.util.Await
-
+import cats.effect.IO
 import io.finch._
 import io.finch.circe._
-import io.finch.syntax._
+import io.finch.catsEffect._
 import io.circe.generic.auto._
 
 object Main extends App {
@@ -47,7 +44,7 @@ object Main extends App {
   def currentTime(l: java.util.Locale): String =
     java.util.Calendar.getInstance(l).getTime.toString
 
-  val time: Endpoint[Time] =
+  val time: Endpoint[IO, Time] =
     post("time" :: jsonBody[Locale]) { l: Locale =>
       Ok(Time(l, currentTime(new java.util.Locale(l.language, l.country))))
     }

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,5 +13,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "1.1.0")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "1.2.1")
 


### PR DESCRIPTION
Our microsite build has been broken and outdated while we've been moving to an Effect Agnostic `Endpoint`. This PR fixes the `sbt docs/makeMicrosite` command. The code examples in the docs all compile but the text that surrounds them is still out of date. My current thinking is that we can use this as a base to fix the text, although I'm open to alternative approaches to fixing our docs. If we decide to merge this, I don't think we should publish the docs to the website until all the text has been fixed.

Some things to note / questions:
- I replaced the Server Sent Event example's use of `AsyncStream` with `Fs2`
- The latest sbt-microsites seems to replace favicons and icons with its own. I've noticed this on other microsites like [cats effect](https://typelevel.org/cats-effect/).
- Set the docs compilation tool to Tut, but we should probably consider moving to mdoc in the future
- contributing.md probably needs to get updated to no longer mention Waffle [which no longer exists](https://web.archive.org/web/20190331134811/https:/waffle.io/)
