### PR TITLE
Add support for 406 Not Acceptable response on content negotiation

### DIFF
--- a/core/src/main/scala/io/finch/Accept.scala
+++ b/core/src/main/scala/io/finch/Accept.scala
@@ -30,6 +30,7 @@ object Accept {
 
   abstract class Matcher[CT <: String] {
     def apply(a: Accept): Boolean
+    def apply(as: List[Accept]): Boolean = as.exists(apply)
   }
 
   object Matcher {

--- a/core/src/main/scala/io/finch/Bootstrap.scala
+++ b/core/src/main/scala/io/finch/Bootstrap.scala
@@ -44,7 +44,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
     includeDateHeader: Boolean = true,
     includeServerHeader: Boolean = true,
     enableMethodNotAllowed: Boolean = false,
-    enableUnsupportedMediaType: Boolean = false
+    enableUnsupportedMediaType: Boolean = false,
+    enableNotAcceptable: Boolean = false
 ) {
 
   class Serve[CT] {
@@ -57,7 +58,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
         includeDateHeader,
         includeServerHeader,
         enableMethodNotAllowed,
-        enableUnsupportedMediaType
+        enableUnsupportedMediaType,
+        enableNotAcceptable
       )
   }
 
@@ -65,7 +67,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
       includeDateHeader: Boolean = includeDateHeader,
       includeServerHeader: Boolean = includeServerHeader,
       enableMethodNotAllowed: Boolean = enableMethodNotAllowed,
-      enableUnsupportedMediaType: Boolean = enableUnsupportedMediaType
+      enableUnsupportedMediaType: Boolean = enableUnsupportedMediaType,
+      enableNotAcceptable: Boolean = enableNotAcceptable
   ): Bootstrap[F, ES, CTS] = new Bootstrap(
     endpoints,
     server,
@@ -74,7 +77,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
     includeDateHeader,
     includeServerHeader,
     enableMethodNotAllowed,
-    enableUnsupportedMediaType
+    enableUnsupportedMediaType,
+    enableNotAcceptable
   )
 
   def serve[CT]: Serve[CT] = new Serve[CT]
@@ -88,7 +92,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
       includeDateHeader,
       includeServerHeader,
       enableMethodNotAllowed,
-      enableUnsupportedMediaType
+      enableUnsupportedMediaType,
+      enableNotAcceptable
     )
 
   def middleware(f: Endpoint.Compiled[F] => Endpoint.Compiled[F]): Bootstrap[F, ES, CTS] =
@@ -100,7 +105,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
       includeDateHeader,
       includeServerHeader,
       enableMethodNotAllowed,
-      enableUnsupportedMediaType
+      enableUnsupportedMediaType,
+      enableNotAcceptable
     )
 
   private[finch] def compile(implicit ts: Compile[F, ES, CTS]): Endpoint.Compiled[F] = {
@@ -108,7 +114,8 @@ class Bootstrap[F[_], ES <: HList, CTS <: HList](
       includeDateHeader,
       includeServerHeader,
       enableMethodNotAllowed,
-      enableUnsupportedMediaType
+      enableUnsupportedMediaType,
+      enableNotAcceptable
     )
 
     middleware(ts(endpoints, options, Compile.Context()))

--- a/core/src/main/scala/io/finch/Compile.scala
+++ b/core/src/main/scala/io/finch/Compile.scala
@@ -1,8 +1,8 @@
 package io.finch
 
 import cats.syntax.all._
-import cats.{Applicative, MonadError}
-import com.twitter.finagle.http.{Method, Request, Response, Status, Version}
+import cats.{Applicative, MonadThrow}
+import com.twitter.finagle.http.{Method, Response, Status, Version}
 import io.finch.internal.currentTime
 import shapeless._
 
@@ -19,8 +19,7 @@ import scala.annotation.implicitNotFound
   *   - include the date header on each response (unless disabled)
   *   - include the server header on each response (unless disabled)
   */
-@implicitNotFound(
-  """An Endpoint you're trying to compile is missing one or more encoders.
+@implicitNotFound("""An Endpoint you're trying to compile is missing one or more encoders.
 
   Make sure each endpoint in ${ES}, ${CTS} is one of the following:
 
@@ -29,21 +28,20 @@ import scala.annotation.implicitNotFound
   * A coproduct made up of some combination of the above
 
   See https://github.com/finagle/finch/blob/master/docs/src/main/tut/cookbook.md#fixing-the-toservice-compile-error
-"""
-)
+""")
 trait Compile[F[_], ES <: HList, CTS <: HList] {
   def apply(endpoints: ES, options: Compile.Options, context: Compile.Context): Endpoint.Compiled[F]
 }
 
 object Compile {
 
-  /** HTTP options propagated from [[Bootstrap]].
-    */
+  /** HTTP options propagated from [[Bootstrap]]. */
   final case class Options(
       includeDateHeader: Boolean,
       includeServerHeader: Boolean,
       enableMethodNotAllowed: Boolean,
-      enableUnsupportedMediaType: Boolean
+      enableUnsupportedMediaType: Boolean,
+      enableNotAcceptable: Boolean
   )
 
   /** HTTP context propagated between endpoints.
@@ -52,75 +50,50 @@ object Compile {
     */
   final case class Context(wouldAllow: List[Method] = Nil)
 
-  private val respond400: PartialFunction[Throwable, Output[Nothing]] = {
+  private[this] val respond400: PartialFunction[Throwable, Output[Nothing]] = {
     case e: io.finch.Error   => Output.failure(e, Status.BadRequest)
     case es: io.finch.Errors => Output.failure(es, Status.BadRequest)
   }
 
-  private val respond415: PartialFunction[Throwable, Output[Nothing]] = {
+  private[this] val respond415: PartialFunction[Throwable, Output[Nothing]] = {
     case e: io.finch.Error if e.getCause eq Decode.UnsupportedMediaTypeException =>
       Output.failure(e, Status.UnsupportedMediaType)
   }
 
-  private def conformHttp(rep: Response, version: Version, options: Options): Response = {
+  private def conformHttp(rep: Response, version: Version, opts: Options): Response = {
     rep.version = version
-
-    if (options.includeDateHeader) {
-      rep.headerMap.setUnsafe("Date", currentTime())
-    }
-
-    if (options.includeServerHeader) {
-      rep.headerMap.setUnsafe("Server", "Finch")
-    }
-
+    if (opts.includeDateHeader) rep.headerMap.setUnsafe("Date", currentTime())
+    if (opts.includeServerHeader) rep.headerMap.setUnsafe("Server", "Finch")
     rep
   }
 
-  implicit def hnilTS[F[_]](implicit F: Applicative[F]): Compile[F, HNil, HNil] = new Compile[F, HNil, HNil] {
-    def apply(es: HNil, opts: Options, ctx: Context): Endpoint.Compiled[F] =
-      Endpoint.Compiled[F] { req: Request =>
-        val rep = Response()
+  implicit def hnilTS[F[_]](implicit F: Applicative[F]): Compile[F, HNil, HNil] = (_, opts, ctx) =>
+    Endpoint.Compiled { req =>
+      val notAllowed = opts.enableMethodNotAllowed && ctx.wouldAllow.nonEmpty
+      val rep = Response(if (notAllowed) Status.MethodNotAllowed else Status.NotFound)
+      if (notAllowed) rep.allow = ctx.wouldAllow
+      F.pure((Trace.empty, Right(conformHttp(rep, req.version, opts))))
+    }
 
-        if (ctx.wouldAllow.nonEmpty && opts.enableMethodNotAllowed) {
-          rep.status = Status.MethodNotAllowed
-          rep.allow = ctx.wouldAllow
-        } else {
-          rep.status = Status.NotFound
-        }
-
-        F.pure(Trace.empty -> Right(conformHttp(rep, req.version, opts)))
-      }
-  }
-
-  type IsNegotiable[C] = OrElse[C <:< Coproduct, DummyImplicit]
-
-  implicit def hlistTS[F[_], A, EH <: Endpoint[F, A], ET <: HList, CTH, CTT <: HList](implicit
-      ntrA: ToResponse.Negotiable[F, A, CTH],
-      ntrE: ToResponse.Negotiable[F, Exception, CTH],
-      F: MonadError[F, Throwable],
-      tsT: Compile[F, ET, CTT],
-      isNegotiable: IsNegotiable[CTH]
-  ): Compile[F, Endpoint[F, A] :: ET, CTH :: CTT] = new Compile[F, Endpoint[F, A] :: ET, CTH :: CTT] {
-    def apply(es: Endpoint[F, A] :: ET, opts: Options, ctx: Context): Endpoint.Compiled[F] = {
-      val handler = if (opts.enableUnsupportedMediaType) respond415.orElse(respond400) else respond400
-      val negotiateContent = isNegotiable.fold(_ => true, _ => false)
-      val underlying = es.head.handle(handler)
-
-      Endpoint.Compiled[F] { req: Request =>
-        underlying(Input.fromRequest(req)) match {
-          case EndpointResult.Matched(rem, trc, out) if rem.route.isEmpty =>
-            val accept = if (negotiateContent) req.accept.map(a => Accept.fromString(a)).toList else Nil
-
-            F.flatMap(out)(oa => oa.toResponse(F, ntrA(accept), ntrE(accept)).map(r => conformHttp(r, req.version, opts))).attempt.map(e => trc -> e)
-
-          case EndpointResult.NotMatched.MethodNotAllowed(allowed) =>
-            tsT(es.tail, opts, ctx.copy(wouldAllow = ctx.wouldAllow ++ allowed))(req)
-
-          case _ =>
-            tsT(es.tail, opts, ctx)(req)
-        }
+  implicit def hlistTS[F[_]: MonadThrow, A, ET <: HList, CTH, CTT <: HList](implicit
+      negotiable: ToResponse.Negotiable[F, A, CTH],
+      rest: Compile[F, ET, CTT],
+      isNegotiable: CTH <:< Coproduct = null
+  ): Compile[F, Endpoint[F, A] :: ET, CTH :: CTT] = { case (e :: es, opts, ctx) =>
+    val endpoint = e.handle(if (opts.enableUnsupportedMediaType) respond415 orElse respond400 else respond400)
+    Endpoint.Compiled { req =>
+      endpoint(Input.fromRequest(req)) match {
+        case EndpointResult.Matched(rem, trc, out) if rem.route.isEmpty =>
+          val negotiate = isNegotiable != null || (opts.enableNotAcceptable && req.accept.nonEmpty)
+          val negotiated = negotiable(if (negotiate) req.accept.map(Accept.fromString).toList else Nil)
+          val acceptable = !negotiate || negotiated.acceptable || !opts.enableNotAcceptable
+          val rep = if (acceptable) out.flatMap(_.toResponse(negotiated)) else Response(Status.NotAcceptable).pure[F]
+          rep.map(conformHttp(_, req.version, opts)).attempt.map((trc, _))
+        case EndpointResult.NotMatched.MethodNotAllowed(allowed) =>
+          rest(es, opts, ctx.copy(wouldAllow = ctx.wouldAllow ++ allowed))(req)
+        case _ =>
+          rest(es, opts, ctx)(req)
       }
     }
   }
-
 }


### PR DESCRIPTION
Controlled by a flag in `Bootstrap` similar to other response codes.
Returns 406 when enabled and no matching Accept header is found.

Refactors `ToResponse.Negotiable` to achieve this effect:
 - Value and exception encoders are now bundled into `Negotiated`
 - `Negotiated` also includes an `acceptable` flag

Closes #1147 in favour of the preferred approach discussed in that PR