### PR TITLE
kind-projector 0.13.2 (was 0.10.3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ val baseSettings = Seq(
   (Compile / console / scalacOptions) += "-Yrepl-class-based",
   (Test / fork) := true,
   (ThisBuild / javaOptions) ++= Seq("-Xss2048K"),
-  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.3" cross CrossVersion.binary),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
   ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0",
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision,

--- a/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
+++ b/json-test/src/main/scala/io/finch/test/AbstractJsonSpec.scala
@@ -54,7 +54,7 @@ abstract class AbstractJsonSpec extends AnyFlatSpec with Matchers with Checkers 
   def checkStreamJson[S[_[_], _], F[_]](library: String)(
       fromList: List[ExampleNestedCaseClass] => S[F, ExampleNestedCaseClass],
       toList: S[F, ExampleNestedCaseClass] => List[ExampleNestedCaseClass]
-  )(implicit en: DecodeStream.Json[S, F, ExampleNestedCaseClass], functor: Functor[S[F, ?]]): Unit =
+  )(implicit en: DecodeStream.Json[S, F, ExampleNestedCaseClass], functor: Functor[S[F, *]]): Unit =
     loop(
       "ExampleNestedCaseClass",
       JsonLaws.streaming[S, F, ExampleNestedCaseClass](fromList, toList).all,

--- a/json-test/src/main/scala/io/finch/test/JsonLaws.scala
+++ b/json-test/src/main/scala/io/finch/test/JsonLaws.scala
@@ -41,7 +41,7 @@ trait DecodeJsonLaws[A] extends Laws with AllInstances {
 }
 
 abstract class StreamJsonLaws[S[_[_], _], F[_], A](implicit
-    F: Functor[S[F, ?]]
+    F: Functor[S[F, *]]
 ) extends Laws
     with AllInstances {
 
@@ -108,7 +108,7 @@ object JsonLaws {
       streamToList: S[F, A] => List[A]
   )(implicit
       decoder: DecodeStream.Json[S, F, A],
-      functor: Functor[S[F, ?]]
+      functor: Functor[S[F, *]]
   ): StreamJsonLaws[S, F, A] =
     new StreamJsonLaws[S, F, A] {
       val toList: S[F, A] => List[A] = streamToList


### PR DESCRIPTION
Scala 2.12.16 and 2.13.9 will prohibit the use of `?` in this way, so this changes to the newer `*` syntax which will also work in Scala 3