### PR TITLE
Clean up examples to not use toAsync

### DIFF
--- a/benchmarks/src/main/scala/io/finch/benchmarks.scala
+++ b/benchmarks/src/main/scala/io/finch/benchmarks.scala
@@ -36,8 +36,8 @@ abstract class FinchBenchmark extends Endpoint.Module[IO] {
 
 @State(Scope.Benchmark)
 class InputBenchmark extends FinchBenchmark {
-  val foo = Request()
-  val bar = Request("/foo/bar/baz/que/quz")
+  private val foo = Request()
+  private val bar = Request("/foo/bar/baz/que/quz")
 
   @Benchmark
   def fromEmptyPath: Input = Input.fromRequest(foo)
@@ -191,7 +191,7 @@ class JsonBenchmark extends FinchBenchmark {
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-abstract class BootstrapBenchmark[CT](init: Bootstrap[Id, HNil, HNil])(implicit
+abstract class BootstrapBenchmark[CT](init: Bootstrap[IO, HNil, HNil])(implicit
     tsf: Compile[IO, Endpoint[IO, List[Foo]] :: HNil, CT :: HNil]
 ) extends FinchBenchmark {
 
@@ -206,11 +206,11 @@ abstract class BootstrapBenchmark[CT](init: Bootstrap[Id, HNil, HNil])(implicit
   }))
 }
 
-class JsonBootstrapBenchmark extends BootstrapBenchmark[Application.Json](Bootstrap)
+class JsonBootstrapBenchmark extends BootstrapBenchmark[Application.Json](Bootstrap[IO])
 
-class TextBootstrapBenchmark extends BootstrapBenchmark[Text.Plain](Bootstrap)
+class TextBootstrapBenchmark extends BootstrapBenchmark[Text.Plain](Bootstrap[IO])
 
-class JsonAndTextNegotiatedBootstrapBenchmark extends BootstrapBenchmark[Application.Json :+: Text.Plain :+: CNil](Bootstrap) {
+class JsonAndTextNegotiatedBootstrapBenchmark extends BootstrapBenchmark[Application.Json :+: Text.Plain :+: CNil](Bootstrap[IO]) {
 
   private val acceptValues: Array[String] = Array("application/json", "text/plain")
 
@@ -242,7 +242,7 @@ class HttpMessageBenchmark extends FinchBenchmark {
 
   import io.finch.internal.HttpMessage
 
-  val req = Request()
+  private val req = Request()
   req.contentType = "application/json;charset=utf-8"
 
   @Benchmark

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -287,46 +287,46 @@ trait Endpoint[F[_], A] {
     left.coproduct(right)
   }
 
-  /** Converts this endpoint to a Finagle service `Request => Future[Response]` that serves JSON.
-    *
-    * Consider using [[io.finch.Bootstrap]] instead.
-    */
-  final def toService(implicit
-      F: Async[F],
-      tr: ToResponse.Aux[F, A, Application.Json],
-      tre: ToResponse.Aux[F, Exception, Application.Json]
-  ): Resource[F, Service[Request, Response]] = toServiceAs[Application.Json]
-
-  /** Converts this endpoint to a Finagle service `Request => Future[Response]` that serves custom content-type `CT`.
-    *
-    * Consider using [[io.finch.Bootstrap]] instead.
-    */
-  final def toServiceAs[CT <: String](implicit
-      F: Async[F],
-      tr: ToResponse.Aux[F, A, CT],
-      tre: ToResponse.Aux[F, Exception, CT]
-  ): Resource[F, Service[Request, Response]] = Bootstrap.serve[CT](this).toService
-
-  /** Converts this endpoint to Endpoint.Compiled[F] what is efficiently is Kleisli[F, Request, Response] where responses are encoded with JSON encoder.
-    *
-    * Consider using [[io.finch.Bootstrap]] instead
-    */
-  final def compile(implicit
-      F: MonadError[F, Throwable],
-      tr: ToResponse.Aux[F, A, Application.Json],
-      tre: ToResponse.Aux[F, Exception, Application.Json]
-  ): Endpoint.Compiled[F] = compileAs[Application.Json]
-
-  /** Converts this endpoint to Endpoint.Compiled[F] what is efficiently is Kleisli[F, Request, Response] where responses are encoded with encoder corresponding
-    * to `CT` Content-Type.
-    *
-    * Consider using [[io.finch.Bootstrap]] instead
-    */
-  final def compileAs[CT <: String](implicit
-      F: MonadError[F, Throwable],
-      tr: ToResponse.Aux[F, A, CT],
-      tre: ToResponse.Aux[F, Exception, CT]
-  ): Endpoint.Compiled[F] = Bootstrap.serve[CT](this).compile
+//  /** Converts this endpoint to a Finagle service `Request => Future[Response]` that serves JSON.
+//    *
+//    * Consider using [[io.finch.Bootstrap]] instead.
+//    */
+//  final def toService(implicit
+//      F: Async[F],
+//      tr: ToResponse.Aux[F, A, Application.Json],
+//      tre: ToResponse.Aux[F, Exception, Application.Json]
+//  ): Resource[F, Service[Request, Response]] = toServiceAs[Application.Json]
+//
+//  /** Converts this endpoint to a Finagle service `Request => Future[Response]` that serves custom content-type `CT`.
+//    *
+//    * Consider using [[io.finch.Bootstrap]] instead.
+//    */
+//  final def toServiceAs[CT <: String](implicit
+//      F: Async[F],
+//      tr: ToResponse.Aux[F, A, CT],
+//      tre: ToResponse.Aux[F, Exception, CT]
+//  ): Resource[F, Service[Request, Response]] = Bootstrap.serve[CT](this).toService
+//
+//  /** Converts this endpoint to Endpoint.Compiled[F] what is efficiently is Kleisli[F, Request, Response] where responses are encoded with JSON encoder.
+//    *
+//    * Consider using [[io.finch.Bootstrap]] instead
+//    */
+//  final def compile(implicit
+//      F: MonadError[F, Throwable],
+//      tr: ToResponse.Aux[F, A, Application.Json],
+//      tre: ToResponse.Aux[F, Exception, Application.Json]
+//  ): Endpoint.Compiled[F] = compileAs[Application.Json]
+//
+//  /** Converts this endpoint to Endpoint.Compiled[F] what is efficiently is Kleisli[F, Request, Response] where responses are encoded with encoder corresponding
+//    * to `CT` Content-Type.
+//    *
+//    * Consider using [[io.finch.Bootstrap]] instead
+//    */
+//  final def compileAs[CT <: String](implicit
+//      F: MonadError[F, Throwable],
+//      tr: ToResponse.Aux[F, A, CT],
+//      tre: ToResponse.Aux[F, Exception, CT]
+//  ): Endpoint.Compiled[F] = Bootstrap.serve[CT](this).compile
 
   /** Recovers from any exception occurred in this endpoint by creating a new endpoint that will handle any matching throwable from the underlying future.
     */
@@ -546,10 +546,14 @@ object Endpoint {
     */
   def apply[F[_]]: EndpointModule[F] = EndpointModule[F]
 
-  /** Convert [[Endpoint.Compiled]] into Finagle Service
-    */
-  def toService[F[_]: Async](compiled: Endpoint.Compiled[F]): Resource[F, Service[Request, Response]] =
-    Dispatcher[F].map(ToService(compiled, _))
+//  /** Convert [[Endpoint.Compiled]] into Finagle Service
+//    */
+//  def toService[F[_]](compiled: Endpoint.Compiled[F])(implicit F: Async[F]): Resource[F, Service[Request, Response]] =
+//    Dispatcher[F].flatMap { dispatcher =>
+//      Resource.make(F.pure(ToService(compiled, dispatcher))) { service =>
+//        F.defer(service.close().toAsync[F])
+//      }
+//    }
 
   /** Creates an empty [[Endpoint]] (an endpoint that never matches) for a given type.
     */

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -1,11 +1,9 @@
 package io.finch
 
 import cats.data._
-import cats.effect.std.Dispatcher
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all._
 import cats.{Alternative, Applicative, ApplicativeError, Apply, Functor, Id, Monad, MonadError, MonoidK, SemigroupK, ~>}
-import com.twitter.finagle.Service
 import com.twitter.finagle.http.exp.{Multipart => FinagleMultipart}
 import com.twitter.finagle.http.{Cookie => FinagleCookie, Method => FinagleMethod, Request, Response}
 import com.twitter.io.Buf
@@ -287,47 +285,6 @@ trait Endpoint[F[_], A] {
     left.coproduct(right)
   }
 
-//  /** Converts this endpoint to a Finagle service `Request => Future[Response]` that serves JSON.
-//    *
-//    * Consider using [[io.finch.Bootstrap]] instead.
-//    */
-//  final def toService(implicit
-//      F: Async[F],
-//      tr: ToResponse.Aux[F, A, Application.Json],
-//      tre: ToResponse.Aux[F, Exception, Application.Json]
-//  ): Resource[F, Service[Request, Response]] = toServiceAs[Application.Json]
-//
-//  /** Converts this endpoint to a Finagle service `Request => Future[Response]` that serves custom content-type `CT`.
-//    *
-//    * Consider using [[io.finch.Bootstrap]] instead.
-//    */
-//  final def toServiceAs[CT <: String](implicit
-//      F: Async[F],
-//      tr: ToResponse.Aux[F, A, CT],
-//      tre: ToResponse.Aux[F, Exception, CT]
-//  ): Resource[F, Service[Request, Response]] = Bootstrap.serve[CT](this).toService
-//
-//  /** Converts this endpoint to Endpoint.Compiled[F] what is efficiently is Kleisli[F, Request, Response] where responses are encoded with JSON encoder.
-//    *
-//    * Consider using [[io.finch.Bootstrap]] instead
-//    */
-//  final def compile(implicit
-//      F: MonadError[F, Throwable],
-//      tr: ToResponse.Aux[F, A, Application.Json],
-//      tre: ToResponse.Aux[F, Exception, Application.Json]
-//  ): Endpoint.Compiled[F] = compileAs[Application.Json]
-//
-//  /** Converts this endpoint to Endpoint.Compiled[F] what is efficiently is Kleisli[F, Request, Response] where responses are encoded with encoder corresponding
-//    * to `CT` Content-Type.
-//    *
-//    * Consider using [[io.finch.Bootstrap]] instead
-//    */
-//  final def compileAs[CT <: String](implicit
-//      F: MonadError[F, Throwable],
-//      tr: ToResponse.Aux[F, A, CT],
-//      tre: ToResponse.Aux[F, Exception, CT]
-//  ): Endpoint.Compiled[F] = Bootstrap.serve[CT](this).compile
-
   /** Recovers from any exception occurred in this endpoint by creating a new endpoint that will handle any matching throwable from the underlying future.
     */
   final def rescue(pf: PartialFunction[Throwable, F[Output[A]]])(implicit
@@ -545,15 +502,6 @@ object Endpoint {
     * }}}
     */
   def apply[F[_]]: EndpointModule[F] = EndpointModule[F]
-
-//  /** Convert [[Endpoint.Compiled]] into Finagle Service
-//    */
-//  def toService[F[_]](compiled: Endpoint.Compiled[F])(implicit F: Async[F]): Resource[F, Service[Request, Response]] =
-//    Dispatcher[F].flatMap { dispatcher =>
-//      Resource.make(F.pure(ToService(compiled, dispatcher))) { service =>
-//        F.defer(service.close().toAsync[F])
-//      }
-//    }
 
   /** Creates an empty [[Endpoint]] (an endpoint that never matches) for a given type.
     */

--- a/core/src/main/scala/io/finch/endpoint/endpoint.scala
+++ b/core/src/main/scala/io/finch/endpoint/endpoint.scala
@@ -1,4 +1,5 @@
 package io.finch
+package endpoint
 
 import cats.Applicative
 import cats.effect.{Async, Resource}
@@ -9,38 +10,34 @@ import shapeless.HNil
 
 import java.io.InputStream
 
-package object endpoint {
+private[finch] class FromInputStream[F[_]](stream: Resource[F, InputStream])(implicit F: Async[F]) extends Endpoint[F, Buf] {
+  private def readLoop(left: Buf, stream: InputStream): F[Buf] = F.defer {
+    for {
+      buffer <- F.delay(new Array[Byte](1024))
+      n <- F.blocking(stream.read(buffer))
+      buf <- if (n == -1) F.pure(left) else readLoop(left.concat(Buf.ByteArray.Owned(buffer, 0, n)), stream)
+    } yield buf
+  }
 
-  private[finch] class FromInputStream[F[_]](stream: Resource[F, InputStream])(implicit F: Async[F]) extends Endpoint[F, Buf] {
+  final def apply(input: Input): Endpoint.Result[F, Buf] =
+    EndpointResult.Matched(
+      input,
+      Trace.empty,
+      stream.use(s => readLoop(Buf.Empty, s).map(buf => Output.payload(buf)))
+    )
+}
 
-    private def readLoop(left: Buf, stream: InputStream): F[Buf] = F.defer {
-      for {
-        buffer <- F.delay(new Array[Byte](1024))
-        n <- F.blocking(stream.read(buffer))
-        buf <- if (n == -1) F.pure(left) else readLoop(left.concat(Buf.ByteArray.Owned(buffer, 0, n)), stream)
-      } yield buf
-    }
-
-    final def apply(input: Input): Endpoint.Result[F, Buf] =
+private[finch] class Asset[F[_]](path: String)(implicit F: Applicative[F]) extends Endpoint[F, HNil] {
+  final def apply(input: Input): Endpoint.Result[F, HNil] = {
+    val req = input.request
+    if (req.method != FinagleMethod.Get || req.path != path) EndpointResult.NotMatched[F]
+    else
       EndpointResult.Matched(
-        input,
-        Trace.empty,
-        stream.use(s => readLoop(Buf.Empty, s).map(buf => Output.payload(buf)))
+        input.withRoute(Nil),
+        Trace.fromRoute(input.route),
+        F.pure(Output.HNil)
       )
   }
 
-  private[finch] class Asset[F[_]](path: String)(implicit F: Applicative[F]) extends Endpoint[F, HNil] {
-    final def apply(input: Input): Endpoint.Result[F, HNil] = {
-      val req = input.request
-      if (req.method != FinagleMethod.Get || req.path != path) EndpointResult.NotMatched[F]
-      else
-        EndpointResult.Matched(
-          input.withRoute(Nil),
-          Trace.fromRoute(input.route),
-          F.pure(Output.HNil)
-        )
-    }
-
-    final override def toString: String = s"GET /$path"
-  }
+  final override def toString: String = s"GET /$path"
 }

--- a/examples/src/main/scala/io/finch/div/Main.scala
+++ b/examples/src/main/scala/io/finch/div/Main.scala
@@ -1,11 +1,8 @@
 package io.finch.div
 
-import cats.effect.{ExitCode, IO, IOApp, Resource}
+import cats.effect.{ExitCode, IO, IOApp}
 import cats.implicits._
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.{Http, ListeningServer, Service}
 import io.finch._
-import io.finch.internal._
 
 /** A tiny Finch application that serves a single endpoint `POST /:a/b:` that divides `a` by `b`.
   *
@@ -32,14 +29,11 @@ object Main extends IOApp with Endpoint.Module[IO] {
     BadRequest(e)
   }
 
-  def serve(service: Service[Request, Response]): Resource[IO, ListeningServer] =
-    Resource.make(IO(Http.server.serve(":8081", service))) { server =>
-      IO.defer(server.close().toAsync[IO])
-    }
 
-  override def run(args: List[String]): IO[ExitCode] =
-    (for {
-      service <- div.toServiceAs[Text.Plain]
-      server <- serve(service)
-    } yield server).useForever
+  override def run(args: List[String]): IO[ExitCode] = {
+    Bootstrap[IO]
+      .serve[Text.Plain](div)
+      .listen(":8081")
+      .useForever
+  }
 }

--- a/examples/src/main/scala/io/finch/div/Main.scala
+++ b/examples/src/main/scala/io/finch/div/Main.scala
@@ -29,11 +29,6 @@ object Main extends IOApp with Endpoint.Module[IO] {
     BadRequest(e)
   }
 
-
-  override def run(args: List[String]): IO[ExitCode] = {
-    Bootstrap[IO]
-      .serve[Text.Plain](div)
-      .listen(":8081")
-      .useForever
-  }
+  override def run(args: List[String]): IO[ExitCode] =
+    Bootstrap[IO].serve[Text.Plain](div).listen(":8081").useForever
 }

--- a/examples/src/main/scala/io/finch/iteratee/Main.scala
+++ b/examples/src/main/scala/io/finch/iteratee/Main.scala
@@ -1,13 +1,11 @@
 package io.finch.iteratee
 
-import cats.effect.{ExitCode, IO, IOApp, Resource}
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.{Http, ListeningServer, Service}
+import cats.effect.{ExitCode, IO, IOApp}
+import com.twitter.finagle.Http
 import io.circe.generic.auto._
 import io.finch._
 import io.finch.catsEffect._
 import io.finch.circe._
-import io.finch.internal._
 import io.iteratee.{Enumerator, Iteratee}
 
 import scala.util.Random
@@ -64,14 +62,9 @@ object Main extends IOApp {
       Ok(enum.map(_.isPrime))
     }
 
-  def serve(service: Service[Request, Response]): Resource[IO, ListeningServer] =
-    Resource.make(IO(Http.server.withStreaming(enabled = true).serve(":8081", service))) { server =>
-      IO.defer(server.close().toAsync[IO])
-    }
-
   def run(args: List[String]): IO[ExitCode] =
-    (for {
-      service <- (sumJson :+: streamJson :+: isPrime).toServiceAs[Application.Json]
-      server <- serve(service)
-    } yield server).useForever
+    Bootstrap[IO](Http.server.withStreaming(enabled = true))
+      .serve[Application.Json](sumJson :+: streamJson :+: isPrime)
+      .listen(":8081")
+      .useForever
 }

--- a/examples/src/main/scala/io/finch/iteratee/Main.scala
+++ b/examples/src/main/scala/io/finch/iteratee/Main.scala
@@ -63,8 +63,5 @@ object Main extends IOApp {
     }
 
   def run(args: List[String]): IO[ExitCode] =
-    Bootstrap[IO](Http.server.withStreaming(enabled = true))
-      .serve[Application.Json](sumJson :+: streamJson :+: isPrime)
-      .listen(":8081")
-      .useForever
+    Bootstrap[IO](Http.server.withStreaming(enabled = true)).serve[Application.Json](sumJson :+: streamJson :+: isPrime).listen(":8081").useForever
 }

--- a/examples/src/main/scala/io/finch/middleware/Main.scala
+++ b/examples/src/main/scala/io/finch/middleware/Main.scala
@@ -49,5 +49,5 @@ object Main extends IOApp with Endpoint.Module[IO] {
   }
 
   override def run(args: List[String]): IO[ExitCode] =
-    Bootstrap[IO].serve[Text.Plain](helloWorld).filter(Function.chain(Seq(stats, logging, auth))).listen(":8081").useForever
+    Bootstrap[IO].serve[Text.Plain](helloWorld).middleware(Function.chain(Seq(stats, logging, auth))).listen(":8081").useForever
 }

--- a/examples/src/main/scala/io/finch/middleware/Main.scala
+++ b/examples/src/main/scala/io/finch/middleware/Main.scala
@@ -48,11 +48,6 @@ object Main extends IOApp with Endpoint.Module[IO] {
     }
   }
 
-  override def run(args: List[String]): IO[ExitCode] = {
-    Bootstrap[IO]
-      .serve[Text.Plain](helloWorld)
-      .filter(Function.chain(Seq(stats, logging, auth)))
-      .listen(":8081")
-      .useForever
-  }
+  override def run(args: List[String]): IO[ExitCode] =
+    Bootstrap[IO].serve[Text.Plain](helloWorld).filter(Function.chain(Seq(stats, logging, auth))).listen(":8081").useForever
 }

--- a/examples/src/main/scala/io/finch/todo/App.scala
+++ b/examples/src/main/scala/io/finch/todo/App.scala
@@ -1,8 +1,8 @@
 package io.finch.todo
 
 import cats.effect.{IO, Ref, Resource}
-import com.twitter.finagle.Service
-import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.ListeningServer
+import com.twitter.finagle.http.Status
 import io.circe.generic.auto._
 import io.finch._
 import io.finch.circe._
@@ -15,10 +15,8 @@ class App(idRef: Ref[IO, Int], storeRef: Ref[IO, Map[Int, Todo]]) extends Endpoi
   final val patchedTodo: Endpoint[IO, Todo => Todo] =
     jsonBody[Todo => Todo]
 
-  final val postTodo: Endpoint[IO, Todo] = post("todos" :: postedTodo) { t: Todo =>
-    storeRef.modify { store =>
-      (store + (t.id -> t), Created(t))
-    }
+  final val postTodo: Endpoint[IO, Todo] = post("todos" :: postedTodo) { todo: Todo =>
+    storeRef.modify(store => (store + (todo.id -> todo), Created(todo)))
   }
 
   final val patchTodo: Endpoint[IO, Todo] =
@@ -35,7 +33,7 @@ class App(idRef: Ref[IO, Int], storeRef: Ref[IO, Map[Int, Todo]]) extends Endpoi
     }
 
   final val getTodos: Endpoint[IO, List[Todo]] = get("todos") {
-    storeRef.get.map(m => Ok(m.values.toList.sortBy(-_.id)))
+    storeRef.get.map(todos => Ok(todos.values.toList.sortBy(-_.id)))
   }
 
   final val deleteTodo: Endpoint[IO, Todo] = delete("todos" :: path[Int]) { id: Int =>
@@ -48,14 +46,12 @@ class App(idRef: Ref[IO, Int], storeRef: Ref[IO, Map[Int, Todo]]) extends Endpoi
   }
 
   final val deleteTodos: Endpoint[IO, List[Todo]] = delete("todos") {
-    storeRef.modify { store =>
-      (Map.empty, Ok(store.values.toList.sortBy(-_.id)))
-    }
+    storeRef.modify(store => (Map.empty, Ok(store.values.toList.sortBy(-_.id))))
   }
 
-  final val toService: Resource[IO, Service[Request, Response]] = Bootstrap[IO]
+  final def listen(address: String): Resource[IO, ListeningServer] = Bootstrap[IO]
     .serve[Application.Json](getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo)
     .serve[Text.Html](classpathAsset("/todo/index.html"))
     .serve[Application.Javascript](classpathAsset("/todo/main.js"))
-    .toService
+    .listen(address)
 }

--- a/examples/src/main/scala/io/finch/todo/App.scala
+++ b/examples/src/main/scala/io/finch/todo/App.scala
@@ -53,13 +53,9 @@ class App(idRef: Ref[IO, Int], storeRef: Ref[IO, Map[Int, Todo]]) extends Endpoi
     }
   }
 
-  val doo = getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo
-
-
-
-//  final def toService: Resource[IO, Service[Request, Response]] = Bootstrap
-//    .serve[Application.Json](getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo)
-//    .serve[Text.Html](classpathAsset("/todo/index.html"))
-//    .serve[Application.Javascript](classpathAsset("/todo/main.js"))
-//    .toService
-//}
+  final val toService: Resource[IO, Service[Request, Response]] = Bootstrap[IO]
+    .serve[Application.Json](getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo)
+    .serve[Text.Html](classpathAsset("/todo/index.html"))
+    .serve[Application.Javascript](classpathAsset("/todo/main.js"))
+    .toService
+}

--- a/examples/src/main/scala/io/finch/todo/App.scala
+++ b/examples/src/main/scala/io/finch/todo/App.scala
@@ -53,9 +53,13 @@ class App(idRef: Ref[IO, Int], storeRef: Ref[IO, Map[Int, Todo]]) extends Endpoi
     }
   }
 
-  final def toService: Resource[IO, Service[Request, Response]] = Bootstrap
-    .serve[Application.Json](getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo)
-    .serve[Text.Html](classpathAsset("/todo/index.html"))
-    .serve[Application.Javascript](classpathAsset("/todo/main.js"))
-    .toService
-}
+  val doo = getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo
+
+
+
+//  final def toService: Resource[IO, Service[Request, Response]] = Bootstrap
+//    .serve[Application.Json](getTodos :+: postTodo :+: deleteTodo :+: deleteTodos :+: patchTodo)
+//    .serve[Text.Html](classpathAsset("/todo/index.html"))
+//    .serve[Application.Javascript](classpathAsset("/todo/main.js"))
+//    .toService
+//}

--- a/examples/src/main/scala/io/finch/todo/Main.scala
+++ b/examples/src/main/scala/io/finch/todo/Main.scala
@@ -1,13 +1,14 @@
 package io.finch.todo
 
-import io.finch._
-import io.finch.circe._
-import io.circe.generic.auto._
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 import com.twitter.app.Flag
 import com.twitter.finagle.ListeningServer
 import com.twitter.server.TwitterServer
+import io.circe.generic.auto._
+import io.finch._
+import io.finch.circe._
+
 import java.util.concurrent.CountDownLatch
 
 /** A simple Finch server serving a TODO application.
@@ -45,19 +46,14 @@ object Main extends TwitterServer with EndpointModule[IO] {
       .serve[Application.Javascript](classpathAsset("/todo/main.js"))
       .listen(s":${port()}")
 
-  def run(): IO[Unit] = {
-    Resource.eval(app)
-      .flatMap(serve)
-      .useForever
-  }
+  def run(): IO[Unit] =
+    Resource.eval(app).flatMap(serve).useForever
 
   def main(): Unit = {
     println(s"Open your browser at http://localhost:${port()}/todo/index.html") // scalastyle:ignore
 
     val latch = new CountDownLatch(1)
-    val cancel = run()
-      .onError(e => IO(exitOnError(e)))
-      .unsafeRunCancelable()
+    val cancel = run().onError(e => IO(exitOnError(e))).unsafeRunCancelable()
 
     onExit {
       cancel()

--- a/examples/src/main/scala/io/finch/wrk/Finagle.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finagle.scala
@@ -23,7 +23,7 @@ object Finagle extends App with Wrk {
 
   val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
 
-  Await.ready(serve(new Service[Request, Response] {
+  Await.ready(server.serve(":8081", new Service[Request, Response] {
     def apply(req: Request): Future[Response] = {
       val payload = mapper.writeValueAsBytes(Payload("Hello, World!"))
 

--- a/examples/src/main/scala/io/finch/wrk/Finagle.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finagle.scala
@@ -23,17 +23,22 @@ object Finagle extends App with Wrk {
 
   val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
 
-  Await.ready(server.serve(":8081", new Service[Request, Response] {
-    def apply(req: Request): Future[Response] = {
-      val payload = mapper.writeValueAsBytes(Payload("Hello, World!"))
+  Await.ready(
+    server.serve(
+      ":8081",
+      new Service[Request, Response] {
+        def apply(req: Request): Future[Response] = {
+          val payload = mapper.writeValueAsBytes(Payload("Hello, World!"))
 
-      val rep = Response(req.version, Status.Ok)
-      rep.content = Buf.ByteArray.Owned(payload)
-      rep.contentType = "application/json"
-      rep.date = currentTime()
-      rep.server = "Finagle"
+          val rep = Response(req.version, Status.Ok)
+          rep.content = Buf.ByteArray.Owned(payload)
+          rep.contentType = "application/json"
+          rep.date = currentTime()
+          rep.server = "Finagle"
 
-      Future.value(rep)
-    }
-  }))
+          Future.value(rep)
+        }
+      }
+    )
+  )
 }

--- a/examples/src/main/scala/io/finch/wrk/Finch.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finch.scala
@@ -1,12 +1,9 @@
 package io.finch.wrk
 
-import cats.effect.{ExitCode, IO, IOApp, Resource}
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.{ListeningServer, Service}
+import cats.effect.{ExitCode, IO, IOApp}
 import io.circe.generic.auto._
 import io.finch._
 import io.finch.circe._
-import io.finch.internal._
 
 /** How to benchmark this:
   *
@@ -20,14 +17,10 @@ import io.finch.internal._
   */
 object Finch extends IOApp with Wrk {
 
-  def serveR(service: Service[Request, Response]): Resource[IO, ListeningServer] =
-    Resource.make(IO(serve(service))) { server =>
-      IO.defer(server.close().toAsync[IO])
-    }
-
-  override def run(args: List[String]): IO[ExitCode] =
-    (for {
-      service <- Endpoint[IO].lift(Payload("Hello, World!")).toServiceAs[Application.Json]
-      server <- serveR(service)
-    } yield server).useForever
+  override def run(args: List[String]): IO[ExitCode] = {
+    Bootstrap[IO](server)
+      .serve[Application.Json](Endpoint[IO].lift(Payload("Hello, World!")))
+      .listen(":8081")
+      .useForever
+  }
 }

--- a/examples/src/main/scala/io/finch/wrk/Finch.scala
+++ b/examples/src/main/scala/io/finch/wrk/Finch.scala
@@ -17,10 +17,6 @@ import io.finch.circe._
   */
 object Finch extends IOApp with Wrk {
 
-  override def run(args: List[String]): IO[ExitCode] = {
-    Bootstrap[IO](server)
-      .serve[Application.Json](Endpoint[IO].lift(Payload("Hello, World!")))
-      .listen(":8081")
-      .useForever
-  }
+  override def run(args: List[String]): IO[ExitCode] =
+    Bootstrap[IO](server).serve[Application.Json](Endpoint[IO].lift(Payload("Hello, World!"))).listen(":8081").useForever
 }

--- a/examples/src/main/scala/io/finch/wrk/Wrk.scala
+++ b/examples/src/main/scala/io/finch/wrk/Wrk.scala
@@ -1,8 +1,8 @@
 package io.finch.wrk
 
+import com.twitter.finagle.Http
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
-import com.twitter.finagle.Http
 
 trait Wrk {
 

--- a/examples/src/main/scala/io/finch/wrk/Wrk.scala
+++ b/examples/src/main/scala/io/finch/wrk/Wrk.scala
@@ -1,14 +1,13 @@
 package io.finch.wrk
 
-import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
-import com.twitter.finagle.{Http, ListeningServer, Service}
+import com.twitter.finagle.Http
 
 trait Wrk {
 
   case class Payload(message: String)
 
-  protected def serve(s: Service[Request, Response]): ListeningServer =
-    Http.server.withCompressionLevel(0).withStatsReceiver(NullStatsReceiver).withTracer(NullTracer).serve(":8081", s)
+  protected def server: Http.Server =
+    Http.server.withCompressionLevel(0).withStatsReceiver(NullStatsReceiver).withTracer(NullTracer)
 }


### PR DESCRIPTION
We can just use IO.delay and avoid dealing with TwitterFuture to IO conversions.