### PR TITLE
Cleanup build

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 resolvers ++= Seq(
   Classpaths.typesafeReleases,
   Classpaths.sbtPluginReleases,
-  "jgit-repo" at "https://download.eclipse.org/jgit/maven",
-  Resolver.sonatypeRepo("snapshots")
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 )
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")


### PR DESCRIPTION
 - Replace deprecated `sonatypeRepo` resolver with `sonatypeOssRepos`
 - Ensure file source and writer are closed
 - Exclude `siteSubdirName` from lint keys to suppress warning
 - Update `joda-time` dependency