### PR TITLE
Enable fatal warnings and set Scala 2.13 as default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import microsites.ExtraMdFileConfig
 
 lazy val buildSettings = Seq(
   organization := "com.github.finagle",
-  scalaVersion := "2.12.15",
+  scalaVersion := "2.13.8",
   crossScalaVersions := Seq("2.12.15", "2.13.8")
 )
 
@@ -30,7 +30,8 @@ def compilerOptions(scalaVersion: String): Seq[String] = Seq(
   "-unchecked",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
-  "-Xlint"
+  "-Xlint",
+  "-Xfatal-warnings"
 ) ++ (CrossVersion.partialVersion(scalaVersion) match {
   case Some((2, scalaMajor)) if scalaMajor == 12 => scala212CompilerOptions
   case Some((2, scalaMajor)) if scalaMajor == 13 => scala213CompilerOptions
@@ -43,7 +44,8 @@ lazy val scala212CompilerOptions = Seq(
 )
 
 lazy val scala213CompilerOptions = Seq(
-  "-Wunused:imports"
+  "-Wunused:imports",
+  "-Xlint:-byname-implicit"
 )
 
 val testDependencies = Seq(
@@ -66,9 +68,7 @@ val baseSettings = Seq(
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
   resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
   scalacOptions ++= compilerOptions(scalaVersion.value),
-  (Compile / console / scalacOptions) ~= {
-    _.filterNot(Set("-Ywarn-unused-import"))
-  },
+  (Compile / console / scalacOptions) ~= (_.filterNot(Set("-Ywarn-unused-import"))),
   (Compile / console / scalacOptions) += "-Yrepl-class-based",
   (Test / fork) := true,
   (ThisBuild / javaOptions) ++= Seq("-Xss2048K"),
@@ -219,9 +219,7 @@ lazy val docSettings = allSettings ++ Seq(
     "-doc-root-content",
     ((Compile / resourceDirectory).value / "rootdoc.txt").getAbsolutePath
   ),
-  scalacOptions ~= {
-    _.filterNot(Set("-Yno-predef", "-Xlint", "-Ywarn-unused-import"))
-  },
+  scalacOptions ~= (_.filterNot(Set("-Yno-predef", "-Xlint", "-Ywarn-unused-import"))),
   git.remoteRepo := "git@github.com:finagle/finch.git",
   (ScalaUnidoc / unidoc / unidocProjectFilter) := inAnyProject -- inProjects(benchmarks, jsonTest),
   (makeSite / includeFilter) := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.svg" | "*.js" | "*.swf" | "*.yml" | "*.md",

--- a/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
+++ b/circe/src/test/scala/io/finch/circe/test/CirceSpec.scala
@@ -11,7 +11,7 @@ class CirceSpec extends AbstractJsonSpec {
   checkJson("circe")
   checkStreamJson[Enumerator, IO]("circe-iteratee")(Enumerator.enumList, _.toVector.unsafeRunSync().toList)
   checkStreamJson[Stream, IO]("circe-fs2")(
-    list => Stream.fromIterator[IO](list.toIterator, 1024),
+    list => Stream.fromIterator[IO](list.iterator, 1024),
     _.compile.toList.unsafeRunSync()
   )
 }

--- a/core/src/main/scala/io/finch/DecodeEntity.scala
+++ b/core/src/main/scala/io/finch/DecodeEntity.scala
@@ -58,17 +58,13 @@ trait HighPriorityDecode extends LowPriorityDecode {
 
 trait LowPriorityDecode {
 
-  /** Creates an [[DecodeEntity]] instance from a given function `String => Either[Throwable, A]`.
-    */
-  def instance[A](fn: String => Either[Throwable, A]): DecodeEntity[A] = new DecodeEntity[A] {
-    def apply(s: String): Either[Throwable, A] = fn(s)
-  }
+  /** Creates an [[DecodeEntity]] instance from a given function `String => Either[Throwable, A]`. */
+  def instance[A](fn: String => Either[Throwable, A]): DecodeEntity[A] = fn(_)
 
-  /** Creates a [[Decode]] from [[shapeless.Generic]] for single value case classes.
-    */
+  /** Creates a [[Decode]] from [[shapeless.Generic]] for single value case classes. */
   implicit def decodeFromGeneric[A, H <: HList, E](implicit
       gen: Generic.Aux[A, H],
       ev: (E :: HNil) =:= H,
       de: DecodeEntity[E]
-  ): DecodeEntity[A] = instance(s => de(s).right.map(b => gen.from(b :: HNil)))
+  ): DecodeEntity[A] = instance(de(_).map(b => gen.from(b :: HNil)))
 }

--- a/core/src/main/scala/io/finch/Error.scala
+++ b/core/src/main/scala/io/finch/Error.scala
@@ -3,7 +3,6 @@ package io.finch
 import cats.data.{NonEmptyChain, NonEmptyList}
 import cats.{Eq, Semigroup, Show}
 
-import scala.compat.Platform.EOL
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 
@@ -25,7 +24,7 @@ sealed abstract class Error extends Exception with NoStackTrace
 final case class Errors(errors: NonEmptyChain[Error]) extends Exception with NoStackTrace {
   override def getMessage: String =
     "One or more errors reading request:" +
-      errors.iterator.map(_.getMessage).mkString(EOL + "  ", EOL + "  ", "")
+      errors.iterator.map(_.getMessage).mkString(System.lineSeparator + "  ", System.lineSeparator + "  ", "")
 }
 
 object Errors {

--- a/core/src/test/scala/io/finch/BodySpec.scala
+++ b/core/src/test/scala/io/finch/BodySpec.scala
@@ -76,7 +76,6 @@ class BodySpec extends FinchSpec {
       val plain = Input.post("/").withBody[Text.Plain](f)
       val csv = Input.post("/").withBody[Application.Csv](f)
       val endpoint = body[Foo, Text.Plain :+: Application.Csv :+: CNil]
-
       endpoint(plain).awaitValueUnsafe(dispatcherIO) === Some(f) && endpoint(csv).awaitValueUnsafe(dispatcherIO) === Some(f)
     }
   }
@@ -84,10 +83,9 @@ class BodySpec extends FinchSpec {
   it should "resolve into NotParsed(Decode.UMTE) if Content-Type does not match" in {
     val i = Input.post("/").withBody[Application.Xml](Buf.Utf8("foo"))
     val b = body[Foo, Text.Plain :+: Application.Csv :+: CNil]
-    val Some(Left(error)) = b(i).awaitOutput(dispatcherIO)
-
-    error shouldBe a[Error.NotParsed]
-    error.getCause shouldBe Decode.UnsupportedMediaTypeException
-
+    inside(b(i).awaitOutput(dispatcherIO)) { case Some(Left(error)) =>
+      error shouldBe a[Error.NotParsed]
+      error.getCause shouldBe Decode.UnsupportedMediaTypeException
+    }
   }
 }

--- a/examples/src/main/scala/io/finch/iteratee/Main.scala
+++ b/examples/src/main/scala/io/finch/iteratee/Main.scala
@@ -47,14 +47,12 @@ object Main extends IOApp {
 
   final case class IsPrime(isPrime: Boolean)
 
-  private def stream: Stream[Int] = Stream.continually(Random.nextInt())
-
   val sumJson: Endpoint[IO, Result] = post("sumJson" :: jsonBodyStream[Enumerator, Number]) { enum: Enumerator[IO, Number] =>
     enum.into(Iteratee.fold[IO, Number, Result](Result(0))(_ add _)).map(Ok)
   }
 
   val streamJson: Endpoint[IO, Enumerator[IO, Number]] = get("streamJson") {
-    Ok(Enumerator.enumStream[IO, Int](stream).map(Number.apply))
+    Ok(Enumerator.iterate[IO, Int](Random.nextInt())(_ => Random.nextInt()).map(Number.apply))
   }
 
   val isPrime: Endpoint[IO, Enumerator[IO, IsPrime]] =

--- a/refined/src/main/scala/io/finch/refined/package.scala
+++ b/refined/src/main/scala/io/finch/refined/package.scala
@@ -4,17 +4,10 @@ import eu.timepit.refined.api.{RefType, Validate}
 
 package object refined {
 
-  implicit def decodePathRefined[F[_, _], A, B](implicit
-      ad: DecodePath[A],
-      v: Validate[A, B],
-      rt: RefType[F]
-  ): DecodePath[F[A, B]] = DecodePath.instance(s => ad(s).flatMap(p => rt.refine[B](p).right.toOption))
+  implicit def decodePathRefined[F[_, _], A, B](implicit ad: DecodePath[A], v: Validate[A, B], rt: RefType[F]): DecodePath[F[A, B]] =
+    DecodePath.instance(ad(_).flatMap(rt.refine[B](_).toOption))
 
-  implicit def decodeEntityRefined[F[_, _], A, B](implicit
-      ad: DecodeEntity[A],
-      v: Validate[A, B],
-      rt: RefType[F]
-  ): DecodeEntity[F[A, B]] =
+  implicit def decodeEntityRefined[F[_, _], A, B](implicit ad: DecodeEntity[A], v: Validate[A, B], rt: RefType[F]): DecodeEntity[F[A, B]] =
     DecodeEntity.instance { s =>
       ad(s) match {
         case Right(r) =>

--- a/refined/src/test/scala/io/finch/refined/PredicateFailedSpec.scala
+++ b/refined/src/test/scala/io/finch/refined/PredicateFailedSpec.scala
@@ -2,19 +2,16 @@ package io.finch.refined
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric._
-import io.finch.FinchSpec
 import io.finch._
 
 class PredicateFailedSpec extends FinchSpec {
-
   it should "return error with predicate failure information" in {
-
     val endpoint = get(param[Int Refined Positive]("int")) { (i: Int Refined Positive) =>
       Ok(i.value)
     }
 
-    val Some(Left(result)) = endpoint(Input.get("/?int=-1")).awaitValue(dispatcherIO)
-
-    result.getCause shouldBe a[PredicateFailed]
+    inside(endpoint(Input.get("/?int=-1")).awaitValue(dispatcherIO)) { case Some(Left(result)) =>
+      result.getCause shouldBe a[PredicateFailed]
+    }
   }
 }


### PR DESCRIPTION
 - Replace usage of deprecated methods
 - Use ScalaTest `inside` instead of inexhaustive pattern matching