### PR TITLE
Scala steward configuration

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,5 @@
+updates.pin = [
+  { groupId = "co.fs2", artifactId="fs2-core", version="2." },
+  { groupId = "io.circe", version="0.13." },
+  { groupId = "org.typelevel", artifactId="cats-effect", version="2." },
+]

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ lazy val buildSettings = Seq(
 lazy val twitterVersion = "22.3.0"
 lazy val circeVersion = "0.13.0"
 lazy val circeIterateeVersion = "0.13.0-M2"
-lazy val circeFs2Version = "0.13.0"
 lazy val shapelessVersion = "2.3.9"
 lazy val catsVersion = "2.7.0"
 lazy val argonautVersion = "6.3.8"
@@ -331,7 +330,7 @@ lazy val circe = project
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-iteratee" % circeIterateeVersion,
-      "io.circe" %% "circe-fs2" % circeFs2Version,
+      "io.circe" %% "circe-fs2" % circeVersion,
       "io.circe" %% "circe-jawn" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion % "test"
     )


### PR DESCRIPTION
chore: use circe version for circe-fs2
---

**Motivation:**
Must be aligned

chore: add scala steward configuration

---

**Modification:**
* freeze `cats-effect` to major version 2
* freeze `fs2-core` to major version (next use CE3)
* freeze `circe-fs2` to minor version (next use fs2 > v3)