### PR TITLE
Use ApplicativeThrow and MonadThrow type aliases

### DIFF
--- a/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
+++ b/circe/src/main/scala/io/finch/circe/AccumulatingDecoders.scala
@@ -1,6 +1,6 @@
 package io.finch.circe
 
-import cats.MonadError
+import cats.MonadThrow
 import cats.data.Validated
 import io.circe._
 import io.circe.iteratee._
@@ -13,38 +13,28 @@ import java.nio.charset.StandardCharsets
 
 trait AccumulatingDecoders {
 
-  /** Maps a Circe's [[Decoder]] to Finch's [[Decode]].
-    */
-  implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json { (b, cs) =>
-    val attemptJson = cs match {
-      case StandardCharsets.UTF_8 =>
-        decodeByteBufferAccumulating[A](b.asByteBuffer)
-      case _ => decodeAccumulating[A](b.asString(cs))
+  /** Maps a Circe's [[Decoder]] to Finch's [[Decode]]. */
+  implicit def decodeCirce[A: Decoder]: Decode.Json[A] =
+    Decode.json { (b, cs) =>
+      (cs match {
+        case StandardCharsets.UTF_8 => decodeByteBufferAccumulating[A](b.asByteBuffer)
+        case _                      => decodeAccumulating[A](b.asString(cs))
+      }).fold(errors => Left(Errors(errors)), Right.apply)
     }
 
-    attemptJson.fold[Either[Throwable, A]](nel => Left(Errors(nel)), Right.apply)
-  }
-
-  implicit def iterateeCirceDecoder[F[_], A: Decoder](implicit
-      monadError: MonadError[F, Throwable]
-  ): DecodeStream.Json[Enumerator, F, A] = DecodeStream.instance[Enumerator, F, A, Application.Json] { (enum, cs) =>
-    val parsed = cs match {
-      case StandardCharsets.UTF_8 =>
-        enum.map(_.asByteArray).through(byteStreamParser[F])
-      case _ =>
-        enum.map(_.asString(cs)).through(stringStreamParser[F])
+  implicit def iterateeCirceDecoder[F[_]: MonadThrow, A: Decoder]: DecodeStream.Json[Enumerator, F, A] =
+    DecodeStream.instance[Enumerator, F, A, Application.Json] { (enum, cs) =>
+      (cs match {
+        case StandardCharsets.UTF_8 => enum.map(_.asByteArray).through(byteStreamParser[F])
+        case _                      => enum.map(_.asString(cs)).through(stringStreamParser[F])
+      }).through(decoderAccumulating[F, A])
     }
-    parsed.through(decoderAccumulating[F, A])
-  }
 
-  private def decoderAccumulating[F[_], A](implicit
-      F: MonadError[F, Throwable],
-      decode: Decoder[A]
-  ): Enumeratee[F, Json, A] = Enumeratee.flatMap(json =>
-    decode.decodeAccumulating(json.hcursor) match {
-      case Validated.Invalid(errors) => Enumerator.liftM(F.raiseError(Errors(errors)))
-      case Validated.Valid(a)        => Enumerator.enumOne(a)
+  private def decoderAccumulating[F[_]: MonadThrow, A: Decoder]: Enumeratee[F, Json, A] =
+    Enumeratee.flatMap { json =>
+      Decoder[A].decodeAccumulating(json.hcursor) match {
+        case Validated.Invalid(errors) => Enumerator.liftM(MonadThrow[F].raiseError(Errors(errors)))
+        case Validated.Valid(a)        => Enumerator.enumOne(a)
+      }
     }
-  )
-
 }

--- a/circe/src/main/scala/io/finch/circe/Decoders.scala
+++ b/circe/src/main/scala/io/finch/circe/Decoders.scala
@@ -1,12 +1,11 @@
 package io.finch.circe
 
-import cats.MonadError
+import cats.MonadThrow
 import cats.effect.Sync
+import cats.syntax.all._
 import fs2.{Chunk, Stream}
-import io.circe.Decoder
-import io.circe.fs2
-import io.circe.iteratee
 import io.circe.jawn._
+import io.circe.{Decoder, fs2, iteratee}
 import io.finch.internal.HttpContent
 import io.finch.{Application, Decode, DecodeStream}
 import io.iteratee.Enumerator
@@ -15,41 +14,30 @@ import java.nio.charset.StandardCharsets
 
 trait Decoders {
 
-  /** Maps a Circe's [[Decoder]] to Finch's [[Decode]].
-    */
-  implicit def decodeCirce[A: Decoder]: Decode.Json[A] = Decode.json { (b, cs) =>
-    val decoded = cs match {
-      case StandardCharsets.UTF_8 => decodeByteBuffer[A](b.asByteBuffer)
-      case _                      => decode[A](b.asString(cs))
+  /** Maps a Circe's [[Decoder]] to Finch's [[Decode]]. */
+  implicit def decodeCirce[A: Decoder]: Decode.Json[A] =
+    Decode.json { (b, cs) =>
+      (cs match {
+        case StandardCharsets.UTF_8 => decodeByteBuffer[A](b.asByteBuffer)
+        case _                      => decode[A](b.asString(cs))
+      }).leftMap(new CirceError(_))
     }
 
-    decoded match {
-      case Left(error) => Left(new CirceError(error))
-      case right       => right
-    }
-  }
-
-  implicit def enumerateCirce[F[_], A: Decoder](implicit
-      F: MonadError[F, Throwable]
-  ): DecodeStream.Json[Enumerator, F, A] =
+  implicit def enumerateCirce[F[_]: MonadThrow, A: Decoder]: DecodeStream.Json[Enumerator, F, A] =
     DecodeStream.instance[Enumerator, F, A, Application.Json] { (enum, cs) =>
-      val parsed = cs match {
-        case StandardCharsets.UTF_8 =>
-          enum.map(_.asByteArray).through(iteratee.byteStreamParser[F])
-        case _ =>
-          enum.map(_.asString(cs)).through(iteratee.stringStreamParser[F])
-      }
-      parsed.through(iteratee.decoder[F, A])
+      (cs match {
+        case StandardCharsets.UTF_8 => enum.map(_.asByteArray).through(iteratee.byteStreamParser[F])
+        case _                      => enum.map(_.asString(cs)).through(iteratee.stringStreamParser[F])
+      }).through(iteratee.decoder[F, A])
     }
 
   implicit def fs2Circe[F[_]: Sync, A: Decoder]: DecodeStream.Json[Stream, F, A] =
     DecodeStream.instance[Stream, F, A, Application.Json] { (stream, cs) =>
-      val parsed = cs match {
+      (cs match {
         case StandardCharsets.UTF_8 =>
           stream.mapChunks(chunk => chunk.flatMap(buf => Chunk.array(buf.asByteArray))).through(fs2.byteStreamParser[F])
         case _ =>
           stream.map(_.asString(cs)).through(fs2.stringStreamParser[F])
-      }
-      parsed.through(fs2.decoder[F, A])
+      }).through(fs2.decoder[F, A])
     }
 }

--- a/core/src/main/scala/io/finch/Endpoint.scala
+++ b/core/src/main/scala/io/finch/Endpoint.scala
@@ -3,7 +3,7 @@ package io.finch
 import cats.data._
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all._
-import cats.{Alternative, Applicative, ApplicativeError, Apply, Functor, Id, Monad, MonadError, MonoidK, SemigroupK, ~>}
+import cats.{Alternative, Applicative, ApplicativeThrow, Apply, Functor, Id, Monad, MonadThrow, MonoidK, SemigroupK, ~>}
 import com.twitter.finagle.http.exp.{Multipart => FinagleMultipart}
 import com.twitter.finagle.http.{Cookie => FinagleCookie, Method => FinagleMethod, Request, Response}
 import com.twitter.io.Buf
@@ -47,7 +47,7 @@ import scala.reflect.ClassTag
   *   val foobar: Endpoint[Foo :+: Bar :+: CNil] = foo :+: bar
   * }}}
   *
-  * An `Endpoint` might be converted into a Finagle [[Service]] with `Endpoint.toService` method so it can be served within Finagle HTTP.
+  * An `Endpoint` might be converted into a Finagle [[com.twitter.finagle.Service]] with `Endpoint.toService` method so it can be served within Finagle HTTP.
   *
   * {{{
   *   import com.twitter.finagle.Http
@@ -85,7 +85,7 @@ trait Endpoint[F[_], A] {
 
   /** Maps this endpoint to the given function `A => Output[B]`.
     */
-  final def mapOutput[B](fn: A => Output[B])(implicit F: MonadError[F, Throwable]): Endpoint[F, B] =
+  final def mapOutput[B](fn: A => Output[B])(implicit F: MonadThrow[F]): Endpoint[F, B] =
     mapOutputAsync(a => F.catchNonFatal(fn(a)))
 
   /** Maps this endpoint to the given function `A => Future[Output[B]]`.
@@ -164,14 +164,12 @@ trait Endpoint[F[_], A] {
     * This combinator is an important piece for Finch's error accumulation. In its current form, `product` will accumulate Finch's own errors (i.e.,
     * [[io.finch.Error]]s) into [[io.finch.Errors]]) and will fail-fast with the first non-Finch error (just ordinary `Exception`) observed.
     */
-  final def product[B](other: Endpoint[F, B])(implicit F: MonadError[F, Throwable]): Endpoint[F, (A, B)] =
+  final def product[B](other: Endpoint[F, B])(implicit F: MonadThrow[F]): Endpoint[F, (A, B)] =
     productWith(other)(Tuple2.apply)
 
   /** Returns a product of this and `other` endpoint. The resulting endpoint returns a value of resulting type for product function.
     */
-  final def productWith[B, O](other: Endpoint[F, B])(p: (A, B) => O)(implicit
-      F: MonadError[F, Throwable]
-  ): Endpoint[F, O] =
+  final def productWith[B, O](other: Endpoint[F, B])(p: (A, B) => O)(implicit F: MonadThrow[F]): Endpoint[F, O] =
     new Endpoint[F, O] with (((Either[Throwable, Output[A]], Either[Throwable, Output[B]])) => F[Output[O]]) {
       final private[this] def collect(a: Throwable, b: Throwable): Throwable = (a, b) match {
         case (aa: Error, bb: Error)   => Errors(NonEmptyList.of(aa, bb))
@@ -207,20 +205,14 @@ trait Endpoint[F[_], A] {
       final override def toString: String = self.toString
     }
 
-  /** Composes this endpoint with the given [[Endpoint]].
-    */
-  final def ::[B](other: Endpoint[F, B])(implicit
-      pa: PairAdjoin[B, A],
-      F: MonadError[F, Throwable]
-  ): Endpoint[F, pa.Out] = new Endpoint[F, pa.Out] with ((B, A) => pa.Out) {
-    private[this] val inner = other.productWith(self)(this)
-
-    final def apply(b: B, a: A): pa.Out = pa(b, a)
-
-    final def apply(input: Input): Endpoint.Result[F, pa.Out] = inner(input)
-
-    final override def toString: String = s"${other.toString} :: ${self.toString}"
-  }
+  /** Composes this endpoint with the given [[Endpoint]]. */
+  final def ::[B](other: Endpoint[F, B])(implicit pa: PairAdjoin[B, A], F: MonadThrow[F]): Endpoint[F, pa.Out] =
+    new Endpoint[F, pa.Out] with ((B, A) => pa.Out) {
+      private[this] val inner = other.productWith(self)(this)
+      final def apply(b: B, a: A) = pa(b, a)
+      final def apply(input: Input) = inner(input)
+      final override def toString = s"${other.toString} :: ${self.toString}"
+    }
 
   /** Sequentially composes this endpoint with the given `other` endpoint. The resulting endpoint will succeed if either this or `that` endpoints are succeed.
     *
@@ -253,33 +245,23 @@ trait Endpoint[F[_], A] {
     final override def toString: String = s"(${self.toString} :+: ${other.toString})"
   }
 
-  /** Composes this endpoint with another in such a way that coproducts are flattened.
-    */
-  final def :+:[B](that: Endpoint[F, B])(implicit
-      a: Adjoin[B :+: A :+: CNil],
-      F: MonadError[F, Throwable]
-  ): Endpoint[F, a.Out] = {
+  /** Composes this endpoint with another in such a way that coproducts are flattened. */
+  final def :+:[B](that: Endpoint[F, B])(implicit a: Adjoin[B :+: A :+: CNil], F: MonadThrow[F]): Endpoint[F, a.Out] = {
     val left = that.map(x => a(Inl[B, A :+: CNil](x)))
     val right = self.map(x => a(Inr[B, A :+: CNil](Inl[A, CNil](x))))
-
     left.coproduct(right)
   }
 
-  /** Recovers from any exception occurred in this endpoint by creating a new endpoint that will handle any matching throwable from the underlying future.
-    */
-  final def rescue(pf: PartialFunction[Throwable, F[Output[A]]])(implicit
-      F: ApplicativeError[F, Throwable]
-  ): Endpoint[F, A] = transformOutput(foa => foa.recoverWith(pf))
+  /** Recovers from any exception occurred in this endpoint by creating a new endpoint that will handle any matching throwable from the underlying future. */
+  final def rescue(pf: PartialFunction[Throwable, F[Output[A]]])(implicit F: ApplicativeThrow[F]): Endpoint[F, A] =
+    transformOutput(_.recoverWith(pf))
 
-  /** Recovers from any exception occurred in this endpoint by creating a new endpoint that will handle any matching throwable from the underlying future.
-    */
-  final def handle(pf: PartialFunction[Throwable, Output[A]])(implicit
-      F: ApplicativeError[F, Throwable]
-  ): Endpoint[F, A] = rescue(pf.andThen(F.pure(_)))
+  /** Recovers from any exception occurred in this endpoint by creating a new endpoint that will handle any matching throwable from the underlying future. */
+  final def handle(pf: PartialFunction[Throwable, Output[A]])(implicit F: ApplicativeThrow[F]): Endpoint[F, A] =
+    transformOutput(_.recover(pf))
 
-  /** Lifts this endpoint into one that always succeeds, with [[Either[Throwable, A]] representing both success and failure cases.
-    */
-  final def attempt(implicit F: MonadError[F, Throwable]): Endpoint[F, Either[Throwable, A]] =
+  /** Lifts this endpoint into one that always succeeds, with [[Either[Throwable, A]] representing both success and failure cases. */
+  final def attempt(implicit F: ApplicativeThrow[F]): Endpoint[F, Either[Throwable, A]] =
     new Endpoint[F, Either[Throwable, A]] with (Either[Throwable, Output[A]] => Output[Either[Throwable, A]]) {
       final def apply(toa: Either[Throwable, Output[A]]): Output[Either[Throwable, A]] = toa match {
         case Right(oo) => oo.map(Right.apply)
@@ -389,32 +371,27 @@ object Endpoint {
   }
 
   private trait EndpointMonoidK[F[_]] extends EndpointSemigroupK[F] with MonoidK[Endpoint[F, *]] {
-    def empty[A]: Endpoint[F, A] = Endpoint.empty[F, A]
+    def empty[A]: Endpoint[F, A] = Endpoint.empty
   }
 
   private class EndpointFunctor[F[_]: Monad] extends Functor[Endpoint[F, *]] {
     def map[A, B](fa: Endpoint[F, A])(f: A => B): Endpoint[F, B] = fa.map(f)
   }
 
-  private class EndpointApply[F[_]](implicit F: MonadError[F, Throwable]) extends EndpointFunctor[F] with Apply[Endpoint[F, *]] {
-    def ap[A, B](ff: Endpoint[F, A => B])(fa: Endpoint[F, A]): Endpoint[F, B] =
-      ff.productWith(fa)((f, a) => f(a))
+  private class EndpointApply[F[_]: MonadThrow] extends EndpointFunctor[F] with Apply[Endpoint[F, *]] {
+    def ap[A, B](ff: Endpoint[F, A => B])(fa: Endpoint[F, A]): Endpoint[F, B] = ff.productWith(fa)(_ apply _)
   }
 
-  private class EndpointApplicative[F[_]](implicit F: MonadError[F, Throwable]) extends EndpointApply[F] with Applicative[Endpoint[F, *]] {
-    def pure[A](x: A): Endpoint[F, A] =
-      Endpoint.const[F, A](x)
+  private class EndpointApplicative[F[_]: MonadThrow] extends EndpointApply[F] with Applicative[Endpoint[F, *]] {
+    def pure[A](x: A): Endpoint[F, A] = Endpoint.const(x)
   }
 
-  private class EndpointAlternative[F[_]](implicit F: MonadError[F, Throwable])
-      extends EndpointApplicative[F]
-      with EndpointMonoidK[F]
-      with Alternative[Endpoint[F, *]]
+  private class EndpointAlternative[F[_]: MonadThrow] extends EndpointApplicative[F] with EndpointMonoidK[F] with Alternative[Endpoint[F, *]]
 
-  implicit def endpointAlternative[F[_]](implicit F: MonadError[F, Throwable]): Alternative[Endpoint[F, *]] =
+  implicit def endpointAlternative[F[_]: MonadThrow]: Alternative[Endpoint[F, *]] =
     new EndpointAlternative[F]
 
-  implicit def endpointApplicative[F[_]](implicit F: MonadError[F, Throwable]): Applicative[Endpoint[F, *]] =
+  implicit def endpointApplicative[F[_]: MonadThrow]: Applicative[Endpoint[F, *]] =
     new EndpointApplicative[F]
 
   implicit def endpointFunctor[F[_]: Monad]: Functor[Endpoint[F, *]] =
@@ -434,28 +411,21 @@ object Endpoint {
     */
   def apply[F[_]]: EndpointModule[F] = EndpointModule[F]
 
-  /** Creates an empty [[Endpoint]] (an endpoint that never matches) for a given type.
-    */
+  /** Creates an empty [[Endpoint]] (an endpoint that never matches) for a given type. */
   def empty[F[_], A]: Endpoint[F, A] =
-    new Endpoint[F, A] {
-      final def apply(input: Input): Result[F, A] = EndpointResult.NotMatched[F]
-    }
+    _ => EndpointResult.NotMatched[F]
 
-  /** An [[Endpoint]] that, when composed with other endpoints, doesn't change anything.
-    */
+  /** Creates an [[Endpoint]] that returns an output regardless of the input. */
+  def output[F[_], A](o: F[Output[A]]): Endpoint[F, A] =
+    EndpointResult.Matched(_, Trace.empty, o)
+
+  /** Creates an [[Endpoint]] that, when composed with other endpoints, doesn't change anything. */
   def zero[F[_]](implicit F: Applicative[F]): Endpoint[F, HNil] =
-    new Endpoint[F, HNil] {
-      final def apply(input: Input): Result[F, HNil] =
-        EndpointResult.Matched(input, Trace.empty, F.pure(Output.HNil))
-    }
+    output(F.pure(Output.HNil))
 
-  /** Creates an [[Endpoint]] that always matches and returns a given value (evaluated eagerly).
-    */
+  /** Creates an [[Endpoint]] that always matches and returns a given value (evaluated eagerly). */
   def const[F[_], A](a: A)(implicit F: Applicative[F]): Endpoint[F, A] =
-    new Endpoint[F, A] {
-      final def apply(input: Input): Result[F, A] =
-        EndpointResult.Matched(input, Trace.empty, F.pure(Output.payload(a)))
-    }
+    output(F.pure(Output.payload(a)))
 
   /** Creates an [[Endpoint]] that always matches and returns a given value (evaluated lazily).
     *
@@ -468,34 +438,19 @@ object Endpoint {
     * }}}
     */
   def lift[F[_], A](a: => A)(implicit F: Sync[F]): Endpoint[F, A] =
-    new Endpoint[F, A] {
-      final def apply(input: Input): Result[F, A] =
-        EndpointResult.Matched(input, Trace.empty, F.delay(Output.payload(a)))
-    }
+    output(F.delay(Output.payload(a)))
 
-  /** Creates an [[Endpoint]] that always matches and returns a given `F` (evaluated lazily).
-    */
+  /** Creates an [[Endpoint]] that always matches and returns a given `F` (evaluated lazily). */
   def liftAsync[F[_], A](fa: => F[A])(implicit F: Sync[F]): Endpoint[F, A] =
-    new Endpoint[F, A] {
-      final def apply(input: Input): Result[F, A] =
-        EndpointResult.Matched(input, Trace.empty, F.defer(fa).map(a => Output.payload(a)))
-    }
+    output(F.defer(fa).map(Output.payload(_)))
 
-  /** Creates an [[Endpoint]] that always matches and returns a given `Output` (evaluated lazily).
-    */
+  /** Creates an [[Endpoint]] that always matches and returns a given `Output` (evaluated lazily). */
   def liftOutput[F[_], A](oa: => Output[A])(implicit F: Sync[F]): Endpoint[F, A] =
-    new Endpoint[F, A] {
-      final def apply(input: Input): Result[F, A] =
-        EndpointResult.Matched(input, Trace.empty, F.delay(oa))
-    }
+    output(F.delay(oa))
 
-  /** Creates an [[Endpoint]] that always matches and returns a given `F[Output]` (evaluated lazily).
-    */
+  /** Creates an [[Endpoint]] that always matches and returns a given `F[Output]` (evaluated lazily). */
   def liftOutputAsync[F[_], A](foa: => F[Output[A]])(implicit F: Sync[F]): Endpoint[F, A] =
-    new Endpoint[F, A] {
-      final def apply(input: Input): Result[F, A] =
-        EndpointResult.Matched(input, Trace.empty, F.defer(foa))
-    }
+    output(F.defer(foa))
 
   /** Creates an [[Endpoint]] from a given [[InputStream]]. Uses [[Resource]] for safer resource management
     *


### PR DESCRIPTION
Also add `Endpoint.output` constructor and reuse it.
Convert some instances to SAM syntax.