### PR TITLE
Migrate Errors to NonEmptyChain and add a Semigroup instance

### DIFF
--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -1,8 +1,7 @@
 package io.finch
 
-import cats.data.NonEmptyList
-import cats.syntax.eq._
-import cats.{Eq, Show}
+import cats.data.{NonEmptyChain, NonEmptyList}
+import cats.{Eq, Semigroup, Show}
 
 import scala.compat.Platform.EOL
 import scala.reflect.ClassTag
@@ -23,24 +22,29 @@ sealed abstract class Error extends Exception with NoStackTrace
   *
   * Error accumulation happens as part of the `.product` (or `adjoin`, `::`) combinator.
   */
-case class Errors(errors: NonEmptyList[Error]) extends Exception with NoStackTrace {
+final case class Errors(errors: NonEmptyChain[Error]) extends Exception with NoStackTrace {
   override def getMessage: String =
     "One or more errors reading request:" +
-      errors.map(_.getMessage).toList.mkString(EOL + "  ", EOL + "  ", "")
+      errors.iterator.map(_.getMessage).mkString(EOL + "  ", EOL + "  ", "")
+}
+
+object Errors {
+  def apply(errors: NonEmptyList[Error]): Errors =
+    Errors(NonEmptyChain.fromNonEmptyList(errors))
+
+  def of(error: Error, errors: Error*): Errors =
+    Errors(NonEmptyChain.of(error, errors: _*))
+
+  implicit val eq: Eq[Errors] = Eq.by(_.errors)
+  implicit val semigroup: Semigroup[Errors] =
+    (xs, ys) => Errors(xs.errors ++ ys.errors)
 }
 
 object Error {
+  implicit val eq: Eq[Error] = Eq.by(_.getMessage)
+  implicit val show: Show[Error] = _.getMessage
 
-  implicit val eq: Eq[Error] = Eq.instance[Error] { (error1, error2) =>
-    error1.getMessage === error2.getMessage
-  }
-
-  implicit val valueShow: Show[Error] = Show.show[Error] { error =>
-    error.getMessage
-  }
-
-  /** A request entity {{what}} was missing.
-    */
+  /** A request entity {{what}} was missing. */
   abstract class NotPresent(what: String) extends Error {
     override def getMessage: String = s"Request is missing a $what."
   }
@@ -50,18 +54,17 @@ object Error {
   final case class HeaderNotPresent(name: String) extends NotPresent(s"header '$name'")
   final case class CookieNotPresent(name: String) extends NotPresent(s"cookie '$name''")
 
-  /** A request entity {{what}} can't be parsed into a given {{targetType}}.
-    */
+  /** A request entity {{what}} can't be parsed into a given {{targetType}}. */
   abstract class NotParsed(what: String, targetType: ClassTag[_]) extends Error {
     override def getMessage: String = {
       // Note: https://issues.scala-lang.org/browse/SI-2034
       val className = targetType.runtimeClass.getName
       val simpleName = className.substring(className.lastIndexOf(".") + 1)
       val cause = if (getCause == null) "unknown cause" else getCause.getMessage
-
-      s"Request $what cannot be converted to ${simpleName}: $cause."
+      s"Request $what cannot be converted to $simpleName: $cause."
     }
   }
+
   final case class BodyNotParsed(targetType: ClassTag[_]) extends NotParsed("body", targetType)
   final case class ParamNotParsed(name: String, targetType: ClassTag[_]) extends NotParsed(s"param '$name'", targetType)
   final case class HeaderNotParsed(name: String, targetType: ClassTag[_]) extends NotParsed(s"header '$name'", targetType)


### PR DESCRIPTION
Closes #808 - I didn't add the `validated` method, because it's nothing more than `mapAsync(validator(_).liftTo[F])` now that we have removed `RequestItem`