### PR TITLE
modified the document of sample code (in README).

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ This "Hello World!" example is built with just `finchx-core` (polymorphic endpoi
 ```scala
 import io.finch._, cats.effect.IO
 import com.twitter.finagle.Http
+import com.twitter.util.Await
 
 object Main extends App with Endpoint.Module[IO] {
   val api: Endpoint[IO, String] = get("hello") { Ok("Hello, World!") }
-  Http.server.serve(":8080", api.toServiceAs[Text.Plain])
+  Await.ready(Http.server.serve(":8080", api.toServiceAs[Text.Plain]))
 }
 ```
 


### PR DESCRIPTION
Maybe, server finish running before receiving a request, not exist `Await.ready`