### PR TITLE
Remove dead references to AsyncStream

### DIFF
--- a/core/src/test/scala/io/finch/FinchSpec.scala
+++ b/core/src/test/scala/io/finch/FinchSpec.scala
@@ -9,7 +9,6 @@ import cats.Eq
 import cats.data.NonEmptyList
 import cats.effect.{Effect, IO}
 import cats.instances.AllInstances
-import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.http._
 import com.twitter.io.Buf
 import com.twitter.util._
@@ -176,14 +175,6 @@ trait FinchSpec extends AnyFlatSpec with Matchers with Checkers with AllInstance
     (st, cs, hs, c) <- genOutputMeta
     a <- Arbitrary.arbitrary[A]
   } yield Output.Payload(a, st, cs, hs, c)
-
-  def genAsyncStreamOutput[A: Arbitrary]: Gen[Output[AsyncStream[A]]] = Gen.oneOf(
-    genEmptyOutput,
-    for {
-      (st, cs, hs, c) <- genOutputMeta
-      a <- Arbitrary.arbitrary[A]
-    } yield Output.Payload(AsyncStream.of(a), st, cs, hs, c)
-  )
 
   def genOutput[A: Arbitrary]: Gen[Output[A]] = Gen.oneOf(
     genPayloadOutput[A],
@@ -380,9 +371,6 @@ trait FinchSpec extends AnyFlatSpec with Matchers with Checkers with AllInstance
     Arbitrary(genPayloadOutput[A])
 
   implicit def arbitraryOutput[A: Arbitrary]: Arbitrary[Output[A]] = Arbitrary(genOutput[A])
-
-  implicit def arbitraryAsyncStreamOutput[A: Arbitrary]: Arbitrary[Output[AsyncStream[A]]] =
-    Arbitrary(genAsyncStreamOutput[A])
 
   implicit def arbitraryRequestItem: Arbitrary[items.RequestItem] =
     Arbitrary(genRequestItem)

--- a/core/src/test/scala/io/finch/ServerSentEventSpec.scala
+++ b/core/src/test/scala/io/finch/ServerSentEventSpec.scala
@@ -3,7 +3,6 @@ package io.finch
 import java.nio.charset.{Charset, StandardCharsets}
 
 import cats.Show
-import com.twitter.concurrent.AsyncStream
 import com.twitter.io.Buf
 import io.finch.internal.HttpContent
 import org.scalacheck.Gen.Choose
@@ -50,13 +49,6 @@ class ServerSentEventSpec extends AnyFlatSpec with Matchers with Checkers {
     sse <- dataOnlySse
     retry <- Choose.chooseLong.choose(-1000, 1000)
   } yield sse.copy(retry = Some(retry))
-
-  def streamDataOnlyGenerator: Gen[AsyncStream[ServerSentEvent[String]]] = for {
-    strs <- Gen.nonEmptyListOf(dataOnlySse)
-  } yield AsyncStream.fromSeq(strs)
-
-  implicit def arbitrarySse: Arbitrary[AsyncStream[ServerSentEvent[String]]] =
-    Arbitrary(streamDataOnlyGenerator)
 
   val encoder = encodeEventStream[String](Show.fromToString)
 

--- a/docs/mdoc/cookbook.md
+++ b/docs/mdoc/cookbook.md
@@ -85,26 +85,6 @@ val file: Endpoint[IO, Buf] = get("file") {
 content given their _dynamic_ nature. Instead, a static HTTP server (i.e., [Nginx][nginx]) would be
 the perfect fit.
 
-It's also possible to _stream_ the file content to the client using [`AsyncStream`][as].
-
-```scala mdoc:silent:nest
-import io.finch._
-import io.finch.catsEffect._
-import com.twitter.conversions.StorageUnitOps._
-import com.twitter.concurrent.AsyncStream
-import com.twitter.finagle.Http
-import com.twitter.io.{Buf, BufReader, Reader}
-
-import java.io.File
-
-val reader: Reader[Buf] = Reader.fromFile(new File("/dev/urandom"))
-
-val file: Endpoint[IO, AsyncStream[Buf]] = get("stream-of-file") {
-  val chunkedReader = BufReader.chunked(reader, chunkSize = 512.kilobytes.inBytes.toInt)
-  Ok(Reader.toAsyncStream(chunkedReader))
-}
-```
-
 ### Converting `Errors` into JSON
 
 Finch's own errors are often accumulated in the product `Endpoint` and represented as
@@ -432,7 +412,7 @@ e(Input.get("/foo")).awaitValueUnsafe()
 ### Server Sent Events
 
 Finch offers support for [Server Sent Events][server-sent-events] through the `finch-sse` sub-project.
-Server Sent Events are represented as `AsyncStream`s and streamed over the chunked HTTP transport.
+Server Sent Events are represented as `Stream`s and streamed over the chunked HTTP transport.
 
 The `ServerSentEvent` case class carries an arbitrary `data` field and it's possible to encode any
 `ServerSentEvent[A]` for which `cats.Show[A]` is defined.
@@ -531,7 +511,6 @@ call. See finagle-http-auth's README for more usage details.
 [loadbalancing]: http://twitter.github.io/finagle/guide/Clients.html#load-balancing
 [futures]: http://twitter.github.io/finagle/guide/Futures.html
 [bijection]: https://github.com/twitter/bijection
-[as]: https://github.com/twitter/util/blob/develop/util-core/src/main/scala/com/twitter/concurrent/AsyncStream.scala
 [cors-filter]: https://github.com/twitter/finagle/blob/develop/finagle-http/src/main/scala/com/twitter/finagle/http/filter/Cors.scala
 [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
 [server-sent-events]: https://en.wikipedia.org/wiki/Server-sent_events

--- a/docs/mdoc/user-guide.md
+++ b/docs/mdoc/user-guide.md
@@ -263,11 +263,6 @@ bodies in a single step.
 - `jsonBody(Option)[A]` - an alias for `body[A, Application.Json]`.
 - `textBody(Option)[A]` - an alias for `body[A, Text.Plain]`
 
-Chunked bodies:
-
-- `asyncBody` - chunked/streamed (only matches chunked requests) body represented as an
-  `AsyncStream[Buf]`.
-
 #### Multipart
 
 Finch supports reading file uploads and attributes from the `multipart/form-data` HTTP bodies with


### PR DESCRIPTION
The arb instances aren't used by any tests, and the docs are a
confusing fabrication.